### PR TITLE
Fix decision capture, Dart indexing, and Copilot rules support

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ContextStreamClient } from "./client.js";
+
+const baseConfig = {
+  apiUrl: "https://api.contextstream.io",
+  apiKey: "test-key",
+  userAgent: "contextstream-mcp/test",
+  contextPackEnabled: true,
+  showTiming: false,
+  toolSurfaceProfile: "default" as const,
+};
+
+describe("ContextStreamClient.captureContext", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("preserves decision event types for decision queries", async () => {
+    const client = new ContextStreamClient(baseConfig);
+    const createMemoryEvent = vi
+      .spyOn(client, "createMemoryEvent")
+      .mockResolvedValue({ success: true } as any);
+
+    await client.captureContext({
+      workspace_id: "11111111-1111-4111-8111-111111111111",
+      event_type: "decision",
+      title: "Use connection pooling",
+      content: "Pooling improves throughput for repeated database work.",
+    });
+
+    expect(createMemoryEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: "decision",
+        metadata: expect.objectContaining({
+          original_type: "decision",
+          tags: expect.arrayContaining(["decision"]),
+        }),
+      })
+    );
+  });
+
+  it("keeps lesson-system events stored as manual notes with lesson tags", async () => {
+    const client = new ContextStreamClient(baseConfig);
+    const createMemoryEvent = vi
+      .spyOn(client, "createMemoryEvent")
+      .mockResolvedValue({ success: true } as any);
+
+    await client.captureContext({
+      workspace_id: "11111111-1111-4111-8111-111111111111",
+      event_type: "lesson",
+      title: "Check pagination first",
+      content: "The API paginates by default.",
+    });
+
+    expect(createMemoryEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: "manual_note",
+        metadata: expect.objectContaining({
+          original_type: "lesson",
+          tags: expect.arrayContaining(["lesson", "lesson_system"]),
+        }),
+      })
+    );
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -3013,6 +3013,10 @@ export class ContextStreamClient {
         tags.push(params.event_type);
         break;
       case "decision":
+        // Decision queries filter on the stored event_type, so preserve it.
+        apiEventType = "decision";
+        tags.push(params.event_type);
+        break;
       case "insight":
       case "preference":
       case "note":

--- a/src/files.test.ts
+++ b/src/files.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  clearGitContextCache,
+  countIndexableFiles,
+  detectLanguage,
+  readFilesFromDirectory,
+} from "./files.js";
+
+async function makeTempProject(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "contextstream-files-test-"));
+}
+
+describe("files", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    clearGitContextCache();
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true }))
+    );
+  });
+
+  it("treats Dart files as indexable source", async () => {
+    const root = await makeTempProject();
+    tempDirs.push(root);
+
+    await fs.mkdir(path.join(root, "lib"), { recursive: true });
+    await fs.writeFile(path.join(root, "lib", "main.dart"), "void main() {}\n", "utf8");
+
+    const count = await countIndexableFiles(root, { maxFiles: 10 });
+    const files = await readFilesFromDirectory(root, { maxFiles: 10 });
+
+    expect(count.count).toBe(1);
+    expect(files.map((file) => file.path)).toContain(path.join("lib", "main.dart"));
+  });
+
+  it("detects Dart language metadata", () => {
+    expect(detectLanguage("lib/main.dart")).toBe("dart");
+  });
+});

--- a/src/files.ts
+++ b/src/files.ts
@@ -101,6 +101,8 @@ const CODE_EXTENSIONS = new Set([
   "graphql",
   "proto",
   "dockerfile",
+  // Dart/Flutter
+  "dart",
 ]);
 
 // Directories to ignore
