### PR TITLE
docs: add GitHub Copilot CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,33 @@ claude mcp update contextstream -e CONTEXTSTREAM_API_KEY=your_key
 
 </details>
 
+<details>
+<summary><b>GitHub Copilot CLI</b></summary>
+
+Use the Copilot CLI to interactively add the MCP server:
+
+```bash
+/mcp add
+```
+
+Or add to `~/.copilot/mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "contextstream": {
+      "command": "npx",
+      "args": ["-y", "@contextstream/mcp-server"],
+      "env": { "CONTEXTSTREAM_API_KEY": "your_key" }
+    }
+  }
+}
+```
+
+For more information, see the [GitHub Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli).
+
+</details>
+
 ---
 
 ## Links


### PR DESCRIPTION
Adds GitHub Copilot CLI installation instructions to the README under the Manual Configuration section.

## Changes

- Added collapsible "GitHub Copilot CLI" section after VS Code
- Includes interactive setup (`/mcp add`) and manual configuration options
- Uses the same JSON configuration pattern as other clients
- Links to official Copilot CLI documentation

## Testing

- Verified markdown renders correctly
- JSON configuration matches existing client patterns