### PR TITLE
Fix tag propagation across event capture paths

### DIFF
--- a/src/client.tags.test.ts
+++ b/src/client.tags.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ContextStreamClient } from "./client.js";
+import type { Config } from "./config.js";
+
+const TEST_WORKSPACE_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("ContextStreamClient tag payloads", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let client: ContextStreamClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { id: "evt_123" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+
+    const config: Config = {
+      apiUrl: "https://api.contextstream.io",
+      apiKey: "test-api-key",
+      userAgent: "contextstream-test",
+      contextPackEnabled: true,
+      showTiming: false,
+      toolSurfaceProfile: "default",
+    };
+    client = new ContextStreamClient(config);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("createMemoryEvent sends top-level tags", async () => {
+    await client.createMemoryEvent({
+      workspace_id: TEST_WORKSPACE_ID,
+      event_type: "insight",
+      title: "Example event",
+      content: "Some content",
+      tags: ["category:testing", "priority:high"],
+    });
+
+    const [, options] = fetchSpy.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    expect(JSON.parse(String(options.body))).toEqual(
+      expect.objectContaining({
+        workspace_id: TEST_WORKSPACE_ID,
+        tags: ["category:testing", "priority:high"],
+      })
+    );
+  });
+
+  it("sessionRemember sends tags as a JSON array", async () => {
+    await client.sessionRemember({
+      workspace_id: TEST_WORKSPACE_ID,
+      content: "Something important",
+      tags: ["high_priority", "always_surface"],
+    });
+
+    const [, options] = fetchSpy.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    expect(JSON.parse(String(options.body))).toEqual(
+      expect.objectContaining({
+        workspace_id: TEST_WORKSPACE_ID,
+        content: "Something important",
+        tags: ["high_priority", "always_surface"],
+      })
+    );
+  });
+});

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -26,14 +26,16 @@ describe("ContextStreamClient.captureContext", () => {
       event_type: "decision",
       title: "Use connection pooling",
       content: "Pooling improves throughput for repeated database work.",
+      tags: ["category:testing"],
     });
 
     expect(createMemoryEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         event_type: "decision",
+        tags: expect.arrayContaining(["category:testing", "decision"]),
         metadata: expect.objectContaining({
           original_type: "decision",
-          tags: expect.arrayContaining(["decision"]),
+          tags: expect.arrayContaining(["category:testing", "decision"]),
         }),
       })
     );