@@ -827,6 +829,7 @@ export function detectLanguage(filePath: string): string {
     swift: "swift",
     scala: "scala",
     sql: "sql",
+    dart: "dart",
     md: "markdown",
     json: "json",
     yaml: "yaml",

--- a/src/rules-templates.test.ts
+++ b/src/rules-templates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generateRuleContent } from "./rules-templates.js";
+import { generateAllRuleFiles, generateRuleContent } from "./rules-templates.js";
 
 describe("rules-templates plan-mode guidance", () => {
   it("bootstrap rules mention plan-mode discovery tools in search-first guidance", () => {
@@ -17,5 +17,25 @@ describe("rules-templates plan-mode guidance", () => {
     const content = result!.content;
     expect(content).toContain("Task(subagent_type=\"Explore\")");
     expect(content).toContain("search(mode=\"auto\", query=\"...\", output_format=\"paths\")");
+  });
+
+  it("generates Copilot instructions plus a companion skill file", () => {
+    const result = generateRuleContent("copilot", { mode: "bootstrap" });
+    expect(result).not.toBeNull();
+    expect(result!.filename).toBe(".github/copilot-instructions.md");
+    expect(result!.content).toContain("contextstream-workflow");
+
+    const copilotFiles = generateAllRuleFiles({ mode: "bootstrap" }).filter(
+      (file) => file.editor === "copilot"
+    );
+    expect(copilotFiles.map((file) => file.filename)).toContain(
+      ".github/copilot-instructions.md"
+    );
+    expect(copilotFiles.map((file) => file.filename)).toContain(
+      ".github/skills/contextstream-workflow/SKILL.md"
+    );
+    expect(
+      copilotFiles.find((file) => file.filename.endsWith("SKILL.md"))?.content
+    ).toContain("name: contextstream-workflow");
   });
 });

--- a/src/rules-templates.ts
+++ b/src/rules-templates.ts
@@ -11,6 +11,14 @@ export interface RuleTemplate {
   build: (rules: string) => string;
 }
 
+export type RuleWriteMode = "contextstream_block" | "full_file";
+
+export interface GeneratedRuleFile {
+  filename: string;
+  content: string;
+  writeMode?: RuleWriteMode;
+}
+
 const DEFAULT_CLAUDE_MCP_SERVER_NAME = "contextstream";
 export const RULES_VERSION = VERSION === "unknown" ? "0.0.0" : VERSION;
 
@@ -974,6 +982,168 @@ After updating, user should restart their AI tool.
 // Editors that don't have hooks support and need enhanced rules
 const NO_HOOKS_EDITORS = ["codex", "aider", "antigravity"];
 
+function buildCopilotSkillContent(): string {
+  return `---
+name: contextstream-workflow
+description: "Manage persistent AI memory across sessions with ContextStream MCP."
+---
+
+# ContextStream Workflow Skill
+
+## Purpose
+
+Use ContextStream to keep plans, tasks, decisions, lessons, and implementation context available across Copilot sessions.
+
+## Session Lifecycle
+
+### 1. Start the session
+
+Always call \`init\` at the beginning of a new session:
+
+\`\`\`
+init(
+  folder_path="<project_path>",
+  context_hint="<user's first message>"
+)
+\`\`\`
+
+Then call \`context\` with the current request:
+
+\`\`\`
+context(
+  user_message="<current user message>"
+)
+\`\`\`
+
+For later messages in the same session, call \`context\` first before doing more work.
+
+### 2. Plan multi-step work
+
+Capture a persistent plan:
+
+\`\`\`
+session(
+  action="capture_plan",
+  title="Implement feature X",
+  steps=[
+    {"id": "1", "title": "Research the current code path", "order": 1},
+    {"id": "2", "title": "Implement the change", "order": 2},
+    {"id": "3", "title": "Add verification", "order": 3}
+  ]
+)
+\`\`\`
+
+Then create linked tasks:
+
+\`\`\`
+memory(
+  action="create_task",
+  title="Implement the change",
+  plan_id="<plan_id>",
+  plan_step_id="2",
+  priority="high"
+)
+\`\`\`
+
+### 3. Track progress while working
+
+Start a task:
+
+\`\`\`
+memory(
+  action="update_task",
+  task_id="<task_id>",
+  status="in_progress"
+)
+\`\`\`
+
+Capture a technical decision:
+
+\`\`\`
+session(
+  action="capture",
+  event_type="decision",
+  title="Use repository pattern for data access",
+  content="Chose a repository layer to isolate persistence logic and simplify testing."
+)
+\`\`\`
+
+Finish a task:
+
+\`\`\`
+memory(
+  action="update_task",
+  task_id="<task_id>",
+  status="completed"
+)
+\`\`\`
+
+### 4. Capture lessons
+
+When a mistake or correction happens, save a lesson immediately:
+
+\`\`\`
+session(
+  action="capture_lesson",
+  title="Check pagination behavior before assuming full results",
+  trigger="Assumed the API returned all records in one response",
+  impact="Only the first page was processed",
+  prevention="Verify pagination semantics before implementing the fetch path",
+  severity="medium"
+)
+\`\`\`
+
+### 5. Finish the work
+
+Update the plan:
+
+\`\`\`
+session(
+  action="update_plan",
+  plan_id="<plan_id>",
+  status="completed"
+)
+\`\`\`
+
+Capture a summary event:
+
+\`\`\`
+memory(
+  action="create_event",
+  event_type="implementation",
+  title="Feature X complete",
+  content="Implemented the change, added tests, and verified the result."
+)
+\`\`\`
+
+## Search-First Workflow
+
+- Before local code discovery, use \`search(mode="auto", query="...")\`
+- Use \`search(mode="keyword")\` for exact symbols or strings
+- Use \`search(mode="pattern")\` for glob or regex-style lookup
+- Use local reads only after search narrows the file set
+
+## Quick Reference
+
+| Need | Tool |
+|------|------|
+| Relevant project context | \`context(user_message="...")\` |
+| Code discovery | \`search(mode="auto", query="...")\` |
+| Persistent plan | \`session(action="capture_plan")\` |
+| Task status | \`memory(action="update_task")\` |
+| Decision capture | \`session(action="capture", event_type="decision")\` |
+| Past context | \`session(action="recall", query="...")\` |
+| Lessons | \`session(action="get_lessons", query="...")\` |
+
+## Anti-Patterns
+
+- Do not store trivial file reads or command output as memory
+- Do not skip \`context(...)\` on later turns
+- Do not use local file scanning before \`search(...)\` unless search returns 0 results
+- Do not use editor-only task lists as the persistent record; mirror important work in ContextStream
+`;
+}
+
 export const TEMPLATES: Record<string, RuleTemplate> = {
   codex: {
     filename: "AGENTS.md",
@@ -1045,6 +1215,25 @@ ${rules
 ${rules}
 `,
   },
+
+  copilot: {
+    filename: ".github/copilot-instructions.md",
+    description: "VS Code GitHub Copilot instructions",
+    build: (rules) => `## ContextStream MCP Integration
+
+This project uses [ContextStream](https://contextstream.io) for persistent AI memory across sessions. Use the \`contextstream-workflow\` skill for detailed examples and reference material.
+
+${rules}
+
+### VS Code Copilot Notes
+
+- Keep this file concise; put detailed workflows in \`.github/skills/contextstream-workflow/SKILL.md\`
+- Use ContextStream plans/tasks as the persistent record of work
+- Before code discovery, use \`search(mode="auto", query="...")\`
+
+Full docs: https://contextstream.io/docs/mcp/tools
+`,
+  },
 };
 
 /**
@@ -1091,7 +1280,10 @@ export function generateRuleContent(
   let content = template.build(rules);
 
   // Add workspace header if provided
-  if (options?.workspaceName || options?.projectName) {
+  if (
+    editor.toLowerCase() !== "copilot" &&
+    (options?.workspaceName || options?.projectName)
+  ) {
     const header = `
 # Workspace: ${options.workspaceName || "Unknown"}
 ${options.projectName ? `# Project: ${options.projectName}` : ""}
@@ -1124,6 +1316,33 @@ ${options.workspaceId ? `# Workspace ID: ${options.workspaceId}` : ""}
   };
 }
 
+export function generateRuleFiles(
+  editor: string,
+  options?: {
+    workspaceName?: string;
+    workspaceId?: string;
+    projectName?: string;
+    additionalRules?: string;
+    mode?: "dynamic" | "minimal" | "full" | "bootstrap";
+  }
+): GeneratedRuleFile[] {
+  const primary = generateRuleContent(editor, options);
+  if (!primary) return [];
+
+  if (editor.toLowerCase() !== "copilot") {
+    return [{ ...primary, writeMode: "contextstream_block" }];
+  }
+
+  return [
+    { ...primary, writeMode: "contextstream_block" },
+    {
+      filename: ".github/skills/contextstream-workflow/SKILL.md",
+      content: buildCopilotSkillContent().trim() + "\n",
+      writeMode: "full_file",
+    },
+  ];
+}
+
 /**
  * Generate all rule files for a project
  */
@@ -1135,10 +1354,12 @@ export function generateAllRuleFiles(options?: {
   mode?: "dynamic" | "minimal" | "full" | "bootstrap";
 }): Array<{ editor: string; filename: string; content: string }> {
   return getAvailableEditors()
-    .map((editor) => {
-      const result = generateRuleContent(editor, options);
-      if (!result) return null;
-      return { editor, ...result };
-    })
+    .flatMap((editor) =>
+      generateRuleFiles(editor, options).map((result) => ({
+        editor,
+        filename: result.filename,
+        content: result.content,
+      }))
+    )
     .filter((r): r is { editor: string; filename: string; content: string } => r !== null);
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -12,8 +12,10 @@ import { SessionManager } from "./session-manager.js";
 import {
   getAvailableEditors,
   generateRuleContent,
+  generateRuleFiles,
   generateAllRuleFiles,
   RULES_VERSION,
+  type RuleWriteMode,
 } from "./rules-templates.js";
 import { VERSION, getUpdateNotice, invalidateCacheIfBehind } from "./version.js";
 import { generateToolCatalog, getCoreToolsHint, type CatalogFormat } from "./tool-catalog.js";
@@ -434,6 +436,7 @@ const CONTEXTSTREAM_END_MARKER = "<!-- END ContextStream -->";
 const RULES_PROJECT_FILES: Record<string, string> = {
   codex: "AGENTS.md",
   claude: "CLAUDE.md",
+  copilot: path.join(".github", "copilot-instructions.md"),
   cursor: ".cursorrules",
   cline: ".clinerules",
   kilo: path.join(".kilocode", "rules", "contextstream.md"),
@@ -813,9 +816,23 @@ function replaceContextStreamBlock(
 
 async function upsertRuleFile(
   filePath: string,
-  content: string
+  content: string,
+  writeMode: RuleWriteMode = "contextstream_block"
 ): Promise<"created" | "updated" | "appended"> {
   await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+
+  if (writeMode === "full_file") {
+    let existing = "";
+    try {
+      existing = await fs.promises.readFile(filePath, "utf8");
+    } catch {
+      // file does not exist yet
+    }
+
+    await fs.promises.writeFile(filePath, content.trimEnd() + "\n", "utf8");
+    return existing ? "updated" : "created";
+  }
+
   const wrappedContent = wrapWithMarkers(content);
 
   let existing = "";
@@ -856,7 +873,7 @@ async function writeEditorRules(options: {
   const results: Array<{ editor: string; filename: string; status: string }> = [];
 
   for (const editor of editors) {
-    const rule = generateRuleContent(editor, {
+    const ruleFiles = generateRuleFiles(editor, {
       workspaceName: options.workspaceName,
       workspaceId: options.workspaceId,
       projectName: options.projectName,
@@ -864,25 +881,27 @@ async function writeEditorRules(options: {
       mode: options.mode,
     });
 
-    if (!rule) {
+    if (ruleFiles.length === 0) {
       results.push({ editor, filename: "", status: "unknown editor" });
       continue;
     }
 
-    const filePath = path.join(options.folderPath, rule.filename);
-    if (fs.existsSync(filePath) && !options.overwriteExisting) {
-      results.push({ editor, filename: rule.filename, status: "skipped (exists)" });
-      continue;
-    }
-    try {
-      const status = await upsertRuleFile(filePath, rule.content);
-      results.push({ editor, filename: rule.filename, status });
-    } catch (err) {
-      results.push({
-        editor,
-        filename: rule.filename,
-        status: `error: ${(err as Error).message}`,
-      });
+    for (const rule of ruleFiles) {
+      const filePath = path.join(options.folderPath, rule.filename);
+      if (fs.existsSync(filePath) && !options.overwriteExisting) {
+        results.push({ editor, filename: rule.filename, status: "skipped (exists)" });
+        continue;
+      }
+      try {
+        const status = await upsertRuleFile(filePath, rule.content, rule.writeMode);
+        results.push({ editor, filename: rule.filename, status });
+      } catch (err) {
+        results.push({
+          editor,
+          filename: rule.filename,
+          status: `error: ${(err as Error).message}`,
+        });
+      }
     }
   }
 
@@ -7757,7 +7776,7 @@ Example: "What were the auth decisions?" or "What are my TypeScript preferences?
     "generate_rules",
     {
       title: "Generate ContextStream rules",
-      description: `Generate AI rule files for editors (Cursor, Cline, Kilo Code, Roo Code, Claude Code, Aider).
+      description: `Generate AI rule files for editors (Cursor, Cline, Kilo Code, Roo Code, Claude Code, GitHub Copilot, Aider).
 Defaults to the current project folder; no folder_path required when run from a project.
 Supported editors: ${getAvailableEditors().join(", ")}`,
       inputSchema: z.object({
@@ -7769,6 +7788,7 @@ Supported editors: ${getAvailableEditors().join(", ")}`,
           .array(
             z.enum([
               "codex",
+              "copilot",
               "cursor",
               "cline",
               "kilo",
@@ -7796,7 +7816,7 @@ Supported editors: ${getAvailableEditors().join(", ")}`,
           .boolean()
           .optional()
           .default(true)
-          .describe("Overwrite ContextStream block in existing rule files (default: true). User content outside the block is preserved."),
+          .describe("Overwrite existing rule files (default: true). User content outside the ContextStream block is preserved when block updates are supported."),
         apply_global: z
           .boolean()
           .optional()
@@ -7829,7 +7849,7 @@ Supported editors: ${getAvailableEditors().join(", ")}`,
 
       if (input.dry_run) {
         for (const editor of editors) {
-          const rule = generateRuleContent(editor, {
+          const ruleFiles = generateRuleFiles(editor, {
             workspaceName: input.workspace_name,
             workspaceId: input.workspace_id,
             projectName: input.project_name,
@@ -7837,16 +7857,18 @@ Supported editors: ${getAvailableEditors().join(", ")}`,
             mode: input.mode,
           });
 
-          if (!rule) {
+          if (ruleFiles.length === 0) {
             results.push({ editor, filename: "", status: "unknown editor" });
             continue;
           }
 
-          results.push({
-            editor,
-            filename: rule.filename,
-            status: "dry run - would update",
-          });
+          for (const rule of ruleFiles) {
+            results.push({
+              editor,
+              filename: rule.filename,
+              status: "dry run - would update",
+            });
+          }
         }
       } else {
         const writeResults = await writeEditorRules({
@@ -7990,7 +8012,7 @@ Supported editors: ${getAvailableEditors().join(", ")}`,
     "generate_editor_rules",
     {
       title: "Generate editor AI rules",
-      description: `Generate AI rule files for editors (Cursor, Cline, Kilo Code, Roo Code, Claude Code, Aider).
+      description: `Generate AI rule files for editors (Cursor, Cline, Kilo Code, Roo Code, Claude Code, GitHub Copilot, Aider).
 These rules instruct the AI to automatically use ContextStream for memory and context.
 Supported editors: ${getAvailableEditors().join(", ")}`,
       inputSchema: z.object({
@@ -8002,6 +8024,7 @@ Supported editors: ${getAvailableEditors().join(", ")}`,
           .array(
             z.enum([
               "codex",
+              "copilot",
               "cursor",
               "cline",
               "kilo",
@@ -8027,7 +8050,7 @@ Supported editors: ${getAvailableEditors().join(", ")}`,
         overwrite_existing: z
           .boolean()
           .optional()
-          .describe("Allow overwriting existing rule files (ContextStream block only)"),
+          .describe("Allow overwriting existing rule files. ContextStream block updates preserve non-ContextStream content when supported."),
         dry_run: z.boolean().optional().describe("If true, return content without writing files"),
       }),
     },
@@ -8049,7 +8072,7 @@ Supported editors: ${getAvailableEditors().join(", ")}`,
 
       if (input.dry_run) {
         for (const editor of editors) {
-          const rule = generateRuleContent(editor, {
+          const ruleFiles = generateRuleFiles(editor, {
             workspaceName: input.workspace_name,
             workspaceId: input.workspace_id,
             projectName: input.project_name,
@@ -8057,17 +8080,19 @@ Supported editors: ${getAvailableEditors().join(", ")}`,
             mode: input.mode,
           });
 
-          if (!rule) {
+          if (ruleFiles.length === 0) {
             results.push({ editor, filename: "", status: "unknown editor" });
             continue;
           }
 
-          results.push({
-            editor,
-            filename: rule.filename,
-            status: "dry run - would update",
-            content: rule.content,
-          });
+          for (const rule of ruleFiles) {
+            results.push({
+              editor,
+              filename: rule.filename,
+              status: "dry run - would update",
+              content: rule.content,
+            });
+          }
         }
       } else {
         const writeResults = await writeEditorRules({


### PR DESCRIPTION
## Summary
- preserve `decision` as the stored event type for `session(action="capture")` so `memory(action="decisions")` and `session(action="decision_trace")` can find captured decisions
- add Dart to indexable file extensions and language detection
- add `copilot` support to `generate_rules`, including `.github/copilot-instructions.md` and `.github/skills/contextstream-workflow/SKILL.md`
- add regression tests for decision capture, Dart indexing, and Copilot rule generation

## Verification
- `npm run typecheck`
- `npm test`
- `npm run build`

Closes #14
Closes #15
Closes #13
Refs #10