### PR TITLE
fix: ensure dashboard todo checkbox updates todo state

### DIFF
--- a/src/client.todos.test.ts
+++ b/src/client.todos.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ContextStreamClient } from "./client.js";
+import type { Config } from "./config.js";
+
+const TEST_TODO_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("ContextStreamClient todos completion", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let client: ContextStreamClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { id: TEST_TODO_ID } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+
+    const config: Config = {
+      apiUrl: "https://api.contextstream.io",
+      apiKey: "test-api-key",
+      userAgent: "contextstream-test",
+      contextPackEnabled: true,
+      showTiming: false,
+    };
+    client = new ContextStreamClient(config);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("todosComplete sends completed=true and status=completed", async () => {
+    await client.todosComplete({ todo_id: TEST_TODO_ID });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchSpy.mock.calls[0] as [RequestInfo | URL, RequestInit];
+
+    expect(String(url)).toContain(`/api/v1/todos/${TEST_TODO_ID}`);
+    expect(options.method).toBe("PATCH");
+    expect(JSON.parse(String(options.body))).toEqual({
+      completed: true,
+      status: "completed",
+    });
+  });
+
+  it("todosIncomplete sends completed=false and status=pending", async () => {
+    await client.todosIncomplete({ todo_id: TEST_TODO_ID });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, options] = fetchSpy.mock.calls[0] as [RequestInfo | URL, RequestInit];
+
+    expect(options.method).toBe("PATCH");
+    expect(JSON.parse(String(options.body))).toEqual({
+      completed: false,
+      status: "pending",
+    });
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -6152,6 +6152,7 @@ export class ContextStreamClient {
     priority?: "low" | "medium" | "high" | "urgent";
     due_at?: string;
     completed?: boolean;
+    status?: "pending" | "completed";
   }) {
     uuidSchema.parse(params.todo_id);
     const { todo_id, ...updates } = params;
@@ -6171,7 +6172,7 @@ export class ContextStreamClient {
    */
   async todosComplete(params: { todo_id: string }) {
     uuidSchema.parse(params.todo_id);
-    return this.todosUpdate({ todo_id: params.todo_id, completed: true });
+    return this.todosUpdate({ todo_id: params.todo_id, completed: true, status: "completed" });
   }
 
   /**
@@ -6179,7 +6180,7 @@ export class ContextStreamClient {
    */
   async todosIncomplete(params: { todo_id: string }) {
     uuidSchema.parse(params.todo_id);
-    return this.todosUpdate({ todo_id: params.todo_id, completed: false });
+    return this.todosUpdate({ todo_id: params.todo_id, completed: false, status: "pending" });
   }
 
   // ============================================

--- a/src/todo-utils.test.ts
+++ b/src/todo-utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { resolveTodoCompletionUpdate } from "./todo-utils.js";
+
+describe("resolveTodoCompletionUpdate", () => {
+  it("maps completed=true to completed status", () => {
+    expect(resolveTodoCompletionUpdate({ completed: true })).toEqual({
+      completed: true,
+      status: "completed",
+    });
+  });
+
+  it("maps completed=false to pending status", () => {
+    expect(resolveTodoCompletionUpdate({ completed: false })).toEqual({
+      completed: false,
+      status: "pending",
+    });
+  });
+
+  it("maps todo_status to completed flag", () => {
+    expect(resolveTodoCompletionUpdate({ todo_status: "completed" })).toEqual({
+      completed: true,
+      status: "completed",
+    });
+    expect(resolveTodoCompletionUpdate({ todo_status: "pending" })).toEqual({
+      completed: false,
+      status: "pending",
+    });
+  });
+
+  it("maps status alias when it matches todo states", () => {
+    expect(resolveTodoCompletionUpdate({ status: "completed" })).toEqual({
+      completed: true,
+      status: "completed",
+    });
+    expect(resolveTodoCompletionUpdate({ status: "pending" })).toEqual({
+      completed: false,
+      status: "pending",
+    });
+  });
+
+  it("prioritizes explicit completed over status aliases", () => {
+    expect(resolveTodoCompletionUpdate({ completed: false, todo_status: "completed" })).toEqual({
+      completed: false,
+      status: "pending",
+    });
+  });
+
+  it("ignores non-todo status aliases", () => {
+    expect(resolveTodoCompletionUpdate({ status: "in_progress" })).toEqual({});
+  });
+});

--- a/src/todo-utils.ts
+++ b/src/todo-utils.ts
@@ -1,0 +1,43 @@
+export type TodoStatus = "pending" | "completed";
+
+function normalizeTodoStatus(status: unknown): TodoStatus | undefined {
+  if (status === "pending" || status === "completed") {
+    return status;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve todo completion updates from legacy and current input fields.
+ *
+ * Supports:
+ * - completed: boolean
+ * - todo_status: "pending" | "completed"
+ * - status alias where values are "pending" | "completed"
+ */
+export function resolveTodoCompletionUpdate(input: {
+  completed?: boolean;
+  todo_status?: TodoStatus;
+  status?: string;
+}): {
+  completed?: boolean;
+  status?: TodoStatus;
+} {
+  if (typeof input.completed === "boolean") {
+    return {
+      completed: input.completed,
+      status: input.completed ? "completed" : "pending",
+    };
+  }
+
+  const normalizedStatus =
+    normalizeTodoStatus(input.todo_status) ?? normalizeTodoStatus(input.status);
+  if (!normalizedStatus) {
+    return {};
+  }
+
+  return {
+    completed: normalizedStatus === "completed",
+    status: normalizedStatus,
+  };
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -47,6 +47,7 @@ import {
   extractIndexTimestamp,
   indexHistoryEntryCount,
 } from "./project-index-utils.js";
+import { resolveTodoCompletionUpdate } from "./todo-utils.js";
 
 type StructuredContent = { [x: string]: unknown } | undefined;
 type ToolTextResult = {
@@ -10891,7 +10892,11 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
           todo_status: z
             .enum(["pending", "completed"])
             .optional()
-            .describe("Todo status filter for list_todos"),
+            .describe("Todo status filter for list_todos, or status update value for update_todo"),
+          completed: z
+            .boolean()
+            .optional()
+            .describe("Todo completion flag for update_todo"),
           due_at: z.string().optional().describe("Due date (ISO 8601) for todo"),
           // Diagram params
           diagram_id: z.string().uuid().optional().describe("Diagram ID for get_diagram/update_diagram/delete_diagram"),
@@ -11400,12 +11405,19 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
             if (!input.todo_id) {
               return errorResult("update_todo requires: todo_id");
             }
+            const todoCompletionUpdate = resolveTodoCompletionUpdate({
+              completed: input.completed,
+              todo_status: input.todo_status,
+              status: input.status,
+            });
             const updateTodoResult = await client.todosUpdate({
               todo_id: input.todo_id,
               title: input.title,
               description: input.description,
               priority: input.todo_priority,
               due_at: input.due_at,
+              completed: todoCompletionUpdate.completed,
+              status: todoCompletionUpdate.status,
             });
             return {
               content: [{ type: "text" as const, text: formatContent(updateTodoResult) }],
@@ -11428,7 +11440,7 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
             }
             const completeTodoResult = await client.todosComplete({ todo_id: input.todo_id });
             return {
-              content: [{ type: "text" as const, text: `✅ Todo marked as completed` }],
+              content: [{ type: "text" as const, text: formatContent(completeTodoResult) }],
             };
           }
 


### PR DESCRIPTION
## Summary
- map todo completion inputs (`completed`, `todo_status`, and status alias) into actual todo state mutations for `memory(action="update_todo")`
- return the real `complete_todo` mutation payload instead of a static success string so dashboard state and toast messaging reflect the actual update result
- send both `completed` and `status` in todo completion client calls for backend compatibility and add regression tests for status mapping and API payload behavior

## Validation
- `npm run test -- src/todo-utils.test.ts src/client.todos.test.ts`
- `npx eslint src/todo-utils.ts src/todo-utils.test.ts src/client.todos.test.ts`
- `npx eslint src/client.ts src/tools.ts src/todo-utils.ts src/client.todos.test.ts src/todo-utils.test.ts` (fails due pre-existing lint issues in `src/client.ts` and `src/tools.ts`)
- `npm run typecheck` (fails due pre-existing type errors in `src/tools.ts`)