@@ -55,6 +57,7 @@ describe("ContextStreamClient.captureContext", () => {
     expect(createMemoryEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         event_type: "manual_note",
+        tags: expect.arrayContaining(["lesson", "lesson_system"]),
         metadata: expect.objectContaining({
           original_type: "lesson",
           tags: expect.arrayContaining(["lesson", "lesson_system"]),

--- a/src/client.ts
+++ b/src/client.ts
@@ -59,6 +59,18 @@ function normalizeNodeType(input: string): string {
   }
 }
 
+function normalizeTags(tags?: string[]): string[] | undefined {
+  if (!tags || tags.length === 0) return undefined;
+  const normalized = Array.from(
+    new Set(
+      tags
+        .map((tag) => String(tag ?? "").trim())
+        .filter(Boolean)
+    )
+  );
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 type GraphTier = "none" | "lite" | "full";
 
 /**
@@ -884,6 +896,7 @@ export class ContextStreamClient {
     event_type: string;
     title: string;
     content: string;
+    tags?: string[];
     metadata?: Record<string, unknown>;
     provenance?: Record<string, unknown>;
     code_refs?: Array<{ file_path: string; symbol_id?: string; symbol_name?: string }>;
@@ -902,7 +915,13 @@ export class ContextStreamClient {
       throw new Error("content is required and cannot be empty");
     }
 
-    return request(this.config, "/memory/events", { body: withDefaults });
+    const normalizedTags = normalizeTags(body.tags);
+    const apiBody = {
+      ...withDefaults,
+      ...(normalizedTags ? { tags: normalizedTags } : {}),
+    };
+
+    return request(this.config, "/memory/events", { body: apiBody });
   }
 
   bulkIngestEvents(body: { workspace_id?: string; project_id?: string; events: any[] }) {
@@ -2994,7 +3013,7 @@ export class ContextStreamClient {
 
     // Map high-level types to API EventType
     let apiEventType = "manual_note";
-    const tags = params.tags || [];
+    const tags = [...(params.tags || [])];
 
     switch (params.event_type) {
       case "conversation":
@@ -3041,18 +3060,21 @@ export class ContextStreamClient {
         tags.push(params.event_type);
     }
 
+    const normalizedTags = normalizeTags(tags);
+
     return this.createMemoryEvent({
       workspace_id: withDefaults.workspace_id,
       project_id: withDefaults.project_id,
       event_type: apiEventType,
       title: params.title,
       content: params.content,
+      tags: normalizedTags,
       provenance: params.provenance,
       code_refs: params.code_refs,
       metadata: {
         original_type: params.event_type,
         session_id: params.session_id,
-        tags: tags,
+        ...(normalizedTags ? { tags: normalizedTags } : {}),
         importance: params.importance || "medium",
         captured_at: new Date().toISOString(),
         source: "mcp_auto_capture",
@@ -3082,8 +3104,9 @@ export class ContextStreamClient {
     const metadata: Record<string, unknown> = {
       ...(params.metadata || {}),
     };
-    if (params.tags && params.tags.length > 0) {
-      metadata.tags = params.tags;
+    const normalizedTags = normalizeTags(params.tags);
+    if (normalizedTags) {
+      metadata.tags = normalizedTags;
     }
     if (!metadata.captured_at) {
       metadata.captured_at = new Date().toISOString();
@@ -3098,6 +3121,7 @@ export class ContextStreamClient {
       event_type: params.event_type,
       title: params.title,
       content: params.content,
+      tags: normalizedTags,
       provenance: params.provenance,
       code_refs: params.code_refs,
       metadata,
@@ -3138,8 +3162,10 @@ export class ContextStreamClient {
     project_id?: string;
     importance?: "low" | "medium" | "high";
     await_indexing?: boolean;
+    tags?: string[];
   }) {
     const withDefaults = this.withDefaults(params);
+    const normalizedTags = normalizeTags(params.tags);
 
     if (!withDefaults.workspace_id) {
       throw new Error(
@@ -3154,6 +3180,7 @@ export class ContextStreamClient {
         project_id: withDefaults.project_id,
         importance: params.importance,
         await_indexing: params.await_indexing,
+        ...(normalizedTags ? { tags: normalizedTags } : {}),
       },
     });
   }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -11014,6 +11014,7 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
               project_id: projectId,
               content: input.content,
               importance,
+              tags: input.tags,
             });
             // Add educational hint for remember
             const rememberHint = getCaptureHint("preference");
@@ -11802,7 +11803,7 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
           order: z.number().optional().describe("Task order within plan"),
           task_ids: z.array(z.string().uuid()).optional().describe("Task IDs for reorder_tasks"),
           blocked_reason: z.string().optional().describe("Reason when task is blocked"),
-          tags: z.array(z.string()).optional().describe("Tags for task"),
+          tags: z.array(z.string()).optional().describe("Tags for event or task categorization"),
           // Batch import params
           events: z
             .array(
@@ -11903,6 +11904,7 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
               event_type: input.event_type,
               title: input.title,
               content: input.content,
+              tags: input.tags,
               metadata: input.metadata,
               provenance: input.provenance,
               code_refs: input.code_refs,


### PR DESCRIPTION
## Summary
- send tags in the top-level `tags` field for memory event creation requests
- preserve top-level tags for `session(action="capture")` while keeping mirrored metadata tags for compatibility
- pass tags through `memory(action="create_event")` and `session(action="remember")`
- add regression coverage for top-level event tags and remember-tag request payloads

## Verification
- `npm run typecheck`
- `npm test`
- `npm run build`

Closes #17