### PR TITLE
Rust MCP parity pass 2: scope & routing correctness (0.4.77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.4.77
+
+**Rust MCP parity pass 2: scope & routing correctness (v0.3.6–v0.5.18 cluster).**
+
+### Central Scope Resolution (new `src/scope.ts`)
+
+- Write paths — memory `create_event`/`create_node`/`create_task`/`create_todo`/`create_diagram`/`create_doc`/`create_roadmap`/`import_batch`, session `capture`/`capture_lesson`/`capture_plan`/`remember`, and all flat write tools — now resolve a consistent `{workspace, project}` pair before the first attempt. A "soft" workspace (neither caller-provided, nor request-header-provided, nor backed by the folder's saved config) that disagrees with the candidate project's real workspace is self-healed by adopting the project's workspace and persisting the correction; explicit workspaces stay authoritative and a mismatched project is dropped with a `[SCOPE]` note instead (Rust v0.5.18 semantics).
+- Project **names** are accepted wherever a `project_id` is taken on these paths (and on `init`): a non-UUID value is matched case-insensitively (ignoring spaces/underscores/hyphens) against the workspace's projects, with a helpful error naming known projects on a miss (v0.3.7).
+- One-shot recovery after stale-scope errors (v0.3.53–v0.3.58): a rejected project retries workspace-only; a stale workspace is cleared (new `SessionManager.replaceScope` + `ContextStreamClient.clearDefaults`) and re-resolved from the folder's saved config, with the retried call re-running against the corrected session context and a `[SCOPE]` note explaining what changed. Applies to memory/session/entity actions and the flat write tools, including the `memory decisions` read path.
+- An explicitly requested but inaccessible project is a hard error instead of a silent mis-scope.
+
+### init Precedence (v0.3.9 + v0.5.7)
+
+- `init(folder_path=…)` suppresses header-injected workspace/project scope so folder binding actually runs; when folder resolution yields no workspace (typical through the HTTP gateway, where the server cannot read the caller's local config), the inherited header scope is restored as the fallback and noted in the result.
+- `init` `project_id` accepts a project name.
+
+### Plan Lookup Hardening (v0.5.14)
+
+- `get_plan`/`update_plan` never dead-end: `plan_id` accepts a UUID or title text, or can be omitted to auto-resolve the latest actionable plan — preferring substantive plans (progress, active status, linked tasks) over stray 0% drafts, and disclosing the auto-pick plus other actionable plans. A miss returns the in-scope plan listing; an empty scope points at `capture_plan`.
+- `capture_plan` (session action and flat tool) rejects degenerate step titles (empty, placeholder dashes, multi-line, >200 chars, bare file paths) with per-title reasons.
+
+### Search Scope Loudness + Local Index Identity (v0.5.7 + v0.5.17)
+
+- `[SCOPE_UNRELIABLE]` banner when the backend flags a search's scope as invalid (previously skipped silently).
+- The local index registry records the git HEAD and normalized git remote identity at local-ingest time. Folder-to-project binding requires the folder's current remote identity to match the recorded one — a repo that merely shares a name or path leaf can never bind to another repo's project. IndexKeeper detects out-of-session commits (HEAD moved past the recorded ingest HEAD) and starts a background re-ingest. Non-git folders and entries without recorded identity are unaffected.
+
+### Already Equivalent (verified, no change)
+
+- Entity list/create inherit the session's active scope (v0.3.10); repeated `init(folder_path=…)` re-binds; per-initialize tool-surface profile reset (v0.5.16).
+
+### Still Tracked for Later Passes
+
+- Search-quality behaviors (v0.3.34, v0.3.45, v0.3.52, v0.3.63, v0.5.10, v0.5.23, v0.5.26); grounding freshness + metadata polish (v0.3.27–29, v0.3.40, v0.3.44, v0.3.49, v0.5.27); session `retro_capture`/`set_account_mode`.
+
 ## 0.4.76
 
 **Rust MCP parity (v0.2.92 → v0.5.27), pass 1: tool-surface parity + confidentiality scrub.**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextstream/mcp-server",
   "mcpName": "io.github.contextstreamio/mcp-server",
-  "version": "0.4.76",
+  "version": "0.4.77",
   "description": "ContextStream MCP server - v0.4.x with consolidated domain tools plus per-action write surfaces (~75% token reduction vs individual tools). Code context, memory, search, Q&A, and AI tools.",
   "type": "module",
   "license": "MIT",

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,6 +23,7 @@ import {
 } from "./workspace-config.js";
 import { globalCache, CacheKeys, CacheTTL } from "./cache.js";
 import { markProjectIndexed, clearProjectIndex, readIndexStatus } from "./hooks-config.js";
+import { readGitHead, readGitRemoteIdentity } from "./project-index-utils.js";
 import { VERSION, getUpdateNotice, getVersionWarning, getVersionInstructions, type VersionNotice } from "./version.js";
 
 const uuidSchema = z.string().uuid();
@@ -521,6 +522,7 @@ export class IndexKeeper {
   private lastIncremental = 0;
   private lastAging = 0;
   private lastStale = 0;
+  private lastDrift = 0;
   private client: ContextStreamClient | null = null;
 
   attach(client: ContextStreamClient) {
@@ -536,6 +538,7 @@ export class IndexKeeper {
     try {
       await this.checkIncremental(projectId, folderPath);
       await this.checkAgingRefresh(projectId, folderPath);
+      await this.checkGitHeadDrift(projectId, folderPath);
     } catch { /* non-fatal */ }
   }
 
@@ -565,6 +568,31 @@ export class IndexKeeper {
       });
     } catch (e) {
       console.error(`[ContextStream] IndexKeeper aging refresh failed:`, e);
+    }
+  }
+
+  /**
+   * Detect commits made outside this session: when the folder's git HEAD has
+   * moved past the HEAD recorded at local-ingest time, start a background
+   * re-ingest and refresh the recorded HEAD so the check converges.
+   */
+  private async checkGitHeadDrift(projectId: string, folderPath: string): Promise<void> {
+    if (!this.shouldFire(this.lastDrift, INDEX_KEEPER_STALE_INTERVAL_MS)) return;
+    this.lastDrift = Date.now();
+    if (!this.client) return;
+    try {
+      const status = await readIndexStatus();
+      const entry = status.projects?.[path.resolve(folderPath)];
+      if (!entry?.git_head) return;
+      const currentHead = await readGitHead(folderPath);
+      if (!currentHead || currentHead === entry.git_head) return;
+      console.error(
+        `[ContextStream] IndexKeeper: git HEAD moved since last ingest for ${folderPath}; starting re-index`
+      );
+      await this.client.ingestLocal({ projectId, rootPath: folderPath });
+      await markProjectIndexed(folderPath, { project_id: projectId, git_head: currentHead });
+    } catch {
+      /* non-fatal */
     }
   }
 
@@ -2866,6 +2894,7 @@ export class ContextStreamClient {
     const resolvedFolder = path.resolve(folderPath);
 
     let bestMatch: { projectId: string; matchLen: number } | null = null;
+    let currentRemotePromise: Promise<string | null> | undefined;
     for (const [projectPath, info] of Object.entries(projects)) {
       const resolvedProjectPath = path.resolve(projectPath);
       if (
@@ -2880,6 +2909,15 @@ export class ContextStreamClient {
 
       if (ContextStreamClient.isStaleIndexEntry(info?.indexed_at)) {
         continue;
+      }
+
+      // Twin/repair binding requires matching git-remote identity: a repo
+      // that merely shares a name or path leaf must never bind to this entry.
+      if (info?.git_remote) {
+        currentRemotePromise ??= readGitRemoteIdentity(resolvedFolder);
+        if ((await currentRemotePromise) !== info.git_remote) {
+          continue;
+        }
       }
 
       const projectId =
@@ -3472,7 +3510,17 @@ export class ContextStreamClient {
               // Pre-write index status to prevent race conditions
               const projectIdCopy = projectId;
               const rootPathCopy = rootPath;
-              markProjectIndexed(rootPathCopy, { project_id: projectIdCopy }).catch(() => {});
+              void (async () => {
+                const [gitHead, gitRemote] = await Promise.all([
+                  readGitHead(rootPathCopy),
+                  readGitRemoteIdentity(rootPathCopy),
+                ]);
+                await markProjectIndexed(rootPathCopy, {
+                  project_id: projectIdCopy,
+                  git_head: gitHead ?? undefined,
+                  git_remote: gitRemote ?? undefined,
+                });
+              })().catch(() => {});
 
               // Fire-and-forget: start indexing in background (deferred to next event loop tick)
               setImmediate(async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -639,6 +639,19 @@ export class ContextStreamClient {
     }
   }
 
+  /**
+   * Clear the client's default workspace/project IDs. Used by scope recovery
+   * when a previously-promoted default turns out to be stale for this session.
+   */
+  clearDefaults(input?: { workspace?: boolean; project?: boolean }) {
+    if (input?.workspace !== false) {
+      this.config.defaultWorkspaceId = undefined;
+    }
+    if (input?.project !== false) {
+      this.config.defaultProjectId = undefined;
+    }
+  }
+
   private withDefaults<T extends { workspace_id?: string; project_id?: string }>(input: T): T {
     const { defaultWorkspaceId, defaultProjectId } = this.config;
     const providedWorkspaceId = this.coerceUuid(input.workspace_id);

--- a/src/git-identity.test.ts
+++ b/src/git-identity.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { normalizeGitRemote } from "./project-index-utils.js";
+
+describe("normalizeGitRemote", () => {
+  it("normalizes ssh and https forms of the same repo to one identity", () => {
+    expect(normalizeGitRemote("git@github.com:org/repo.git")).toBe("github.com/org/repo");
+    expect(normalizeGitRemote("https://github.com/org/repo")).toBe("github.com/org/repo");
+    expect(normalizeGitRemote("https://github.com/Org/Repo.git")).toBe("github.com/org/repo");
+    expect(normalizeGitRemote("ssh://git@github.com/org/repo.git/")).toBe("github.com/org/repo");
+  });
+
+  it("strips embedded credentials", () => {
+    expect(normalizeGitRemote("https://user:token@github.com/org/repo.git")).toBe(
+      "github.com/org/repo"
+    );
+  });
+
+  it("distinguishes different repos that share a name", () => {
+    const a = normalizeGitRemote("git@github.com:contextstream/mcp.git");
+    const b = normalizeGitRemote("git@github.com:contextstream/mcp-server.git");
+    expect(a).not.toBe(b);
+  });
+
+  it("returns null for empty input", () => {
+    expect(normalizeGitRemote("")).toBeNull();
+    expect(normalizeGitRemote("   ")).toBeNull();
+  });
+});

--- a/src/hooks-config.ts
+++ b/src/hooks-config.ts
@@ -1330,6 +1330,10 @@ export interface IndexedProjectInfo {
   indexed_at: string;
   project_id?: string;
   project_name?: string;
+  /** Git HEAD at local-ingest time; drift from it marks the index stale. */
+  git_head?: string;
+  /** Normalized git remote identity; folder binding requires a match. */
+  git_remote?: string;
 }
 
 export interface IndexStatusFile {
@@ -1365,15 +1369,26 @@ export async function writeIndexStatus(status: IndexStatusFile): Promise<void> {
  */
 export async function markProjectIndexed(
   projectPath: string,
-  options?: { project_id?: string; project_name?: string }
+  options?: {
+    project_id?: string;
+    project_name?: string;
+    git_head?: string;
+    git_remote?: string;
+  }
 ): Promise<void> {
   const status = await readIndexStatus();
   const resolvedPath = path.resolve(projectPath);
 
+  // Fields omitted by this caller keep their previously recorded values, so a
+  // marking that carries no git identity can never wipe the identity the
+  // local-ingest path recorded.
+  const previous = status.projects[resolvedPath];
   status.projects[resolvedPath] = {
     indexed_at: new Date().toISOString(),
-    project_id: options?.project_id,
-    project_name: options?.project_name,
+    project_id: options?.project_id ?? previous?.project_id,
+    project_name: options?.project_name ?? previous?.project_name,
+    git_head: options?.git_head ?? previous?.git_head,
+    git_remote: options?.git_remote ?? previous?.git_remote,
   };
 
   await writeIndexStatus(status);

--- a/src/plan-titles.test.ts
+++ b/src/plan-titles.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { degenerateTitleReason, collectDegenerateStepTitles } from "./tools.js";
+
+describe("degenerateTitleReason", () => {
+  it("accepts short action-oriented titles", () => {
+    expect(degenerateTitleReason("Wire write paths through scope resolution")).toBeNull();
+    expect(degenerateTitleReason("Fix src/tools.ts error handling")).toBeNull();
+  });
+
+  it("rejects empty and placeholder titles", () => {
+    expect(degenerateTitleReason("")).toBe("empty");
+    expect(degenerateTitleReason("   ")).toBe("empty");
+    expect(degenerateTitleReason("--")).toBe("placeholder dashes");
+    expect(degenerateTitleReason(undefined)).toBe("missing");
+  });
+
+  it("rejects multi-line and overlong titles", () => {
+    expect(degenerateTitleReason("line one\nline two")).toBe("multi-line");
+    expect(degenerateTitleReason("x".repeat(201))).toContain("too long");
+  });
+
+  it("rejects bare file paths", () => {
+    expect(degenerateTitleReason("src/tools.ts")).toBe("bare file path");
+    expect(degenerateTitleReason("crates/mcp-tools/src/domains/scope.rs")).toBe("bare file path");
+    expect(degenerateTitleReason("index.test.ts")).toBe("bare file path");
+  });
+});
+
+describe("collectDegenerateStepTitles", () => {
+  it("returns null for valid steps or non-arrays", () => {
+    expect(collectDegenerateStepTitles(undefined)).toBeNull();
+    expect(
+      collectDegenerateStepTitles([{ title: "Do the thing" }, { title: "Verify the thing" }])
+    ).toBeNull();
+  });
+
+  it("lists every offending step with its reason", () => {
+    const message = collectDegenerateStepTitles([
+      { title: "Fine title" },
+      { title: "--" },
+      { title: "src/scope.ts" },
+    ]);
+    expect(message).toContain("step 2: placeholder dashes");
+    expect(message).toContain("step 3: bare file path");
+    expect(message).not.toContain("step 1");
+  });
+});

--- a/src/project-index-utils.ts
+++ b/src/project-index-utils.ts
@@ -1,4 +1,53 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
 type RecordValue = Record<string, unknown>;
+
+/** Current git HEAD commit for a folder, or null when unavailable. */
+export async function readGitHead(folderPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", folderPath, "rev-parse", "HEAD"], {
+      timeout: 2_000,
+    });
+    const head = stdout.trim();
+    return /^[0-9a-f]{40}$/i.test(head) ? head.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Normalized origin identity (host/org/repo) for a folder, or null. */
+export async function readGitRemoteIdentity(folderPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", folderPath, "config", "--get", "remote.origin.url"],
+      { timeout: 2_000 }
+    );
+    return normalizeGitRemote(stdout);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reduce a git remote URL to a comparable identity: lowercase host/org/repo
+ * with scheme, credentials, and .git suffix stripped. Both
+ * `git@github.com:org/repo.git` and `https://github.com/org/repo` normalize
+ * to `github.com/org/repo`.
+ */
+export function normalizeGitRemote(url: string): string | null {
+  const trimmed = url.trim().toLowerCase();
+  if (!trimmed) return null;
+  const withoutScheme = trimmed.replace(/^[a-z+]+:\/\//, "").replace(/^[^@/]*@/, "");
+  const unified = withoutScheme
+    .replace(":", "/")
+    .replace(/\.git\/?$/, "")
+    .replace(/\/+$/, "");
+  return unified || null;
+}
 
 export type IndexFreshness = "fresh" | "recent" | "aging" | "stale" | "missing" | "unknown";
 export type IndexConfidence = "high" | "medium" | "low";

--- a/src/scope.test.ts
+++ b/src/scope.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi } from "vitest";
+import { HttpError } from "./http.js";
+import { runWithAuthOverride } from "./auth-context.js";
+import {
+  normalizeScopeUuid,
+  resolveProjectScopeId,
+  resolveWriteScope,
+  recoverWriteScopeAfterProjectError,
+  prependScopeNote,
+  type ScopeClient,
+  type ScopeSession,
+} from "./scope.js";
+
+const WS_A = "11111111-1111-4111-8111-111111111111";
+const WS_B = "22222222-2222-4222-8222-222222222222";
+const WS_C = "33333333-3333-4333-8333-333333333333";
+const PROJ_1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const PROJ_2 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function makeClient(overrides: Partial<ScopeClient> = {}): ScopeClient {
+  return {
+    listProjects: vi.fn(async () => ({ items: [] })),
+    getProject: vi.fn(async () => ({})),
+    getWorkspace: vi.fn(async () => ({})),
+    setDefaults: vi.fn(),
+    clearDefaults: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeSession(
+  context: Record<string, unknown> | null,
+  folderPath: string | null = null
+): ScopeSession & { context: Record<string, unknown> | null } {
+  const state = { context };
+  return {
+    context: state.context,
+    getContext: () => state.context,
+    getFolderPath: () => folderPath,
+    updateScope: vi.fn((input: Record<string, unknown>) => {
+      state.context = { ...(state.context || {}), ...input };
+    }),
+    replaceScope: vi.fn((input: Record<string, unknown>) => {
+      const next = { ...(state.context || {}) };
+      if (input.workspace_id === null) delete next.workspace_id;
+      if (input.project_id === null) delete next.project_id;
+      state.context = next;
+    }),
+  };
+}
+
+describe("normalizeScopeUuid", () => {
+  it("accepts UUIDs and rejects other strings", () => {
+    expect(normalizeScopeUuid(WS_A)).toBe(WS_A);
+    expect(normalizeScopeUuid(` ${WS_A.toUpperCase()} `)).toBe(WS_A);
+    expect(normalizeScopeUuid("my-project")).toBeUndefined();
+    expect(normalizeScopeUuid(42)).toBeUndefined();
+  });
+});
+
+describe("resolveProjectScopeId", () => {
+  it("passes UUIDs through without a lookup", async () => {
+    const client = makeClient();
+    const result = await resolveProjectScopeId(client, WS_A, PROJ_1);
+    expect(result.id).toBe(PROJ_1);
+    expect(client.listProjects).not.toHaveBeenCalled();
+  });
+
+  it("matches a project name ignoring case, spaces, underscores, and hyphens", async () => {
+    const client = makeClient({
+      listProjects: vi.fn(async () => ({
+        items: [
+          { id: PROJ_1, name: "My-Server" },
+          { id: PROJ_2, name: "other" },
+        ],
+      })),
+    });
+    const result = await resolveProjectScopeId(client, WS_A, "my server");
+    expect(result.id).toBe(PROJ_1);
+  });
+
+  it("errors with known project names when nothing matches", async () => {
+    const client = makeClient({
+      listProjects: vi.fn(async () => ({
+        items: [{ id: PROJ_1, name: "alpha" }, { id: PROJ_2, name: "beta" }],
+      })),
+    });
+    const result = await resolveProjectScopeId(client, WS_A, "gamma");
+    expect(result.id).toBeUndefined();
+    expect(result.error).toContain("alpha");
+    expect(result.error).toContain("beta");
+  });
+
+  it("requires a resolved workspace for name lookups", async () => {
+    const client = makeClient();
+    const result = await resolveProjectScopeId(client, undefined, "alpha");
+    expect(result.error).toContain("workspace");
+  });
+
+  it("returns the fallback when no value is provided", async () => {
+    const client = makeClient();
+    const result = await resolveProjectScopeId(client, WS_A, undefined, PROJ_2);
+    expect(result.id).toBe(PROJ_2);
+  });
+});
+
+describe("resolveWriteScope", () => {
+  it("keeps a consistent session scope untouched", async () => {
+    const client = makeClient({
+      getProject: vi.fn(async () => ({ id: PROJ_1, workspace_id: WS_A })),
+    });
+    const session = makeSession({ workspace_id: WS_A, project_id: PROJ_1 });
+    const scope = await resolveWriteScope(client, session, {});
+    expect(scope).toMatchObject({ workspaceId: WS_A, projectId: PROJ_1, recovered: false });
+    expect(session.updateScope).not.toHaveBeenCalled();
+  });
+
+  it("adopts the project's workspace when the active workspace is soft (drift heal)", async () => {
+    const client = makeClient({
+      getProject: vi.fn(async () => ({ id: PROJ_1, workspace_id: WS_B })),
+    });
+    const session = makeSession({ workspace_id: WS_A, project_id: PROJ_1 });
+    const scope = await resolveWriteScope(client, session, {}, { resolveFolderScope: () => null });
+    expect(scope).toMatchObject({ workspaceId: WS_B, projectId: PROJ_1, recovered: true });
+    expect(scope.note).toBeTruthy();
+    expect(session.updateScope).toHaveBeenCalledWith({ workspace_id: WS_B, project_id: PROJ_1 });
+  });
+
+  it("keeps an explicit workspace authoritative and drops the mismatched project", async () => {
+    const client = makeClient({
+      getProject: vi.fn(async () => ({ id: PROJ_1, workspace_id: WS_B })),
+    });
+    const session = makeSession({ workspace_id: WS_A, project_id: PROJ_1 });
+    const scope = await resolveWriteScope(client, session, { workspaceId: WS_A });
+    expect(scope.workspaceId).toBe(WS_A);
+    expect(scope.projectId).toBeUndefined();
+    expect(scope.recovered).toBe(false);
+    expect(scope.note).toContain("different workspace");
+    expect(session.updateScope).not.toHaveBeenCalled();
+  });
+
+  it("treats a header-provided workspace as authoritative", async () => {
+    const client = makeClient({
+      getProject: vi.fn(async () => ({ id: PROJ_1, workspace_id: WS_B })),
+    });
+    const session = makeSession({ project_id: PROJ_1 });
+    const scope = await runWithAuthOverride({ workspaceId: WS_A }, () =>
+      resolveWriteScope(client, session, {}, { resolveFolderScope: () => null })
+    );
+    expect(scope.workspaceId).toBe(WS_A);
+    expect(scope.projectId).toBeUndefined();
+    expect(session.updateScope).not.toHaveBeenCalled();
+  });
+
+  it("treats a folder-config-backed workspace as authoritative", async () => {
+    const client = makeClient({
+      getProject: vi.fn(async () => ({ id: PROJ_1, workspace_id: WS_B })),
+    });
+    const session = makeSession({ workspace_id: WS_A, project_id: PROJ_1 }, "/repo");
+    const scope = await resolveWriteScope(client, session, {}, {
+      resolveFolderScope: () => ({ workspace_id: WS_A }),
+    });
+    expect(scope.workspaceId).toBe(WS_A);
+    expect(scope.projectId).toBeUndefined();
+    expect(session.updateScope).not.toHaveBeenCalled();
+  });
+
+  it("errors when an explicitly requested project is inaccessible", async () => {
+    const client = makeClient({
+      getProject: vi.fn(async () => {
+        throw new HttpError(404, "not found");
+      }),
+    });
+    const session = makeSession({ workspace_id: WS_A });
+    const scope = await resolveWriteScope(client, session, { projectId: PROJ_1 });
+    expect(scope.error).toContain(PROJ_1);
+  });
+
+  it("silently drops a stale session project with a note", async () => {
+    const client = makeClient({
+      getProject: vi.fn(async () => {
+        throw new HttpError(404, "not found");
+      }),
+    });
+    const session = makeSession({ workspace_id: WS_A, project_id: PROJ_1 });
+    const scope = await resolveWriteScope(client, session, {});
+    expect(scope.error).toBeUndefined();
+    expect(scope.workspaceId).toBe(WS_A);
+    expect(scope.projectId).toBeUndefined();
+    expect(scope.staleProjectId).toBe(PROJ_1);
+    expect(scope.note).toContain("no longer accessible");
+  });
+
+  it("returns workspace-only scope when there are no project candidates", async () => {
+    const client = makeClient();
+    const session = makeSession({ workspace_id: WS_A });
+    const scope = await resolveWriteScope(client, session, {});
+    expect(scope).toMatchObject({ workspaceId: WS_A, recovered: false });
+    expect(scope.projectId).toBeUndefined();
+  });
+});
+
+describe("recoverWriteScopeAfterProjectError", () => {
+  it("ignores non-scope errors", async () => {
+    const client = makeClient();
+    const session = makeSession({ workspace_id: WS_A });
+    const recovered = await recoverWriteScopeAfterProjectError(
+      client,
+      session,
+      { workspaceId: WS_A, projectId: PROJ_1, recovered: false },
+      new Error("boom")
+    );
+    expect(recovered).toBeNull();
+  });
+
+  it("retries workspace-only when the workspace is still usable", async () => {
+    const client = makeClient({ getWorkspace: vi.fn(async () => ({ id: WS_A })) });
+    const session = makeSession({ workspace_id: WS_A, project_id: PROJ_1 });
+    const recovered = await recoverWriteScopeAfterProjectError(
+      client,
+      session,
+      { workspaceId: WS_A, projectId: PROJ_1, recovered: false },
+      new HttpError(404, "project gone")
+    );
+    expect(recovered).toMatchObject({
+      workspaceId: WS_A,
+      projectId: undefined,
+      staleProjectId: PROJ_1,
+      recovered: true,
+    });
+  });
+
+  it("clears a stale workspace and recovers from the folder's saved config", async () => {
+    const getWorkspace = vi.fn(async (id: string) => {
+      if (id === WS_A) throw new HttpError(404, "workspace gone");
+      return { id };
+    });
+    const client = makeClient({ getWorkspace });
+    const session = makeSession({ workspace_id: WS_A, project_id: PROJ_1 }, "/repo");
+    const recovered = await recoverWriteScopeAfterProjectError(
+      client,
+      session,
+      { workspaceId: WS_A, projectId: PROJ_1, recovered: false },
+      new HttpError(403, "forbidden"),
+      { resolveFolderScope: () => ({ workspace_id: WS_C, project_id: PROJ_2 }) }
+    );
+    expect(session.replaceScope).toHaveBeenCalled();
+    expect(recovered).toMatchObject({
+      workspaceId: WS_C,
+      projectId: PROJ_2,
+      recovered: true,
+    });
+  });
+
+  it("clears the stale scope and points at init when the folder has no usable config", async () => {
+    const client = makeClient({
+      getWorkspace: vi.fn(async () => {
+        throw new HttpError(404, "workspace gone");
+      }),
+    });
+    const session = makeSession({ workspace_id: WS_A, project_id: PROJ_1 }, "/repo");
+    const recovered = await recoverWriteScopeAfterProjectError(
+      client,
+      session,
+      { workspaceId: WS_A, projectId: PROJ_1, recovered: false },
+      new HttpError(404, "gone"),
+      { resolveFolderScope: () => null }
+    );
+    expect(session.replaceScope).toHaveBeenCalled();
+    expect(recovered?.workspaceId).toBeUndefined();
+    expect(recovered?.note).toContain("init");
+  });
+});
+
+describe("prependScopeNote", () => {
+  it("prepends a [SCOPE] line only when a note exists", () => {
+    const result = { content: [{ type: "text" as const, text: "done" }] };
+    expect(prependScopeNote(result, undefined).content[0].text).toBe("done");
+    expect(prependScopeNote(result, "healed").content[0].text).toBe("[SCOPE] healed\ndone");
+  });
+});

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -9,9 +9,31 @@
  * self-heals implicit ("soft") drift, and recovers once from stale-scope
  * errors.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import { HttpError } from "./http.js";
 import { getAuthOverride } from "./auth-context.js";
 import { resolveWorkspace } from "./workspace-config.js";
+
+// Scope-resolution notes are recorded through an async-local channel so tool
+// handlers don't have to thread them through every return site; the outer
+// tool wrapper captures and prepends them to the rendered result.
+const scopeNoteContext = new AsyncLocalStorage<{ note?: string }>();
+
+/** Run fn while capturing any scope-resolution notes recorded within. */
+export async function runWithScopeNoteCapture<T>(
+  fn: () => Promise<T> | T
+): Promise<{ result: T; note?: string }> {
+  const holder: { note?: string } = {};
+  const result = await scopeNoteContext.run(holder, async () => fn());
+  return { result, note: holder.note };
+}
+
+function recordScopeNote(note?: string): void {
+  if (!note) return;
+  const holder = scopeNoteContext.getStore();
+  if (!holder) return;
+  holder.note = holder.note ? `${holder.note} ${note}` : note;
+}
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -222,6 +244,17 @@ export async function resolveWriteScope(
   input: WriteScopeInput,
   deps?: ScopeResolutionDeps
 ): Promise<ResolvedWriteScope> {
+  const scope = await resolveWriteScopeInner(client, session, input, deps);
+  recordScopeNote(scope.note);
+  return scope;
+}
+
+async function resolveWriteScopeInner(
+  client: ScopeClient,
+  session: ScopeSession | null | undefined,
+  input: WriteScopeInput,
+  deps?: ScopeResolutionDeps
+): Promise<ResolvedWriteScope> {
   const explicitWorkspace = normalizeScopeUuid(input.workspaceId);
   const explicitProject = normalizeScopeUuid(input.projectId);
   const ctx = session?.getContext() ?? null;
@@ -398,12 +431,11 @@ export async function recoverWriteScopeAfterProjectError(
 }
 
 /** Prepend a scope note (if any) to a tool result's first text block. */
-export function prependScopeNote<
-  T extends { content: Array<{ type: "text"; text: string }> },
->(result: T, note: string | undefined): T {
-  if (!note) return result;
-  const first = result.content?.[0];
-  if (first && first.type === "text") {
+export function prependScopeNote<T>(result: T, note: string | undefined): T {
+  if (!note || !result || typeof result !== "object") return result;
+  const content = (result as { content?: Array<{ type?: string; text?: string }> }).content;
+  const first = Array.isArray(content) ? content[0] : undefined;
+  if (first && first.type === "text" && typeof first.text === "string") {
     first.text = `[SCOPE] ${note}\n${first.text}`;
   }
   return result;

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,0 +1,410 @@
+/**
+ * Central workspace/project scope resolution for write paths.
+ *
+ * A session can drift into an inconsistent {workspace, project} pair — for
+ * example a workspace that was adopted implicitly sitting next to a project
+ * that belongs to a different workspace. Writes then fail on some endpoints
+ * and silently mis-scope on others. This module resolves a consistent pair
+ * before a write, keeps the caller's explicit intent authoritative,
+ * self-heals implicit ("soft") drift, and recovers once from stale-scope
+ * errors.
+ */
+import { HttpError } from "./http.js";
+import { getAuthOverride } from "./auth-context.js";
+import { resolveWorkspace } from "./workspace-config.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function normalizeScopeUuid(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return UUID_RE.test(trimmed) ? trimmed.toLowerCase() : undefined;
+}
+
+/** Minimal structural view of ContextStreamClient used by scope resolution. */
+export interface ScopeClient {
+  listProjects(params?: {
+    workspace_id?: string;
+    page?: number;
+    page_size?: number;
+  }): Promise<unknown> | unknown;
+  getProject(projectId: string): Promise<unknown>;
+  getWorkspace(workspaceId: string): Promise<unknown>;
+  setDefaults(input: { workspace_id?: string; project_id?: string }): void;
+  clearDefaults(input?: { workspace?: boolean; project?: boolean }): void;
+}
+
+/** Minimal structural view of SessionManager used by scope resolution. */
+export interface ScopeSession {
+  getContext(): Record<string, unknown> | null;
+  getFolderPath(): string | null;
+  updateScope(input: { workspace_id?: string; project_id?: string; folder_path?: string }): void;
+  replaceScope(input: {
+    workspace_id?: string | null;
+    project_id?: string | null;
+    folder_path?: string;
+  }): void;
+}
+
+export interface ResolvedWriteScope {
+  workspaceId?: string;
+  projectId?: string;
+  /** The project the caller explicitly asked for, when it differs from the outcome. */
+  requestedProjectId?: string;
+  /** A candidate project that turned out to be deleted/inaccessible. */
+  staleProjectId?: string;
+  /** True when resolution changed the session's scope to self-heal. */
+  recovered: boolean;
+  /** One-line, user-facing explanation of any adjustment made. */
+  note?: string;
+  /** Set when resolution cannot proceed (e.g. explicit project unusable). */
+  error?: string;
+}
+
+function unwrapPayload(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (record.data && typeof record.data === "object" && !Array.isArray(record.data)) {
+    return record.data as Record<string, unknown>;
+  }
+  return record;
+}
+
+function collectProjectList(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) return value as Array<Record<string, unknown>>;
+  if (!value || typeof value !== "object") return [];
+  const record = value as Record<string, unknown>;
+  for (const key of ["items", "projects", "results", "data"]) {
+    const nested = record[key];
+    if (Array.isArray(nested)) return nested as Array<Record<string, unknown>>;
+    if (nested && typeof nested === "object") {
+      const deeper = (nested as Record<string, unknown>).items;
+      if (Array.isArray(deeper)) return deeper as Array<Record<string, unknown>>;
+    }
+  }
+  return [];
+}
+
+function scopeErrorStatus(error: unknown): number | undefined {
+  return error instanceof HttpError ? error.status : undefined;
+}
+
+export function isScopeNotFoundError(error: unknown): boolean {
+  return scopeErrorStatus(error) === 404;
+}
+
+export function isScopeAccessError(error: unknown): boolean {
+  const status = scopeErrorStatus(error);
+  return status === 401 || status === 403;
+}
+
+/** True for errors that indicate the workspace/project scope itself is bad. */
+export function isScopeError(error: unknown): boolean {
+  if (isScopeNotFoundError(error) || isScopeAccessError(error)) return true;
+  if (error instanceof HttpError) {
+    const code = String(error.code || "").toLowerCase();
+    return code === "project_access_denied" || code === "scope_invalid";
+  }
+  return false;
+}
+
+function normalizeNameKey(value: string): string {
+  return value.toLowerCase().replace(/[ _-]/g, "");
+}
+
+/**
+ * Resolve a project reference that may be a UUID or a project *name* —
+ * agents commonly pass a name like "my-server" instead of looking up the
+ * UUID. Names are matched case-insensitively, ignoring spaces/underscores/
+ * hyphens, against the resolved workspace's projects.
+ */
+export async function resolveProjectScopeId(
+  client: ScopeClient,
+  workspaceId: string | undefined,
+  raw: string | undefined,
+  fallback?: string
+): Promise<{ id?: string; error?: string }> {
+  const value = raw?.trim();
+  if (!value) return { id: fallback };
+
+  const asUuid = normalizeScopeUuid(value);
+  if (asUuid) return { id: asUuid };
+
+  if (!workspaceId) {
+    return {
+      error: `Invalid project_id UUID: ${value}. A workspace must be resolved before a project name can be looked up — run init first or pass workspace_id.`,
+    };
+  }
+
+  let projects: Array<Record<string, unknown>>;
+  try {
+    projects = collectProjectList(
+      await client.listProjects({ workspace_id: workspaceId, page: 1, page_size: 200 })
+    );
+  } catch {
+    return {
+      error: `Invalid project_id UUID: ${value}. Could not list workspace projects to try a name match — pass a UUID instead.`,
+    };
+  }
+
+  const nameKey = normalizeNameKey(value);
+  for (const project of projects) {
+    const name = String(project?.name ?? "").trim();
+    if (!name) continue;
+    if (name.toLowerCase() === value.toLowerCase() || normalizeNameKey(name) === nameKey) {
+      const id = normalizeScopeUuid(project?.id);
+      if (id) return { id };
+    }
+  }
+
+  const sample = projects
+    .slice(0, 5)
+    .map((p) => String(p?.name ?? "").trim())
+    .filter(Boolean);
+  const more = projects.length > 5 ? `, …+${projects.length - 5} more` : "";
+  return {
+    error: `Invalid project_id UUID: ${value}. No project in this workspace matches that name either. Known projects: ${sample.join(", ")}${more}.`,
+  };
+}
+
+async function workspaceIsUsable(client: ScopeClient, workspaceId: string): Promise<boolean> {
+  try {
+    await client.getWorkspace(workspaceId);
+    return true;
+  } catch (error) {
+    if (isScopeNotFoundError(error) || isScopeAccessError(error)) return false;
+    // Transient failures must not clear a possibly-valid scope.
+    return true;
+  }
+}
+
+export interface WriteScopeInput {
+  workspaceId?: string;
+  projectId?: string;
+}
+
+export interface ScopeResolutionDeps {
+  /** Folder → saved scope lookup; injectable for tests. */
+  resolveFolderScope?: (folderPath: string) => {
+    workspace_id?: string;
+    project_id?: string;
+  } | null;
+}
+
+function defaultResolveFolderScope(
+  folderPath: string
+): { workspace_id?: string; project_id?: string } | null {
+  try {
+    const resolved = resolveWorkspace(folderPath);
+    if (!resolved.config) return null;
+    return {
+      workspace_id: resolved.config.workspace_id,
+      project_id: resolved.config.project_id,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a consistent {workspace, project} pair for a write.
+ *
+ * Candidate ladder: explicit input → session active scope → workspace-only.
+ * When the active workspace and the candidate project disagree, the
+ * project's real workspace is adopted only if the active workspace is
+ * "soft" — neither caller-provided, nor request-header-provided, nor backed
+ * by the folder's saved config. Explicit workspaces stay authoritative and
+ * the mismatched project is dropped with a note instead.
+ */
+export async function resolveWriteScope(
+  client: ScopeClient,
+  session: ScopeSession | null | undefined,
+  input: WriteScopeInput,
+  deps?: ScopeResolutionDeps
+): Promise<ResolvedWriteScope> {
+  const explicitWorkspace = normalizeScopeUuid(input.workspaceId);
+  const explicitProject = normalizeScopeUuid(input.projectId);
+  const ctx = session?.getContext() ?? null;
+  const sessionWorkspace = normalizeScopeUuid(ctx?.workspace_id);
+  const sessionProject = normalizeScopeUuid(ctx?.project_id);
+  const headerWorkspace = normalizeScopeUuid(getAuthOverride()?.workspaceId);
+
+  const activeWorkspace = explicitWorkspace || headerWorkspace || sessionWorkspace;
+
+  const folderPath = session?.getFolderPath() ?? null;
+  const resolveFolderScope = deps?.resolveFolderScope ?? defaultResolveFolderScope;
+  let folderBacked = false;
+  if (!explicitWorkspace && !headerWorkspace && activeWorkspace && folderPath) {
+    const folderScope = resolveFolderScope(folderPath);
+    folderBacked = normalizeScopeUuid(folderScope?.workspace_id) === activeWorkspace;
+  }
+  const workspaceIsSoft = !explicitWorkspace && !headerWorkspace && !folderBacked;
+
+  const candidates: string[] = [];
+  for (const candidate of [explicitProject, sessionProject]) {
+    if (candidate && !candidates.includes(candidate)) candidates.push(candidate);
+  }
+
+  if (candidates.length === 0) {
+    return { workspaceId: activeWorkspace, recovered: false };
+  }
+
+  let staleProjectId: string | undefined;
+  const reachable: Array<{ id: string; workspaceId?: string }> = [];
+  for (const candidate of candidates) {
+    try {
+      const record = unwrapPayload(await client.getProject(candidate));
+      reachable.push({ id: candidate, workspaceId: normalizeScopeUuid(record?.workspace_id) });
+    } catch (error) {
+      if (isScopeError(error)) {
+        staleProjectId = staleProjectId || candidate;
+        continue;
+      }
+      // Transient failure: keep the candidate; its workspace is simply unknown.
+      reachable.push({ id: candidate, workspaceId: undefined });
+    }
+  }
+
+  if (explicitProject && staleProjectId === explicitProject) {
+    return {
+      workspaceId: activeWorkspace,
+      requestedProjectId: explicitProject,
+      staleProjectId,
+      recovered: false,
+      error: `project_id ${explicitProject} is not accessible (deleted or no access). Pass a current project_id, a project name, or run init(folder_path=...) to re-resolve scope.`,
+    };
+  }
+
+  if (reachable.length === 0) {
+    return {
+      workspaceId: activeWorkspace,
+      staleProjectId,
+      recovered: Boolean(staleProjectId),
+      note: staleProjectId
+        ? `Project ${staleProjectId} is no longer accessible; continuing with workspace scope.`
+        : undefined,
+    };
+  }
+
+  // Pass 1: stay in the active workspace when any reachable candidate belongs
+  // to it (candidates with unknown workspaces are assumed compatible).
+  if (activeWorkspace) {
+    const inWorkspace = reachable.find((c) => !c.workspaceId || c.workspaceId === activeWorkspace);
+    if (inWorkspace) {
+      return {
+        workspaceId: activeWorkspace,
+        projectId: inWorkspace.id,
+        staleProjectId,
+        recovered: false,
+      };
+    }
+  } else {
+    const first = reachable[0];
+    if (first.workspaceId) {
+      session?.updateScope({ workspace_id: first.workspaceId, project_id: first.id });
+      return {
+        workspaceId: first.workspaceId,
+        projectId: first.id,
+        staleProjectId,
+        recovered: true,
+        note: `Adopted workspace scope from project ${first.id}.`,
+      };
+    }
+    return { projectId: first.id, staleProjectId, recovered: false };
+  }
+
+  // Pass 2: workspace/project mismatch. Adopt the project's real workspace
+  // only when the active workspace is soft; then persist so the session heals.
+  const best = reachable[0];
+  if (workspaceIsSoft && best.workspaceId) {
+    session?.updateScope({ workspace_id: best.workspaceId, project_id: best.id });
+    return {
+      workspaceId: best.workspaceId,
+      projectId: best.id,
+      requestedProjectId: explicitProject,
+      staleProjectId,
+      recovered: true,
+      note: `Scope self-healed: adopted the workspace that project ${best.id} belongs to (the previous workspace scope was implicit and inconsistent).`,
+    };
+  }
+
+  return {
+    workspaceId: activeWorkspace,
+    requestedProjectId: explicitProject ?? best.id,
+    staleProjectId,
+    recovered: false,
+    note: `Project ${best.id} belongs to a different workspace; kept the authoritative workspace scope and wrote without a project. Pass matching workspace_id and project_id to target that project.`,
+  };
+}
+
+/**
+ * One-shot recovery after a write failed with a scope error. Returns the
+ * scope to retry with, or null when the failure isn't scope-shaped.
+ */
+export async function recoverWriteScopeAfterProjectError(
+  client: ScopeClient,
+  session: ScopeSession | null | undefined,
+  scope: ResolvedWriteScope,
+  error: unknown,
+  deps?: ScopeResolutionDeps
+): Promise<ResolvedWriteScope | null> {
+  if (!isScopeError(error)) return null;
+
+  // The workspace still works: the project binding is what went stale.
+  if (scope.projectId && scope.workspaceId && (await workspaceIsUsable(client, scope.workspaceId))) {
+    return {
+      ...scope,
+      projectId: undefined,
+      staleProjectId: scope.projectId,
+      recovered: true,
+      note: `Project scope ${scope.projectId} was rejected; retried with workspace scope only.`,
+    };
+  }
+
+  // The workspace itself is stale: clear the implicit binding and re-resolve
+  // from the folder's saved config.
+  if (scope.workspaceId && !(await workspaceIsUsable(client, scope.workspaceId))) {
+    const folderPath = session?.getFolderPath() ?? undefined;
+    session?.replaceScope({ workspace_id: null, project_id: null, folder_path: folderPath });
+
+    const resolveFolderScope = deps?.resolveFolderScope ?? defaultResolveFolderScope;
+    const folderScope = folderPath ? resolveFolderScope(folderPath) : null;
+    const folderWorkspace = normalizeScopeUuid(folderScope?.workspace_id);
+    const folderProject = normalizeScopeUuid(folderScope?.project_id);
+
+    if (folderWorkspace && (await workspaceIsUsable(client, folderWorkspace))) {
+      session?.updateScope({
+        workspace_id: folderWorkspace,
+        project_id: folderProject,
+        folder_path: folderPath,
+      });
+      return {
+        workspaceId: folderWorkspace,
+        projectId: folderProject,
+        staleProjectId: scope.projectId,
+        recovered: true,
+        note: `Recovered scope from this folder's saved config after the previous workspace became inaccessible.`,
+      };
+    }
+
+    return {
+      recovered: true,
+      staleProjectId: scope.projectId,
+      note: `Cleared a stale scope (the previous workspace is no longer accessible). Run init(folder_path="...") to re-associate this folder.`,
+    };
+  }
+
+  return null;
+}
+
+/** Prepend a scope note (if any) to a tool result's first text block. */
+export function prependScopeNote<
+  T extends { content: Array<{ type: "text"; text: string }> },
+>(result: T, note: string | undefined): T {
+  if (!note) return result;
+  const first = result.content?.[0];
+  if (first && first.type === "text") {
+    first.text = `[SCOPE] ${note}\n${first.text}`;
+  }
+  return result;
+}

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -168,6 +168,54 @@ export class SessionManager {
     }
   }
 
+  /**
+   * Replace the active workspace/project scope, allowing fields to be cleared.
+   * Unlike updateScope (merge-only), passing null removes the binding — used by
+   * scope recovery when a stale scope must be dropped before re-resolution.
+   */
+  replaceScope(input: {
+    workspace_id?: string | null;
+    project_id?: string | null;
+    folder_path?: string;
+  }) {
+    if (!this.context) {
+      this.context = {};
+    }
+
+    if (input.workspace_id === null) {
+      delete this.context.workspace_id;
+    } else if (typeof input.workspace_id === "string" && input.workspace_id.trim()) {
+      this.context.workspace_id = input.workspace_id;
+    }
+
+    if (input.project_id === null) {
+      delete this.context.project_id;
+    } else if (typeof input.project_id === "string" && input.project_id.trim()) {
+      this.context.project_id = input.project_id;
+    }
+
+    if (typeof input.folder_path === "string" && input.folder_path.trim()) {
+      this.context.folder_path = input.folder_path;
+      this.folderPath = input.folder_path;
+    }
+
+    this.client.clearDefaults({
+      workspace: input.workspace_id === null,
+      project: input.project_id === null || input.workspace_id === null,
+    });
+    const workspaceId =
+      typeof this.context.workspace_id === "string"
+        ? (this.context.workspace_id as string)
+        : undefined;
+    const projectId =
+      typeof this.context.project_id === "string"
+        ? (this.context.project_id as string)
+        : undefined;
+    if (workspaceId || projectId) {
+      this.client.setDefaults({ workspace_id: workspaceId, project_id: projectId });
+    }
+  }
+
   private extractDefaultSearchMode(context: Record<string, unknown>): string | null {
     const fromWorkspace =
       context.workspace &&

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -61,6 +61,8 @@ import {
   extractPendingFilePaths,
   extractIndexTimestamp,
   indexHistoryEntryCount,
+  readGitHead,
+  readGitRemoteIdentity,
 } from "./project-index-utils.js";
 import { resolveTodoCompletionUpdate } from "./todo-utils.js";
 import { globalHotPathStore } from "./hot-paths.js";
@@ -5425,6 +5427,7 @@ export function registerTools(
     const projects = status.projects ?? {};
     const resolvedFolder = path.resolve(folderPath);
     let bestMatch: { projectId: string; matchLen: number } | undefined;
+    let currentRemotePromise: Promise<string | null> | undefined;
 
     for (const [projectPath, info] of Object.entries(projects)) {
       const resolvedProjectPath = path.resolve(projectPath);
@@ -5434,6 +5437,13 @@ export function registerTools(
         resolvedProjectPath.startsWith(`${resolvedFolder}${path.sep}`);
       if (!matches) continue;
       if (!info?.indexed_at) continue;
+
+      // Twin/repair binding requires matching git-remote identity: a repo
+      // that merely shares a name or path leaf must never bind to this entry.
+      if (info?.git_remote) {
+        currentRemotePromise ??= readGitRemoteIdentity(resolvedFolder);
+        if ((await currentRemotePromise) !== info.git_remote) continue;
+      }
 
       const indexedAt = new Date(info.indexed_at);
       if (!Number.isNaN(indexedAt.getTime())) {
@@ -5528,7 +5538,17 @@ export function registerTools(
     options: { preflight?: boolean } = {}
   ): void {
     // Pre-write index status to prevent race conditions
-    markProjectIndexed(resolvedPath, { project_id: projectId }).catch(() => {});
+    void (async () => {
+      const [gitHead, gitRemote] = await Promise.all([
+        readGitHead(resolvedPath),
+        readGitRemoteIdentity(resolvedPath),
+      ]);
+      await markProjectIndexed(resolvedPath, {
+        project_id: projectId,
+        git_head: gitHead ?? undefined,
+        git_remote: gitRemote ?? undefined,
+      });
+    })().catch(() => {});
 
     (async () => {
       try {
@@ -13014,6 +13034,12 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
         const roundTripMs = Date.now() - startTime;
         let { results, total } = extractSearchEnvelope(selected.result);
         const scopeInvalid = isScopeInvalidResult(selected.result);
+        if (scopeInvalid) {
+          modeFallbackNote = appendNote(
+            modeFallbackNote,
+            '[SCOPE_UNRELIABLE] The backend flagged this search\'s workspace/project scope as invalid — results may come from the wrong project. Run init(folder_path="...") to re-bind, or pass workspace_id/project_id explicitly.'
+          );
+        }
 
         for (const r of results) {
           if (r.file_path) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2700,6 +2700,37 @@ const SCOPE_RETRY_CONSOLIDATED_ACTIONS = new Set([
   "list",
 ]);
 
+// A degenerate step/task title turns prose into unsearchable junk tasks —
+// reject at capture time with a per-title reason.
+export function degenerateTitleReason(title: unknown): string | null {
+  if (typeof title !== "string") return "missing";
+  const trimmed = title.trim();
+  if (!trimmed) return "empty";
+  if (/^-+$/.test(trimmed)) return "placeholder dashes";
+  if (trimmed.includes("\n")) return "multi-line";
+  if (trimmed.length > 200) return `too long (${trimmed.length} chars, max 200)`;
+  if (!trimmed.includes(" ") && /^[\w@.\\/-]+\.[a-z0-9]{1,8}$/i.test(trimmed)) {
+    return "bare file path";
+  }
+  if (/^(\.{0,2}\/)?[\w.-]+(\/[\w.-]+)+\/?$/.test(trimmed)) return "bare file path";
+  return null;
+}
+
+export function collectDegenerateStepTitles(steps: unknown): string | null {
+  if (!Array.isArray(steps)) return null;
+  const issues: string[] = [];
+  steps.forEach((step, index) => {
+    const title = (step as Record<string, unknown> | null)?.title;
+    const reason = degenerateTitleReason(title);
+    if (reason) {
+      const shown = typeof title === "string" ? title.slice(0, 60) : String(title);
+      issues.push(`- step ${index + 1}: ${reason} ("${shown}")`);
+    }
+  });
+  if (issues.length === 0) return null;
+  return `capture_plan rejected: ${issues.length} step title(s) are not usable as task titles:\n${issues.join("\n")}\nGive each step a short, action-oriented title; put details in the step description.`;
+}
+
 function scopeRetryEligible(toolName: string, action: unknown): boolean {
   if (SCOPE_RETRY_FLAT_TOOLS.has(toolName)) return true;
   if (toolName === "memory" || toolName === "session" || toolName === "entity") {
@@ -10457,6 +10488,13 @@ After compression, the AI can use session_recall to retrieve this context in fut
       }),
     },
     async (input) => {
+      const degenerateSteps = collectDegenerateStepTitles(input.steps);
+      if (degenerateSteps) {
+        return {
+          content: [{ type: "text" as const, text: degenerateSteps }],
+          isError: true,
+        };
+      }
       const result = await client.createPlan(input);
       return {
         content: [{ type: "text" as const, text: formatContent(result) }],
@@ -13204,6 +13242,109 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
       }
     );
 
+    // Resolve a plan reference for get_plan/update_plan. A UUID is used
+    // directly; other text matches against plan titles in scope; with no
+    // reference at all, the latest actionable plan is picked, preferring
+    // substantive plans (progress, active status, or linked tasks) over
+    // stray 0% drafts. A miss returns the in-scope listing — never a
+    // dead-end.
+    async function resolvePlanForAction(input: {
+      plan_id?: string;
+      query?: string;
+      workspace_id?: string;
+      project_id?: string;
+    }): Promise<{ planId: string; note?: string } | { listing: string } | { error: string }> {
+      const direct = normalizeUuid(input.plan_id);
+      if (direct) return { planId: direct };
+
+      const workspaceId = resolveWorkspaceId(input.workspace_id);
+      if (!workspaceId) {
+        return {
+          error: "Plan lookup requires workspace scope. Run init first, or pass plan_id as a UUID.",
+        };
+      }
+      const projectId = normalizeUuid(input.project_id) || resolveProjectId(undefined);
+      let plans: Array<Record<string, any>> = [];
+      try {
+        const listed = (await client.listPlans({
+          workspace_id: workspaceId,
+          project_id: projectId,
+          limit: 50,
+        })) as any;
+        const collected = Array.isArray(listed)
+          ? listed
+          : listed?.items || listed?.plans || listed?.data?.items || listed?.data?.plans || listed?.data;
+        plans = Array.isArray(collected) ? collected : [];
+      } catch (error) {
+        return {
+          error: `Could not list plans for lookup: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+
+      const lookupRaw = (input.plan_id || input.query || "").trim();
+      if (lookupRaw) {
+        const lookup = lookupRaw.toLowerCase();
+        const matches = plans.filter((p) =>
+          String(p?.title ?? "").trim().toLowerCase().includes(lookup)
+        );
+        const singleId = matches.length === 1 ? normalizeUuid(matches[0]?.id) : undefined;
+        if (singleId) {
+          return {
+            planId: singleId,
+            note: `Resolved plan "${lookupRaw}" to **${matches[0]?.title}**.`,
+          };
+        }
+        if (matches.length > 1) {
+          return {
+            listing: formatPlanCandidates(matches, `Multiple plans match "${lookupRaw}" — pass plan_id:`),
+          };
+        }
+        return {
+          listing: formatPlanCandidates(plans, `No plan matches "${lookupRaw}". Plans in scope:`),
+        };
+      }
+
+      const actionable = plans.filter(
+        (p) => String(p?.status ?? "").toLowerCase() !== "archived"
+      );
+      if (actionable.length === 0) {
+        return { listing: formatPlanCandidates(plans, "No actionable plans in scope.") };
+      }
+      const isSubstantive = (p: Record<string, any>) => {
+        const progress = Number(p?.progress ?? p?.progress_percent ?? 0);
+        const status = String(p?.status ?? "").toLowerCase();
+        const taskCount = Array.isArray(p?.tasks) ? p.tasks.length : Number(p?.task_count ?? 0);
+        return progress > 0 || status === "active" || taskCount > 0;
+      };
+      const pick = actionable.find(isSubstantive) ?? actionable[0];
+      const pickId = normalizeUuid(pick?.id);
+      if (!pickId) {
+        return { listing: formatPlanCandidates(plans, "Plans in scope:") };
+      }
+      const others = actionable
+        .filter((p) => p !== pick)
+        .slice(0, 3)
+        .map((p) => `- ${p?.title || p?.id}`)
+        .join("\n");
+      return {
+        planId: pickId,
+        note: `Auto-resolved to the latest actionable plan: **${pick?.title || pickId}**.${others ? `\nOther actionable plans:\n${others}` : ""}`,
+      };
+    }
+
+    function formatPlanCandidates(plans: Array<Record<string, any>>, headline: string): string {
+      if (!plans.length) {
+        return `${headline}\n(none) — save one with session(action="capture_plan", title="...", steps=[...]).`;
+      }
+      const lines = plans.slice(0, 10).map((p) => {
+        const status = String(p?.status ?? "unknown");
+        const progress = Number(p?.progress ?? p?.progress_percent ?? 0);
+        const progressLabel = Number.isFinite(progress) && progress > 0 ? ` ${progress}%` : "";
+        return `- ${p?.title || "(untitled)"} [${status}${progressLabel}] (id: ${p?.id})`;
+      });
+      return `${headline}\n${lines.join("\n")}`;
+    }
+
     // Resolve a lesson reference (UUID or lookup text) to its memory event id.
     // Text lookups rank exact title matches first and refuse ambiguous
     // matches so a bulk-worded lookup can never silently edit the wrong lesson.
@@ -13426,7 +13567,7 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
             })
             .optional(),
           // Plan-specific params (accept string so truncated UUID prefixes emit a friendly handler-level error; see issue #53)
-          plan_id: z.string().optional().describe("Plan ID (full 36-char UUID) for get_plan/update_plan"),
+          plan_id: z.string().optional().describe("Plan ID (UUID) or plan title text for get_plan/update_plan; omit to resolve the latest actionable plan"),
           event_id: z.string().optional().describe("Event ID (full 36-char UUID)"),
           task_id: z.string().optional().describe("Task ID (full 36-char UUID)"),
           node_id: z.string().optional().describe("Node ID (full 36-char UUID)"),
@@ -14071,6 +14212,10 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
             if (!workspaceId) {
               return errorResult("capture_plan requires workspace_id. Call session_init first.");
             }
+            const degenerateSteps = collectDegenerateStepTitles(input.steps);
+            if (degenerateSteps) {
+              return errorResult(degenerateSteps);
+            }
             const result = await client.createPlan({
               workspace_id: workspaceId,
               project_id: projectId,
@@ -14095,25 +14240,32 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
           }
 
           case "get_plan": {
-            if (!input.plan_id) {
-              return errorResult("get_plan requires: plan_id");
+            const resolvedPlan = await resolvePlanForAction(input);
+            if ("error" in resolvedPlan) return errorResult(resolvedPlan.error);
+            if ("listing" in resolvedPlan) {
+              return { content: [{ type: "text" as const, text: resolvedPlan.listing }] };
             }
             const result = await client.getPlan({
-              plan_id: input.plan_id,
+              plan_id: resolvedPlan.planId,
               include_tasks: input.include_tasks !== false,
             });
+            const planText = resolvedPlan.note
+              ? `${resolvedPlan.note}\n${formatContent(result)}`
+              : formatContent(result);
             return {
-              content: [{ type: "text" as const, text: formatContent(result) }],
-              
+              content: [{ type: "text" as const, text: planText }],
+
             };
           }
 
           case "update_plan": {
-            if (!input.plan_id) {
-              return errorResult("update_plan requires: plan_id");
+            const resolvedPlanForUpdate = await resolvePlanForAction(input);
+            if ("error" in resolvedPlanForUpdate) return errorResult(resolvedPlanForUpdate.error);
+            if ("listing" in resolvedPlanForUpdate) {
+              return { content: [{ type: "text" as const, text: resolvedPlanForUpdate.listing }] };
             }
             const result = await client.updatePlan({
-              plan_id: input.plan_id,
+              plan_id: resolvedPlanForUpdate.planId,
               title: input.title,
               content: input.content,
               description: input.description,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -32,6 +32,14 @@ import {
 } from "./hooks-config.js";
 import { HttpError } from "./http.js";
 import { forgetLocalConfig, resolveWorkspace } from "./workspace-config.js";
+import {
+  isScopeError,
+  prependScopeNote,
+  recoverWriteScopeAfterProjectError,
+  resolveProjectScopeId,
+  resolveWriteScope,
+  runWithScopeNoteCapture,
+} from "./scope.js";
 import { trackToolTokenSavings, type TokenSavingsToolType } from "./token-savings.js";
 import {
   getSessionInitTip,
@@ -2652,6 +2660,54 @@ const VALID_DOC_TYPES = [
   "general",
 ] as const;
 
+// Actions whose writes resolve scope centrally (drift healing) and are
+// eligible for a one-shot retry after a stale-scope error.
+const MEMORY_WRITE_SCOPE_ACTIONS = new Set([
+  "create_event",
+  "create_node",
+  "create_task",
+  "create_todo",
+  "create_diagram",
+  "create_doc",
+  "create_roadmap",
+  "import_batch",
+]);
+const SESSION_WRITE_SCOPE_ACTIONS = new Set([
+  "capture",
+  "capture_lesson",
+  "capture_plan",
+  "remember",
+]);
+const SCOPE_RETRY_FLAT_TOOLS = new Set([
+  "capture_plan",
+  "session_capture",
+  "session_capture_lesson",
+  "session_remember",
+  "memory_create_doc",
+  "memory_update_doc",
+  "memory_delete_doc",
+  "memory_create_task",
+  "memory_update_task",
+  "memory_create_todo",
+  "memory_complete_todo",
+  "memory_create_event",
+]);
+const SCOPE_RETRY_CONSOLIDATED_ACTIONS = new Set([
+  ...MEMORY_WRITE_SCOPE_ACTIONS,
+  ...SESSION_WRITE_SCOPE_ACTIONS,
+  "decisions",
+  "create",
+  "list",
+]);
+
+function scopeRetryEligible(toolName: string, action: unknown): boolean {
+  if (SCOPE_RETRY_FLAT_TOOLS.has(toolName)) return true;
+  if (toolName === "memory" || toolName === "session" || toolName === "entity") {
+    return typeof action === "string" && SCOPE_RETRY_CONSOLIDATED_ACTIONS.has(action);
+  }
+  return false;
+}
+
 const CAPSULE_ACTIONS = [
   "open",
   "get",
@@ -4298,9 +4354,41 @@ export function registerTools(
         const integrationGated = await gateIfIntegrationTool(name);
         if (integrationGated) return integrationGated;
 
-        const result = await handler(input, extra);
-        return maybeStripStructuredContent(result);
+        const { result, note } = await runWithScopeNoteCapture(() => handler(input, extra));
+        return maybeStripStructuredContent(prependScopeNote(result, note));
       } catch (error: any) {
+        // One-shot scope recovery for write-capable calls: heal a stale
+        // workspace/project binding, then retry the handler once. The retried
+        // call re-resolves scope from the corrected session context.
+        if (
+          sessionManager &&
+          isScopeError(error) &&
+          scopeRetryEligible(name, (input as Record<string, unknown> | undefined)?.action)
+        ) {
+          const ctx = sessionManager.getContext();
+          const attempted = {
+            workspaceId:
+              typeof ctx?.workspace_id === "string" ? (ctx.workspace_id as string) : undefined,
+            projectId:
+              typeof ctx?.project_id === "string" ? (ctx.project_id as string) : undefined,
+            recovered: false,
+          };
+          try {
+            const recoveredScope = await recoverWriteScopeAfterProjectError(
+              client,
+              sessionManager,
+              attempted,
+              error
+            );
+            if (recoveredScope) {
+              const { result, note } = await runWithScopeNoteCapture(() => handler(input, extra));
+              const combined = [recoveredScope.note, note].filter(Boolean).join(" ");
+              return maybeStripStructuredContent(prependScopeNote(result, combined || undefined));
+            }
+          } catch {
+            // Retry failed — fall through and render the original error.
+          }
+        }
         const rawMessage = error?.message || String(error);
         const errorMessage =
           rawMessage.length > 500 ? `${rawMessage.slice(0, 500)}…` : rawMessage;
@@ -13421,6 +13509,20 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
         if (resolvedSuggestionId.error) return errorResult(resolvedSuggestionId.error);
         if (resolvedSuggestionId.value) input.suggestion_id = resolvedSuggestionId.value;
 
+        // Capture-style writes resolve a consistent scope centrally (project
+        // names accepted, implicit drift healed, explicit-stale errors).
+        if (SESSION_WRITE_SCOPE_ACTIONS.has(input.action)) {
+          const projectLookup = await resolveProjectScopeId(client, workspaceId, input.project_id);
+          if (projectLookup.error) return errorResult(projectLookup.error);
+          const writeScope = await resolveWriteScope(client, sessionManager ?? null, {
+            workspaceId: input.workspace_id,
+            projectId: projectLookup.id,
+          });
+          if (writeScope.error) return errorResult(writeScope.error);
+          workspaceId = writeScope.workspaceId;
+          projectId = writeScope.projectId;
+        }
+
         switch (input.action) {
           case "capture": {
             if (!input.event_type || !input.title || !input.content) {
@@ -15472,6 +15574,22 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
         );
         if (resolvedMemoryTranscriptId.error) return errorResult(resolvedMemoryTranscriptId.error);
         if (resolvedMemoryTranscriptId.value) input.transcript_id = resolvedMemoryTranscriptId.value;
+
+        // Write actions resolve a consistent scope centrally: project names
+        // are accepted in place of UUIDs, implicit workspace/project drift is
+        // healed before the first attempt, and an explicitly requested but
+        // inaccessible project is a hard error.
+        if (MEMORY_WRITE_SCOPE_ACTIONS.has(input.action)) {
+          const projectLookup = await resolveProjectScopeId(client, workspaceId, input.project_id);
+          if (projectLookup.error) return errorResult(projectLookup.error);
+          const writeScope = await resolveWriteScope(client, sessionManager ?? null, {
+            workspaceId: input.workspace_id,
+            projectId: projectLookup.id,
+          });
+          if (writeScope.error) return errorResult(writeScope.error);
+          workspaceId = writeScope.workspaceId;
+          projectId = writeScope.projectId;
+        }
 
         switch (input.action) {
           case "create_event": {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -8286,7 +8286,7 @@ This does semantic search on the first message. You only need context on subsequ
             "Current workspace/project folder path (absolute). Use this when IDE roots are not available."
           ),
         workspace_id: z.string().uuid().optional().describe("Workspace to initialize context for"),
-        project_id: z.string().uuid().optional().describe("Project to initialize context for"),
+        project_id: z.string().optional().describe("Project to initialize context for (UUID, or a project name to look up)"),
         session_id: z
           .string()
           .optional()
@@ -8350,12 +8350,50 @@ This does semantic search on the first message. You only need context on subsequ
         ideRoots = [input.folder_path];
       }
 
+      // A non-UUID project_id is treated as a project name, matching the
+      // scope-resolution behavior elsewhere.
+      if (input.project_id && !normalizeUuid(input.project_id)) {
+        const projectLookup = await resolveProjectScopeId(
+          client,
+          resolveWorkspaceId(input.workspace_id),
+          input.project_id
+        );
+        if (projectLookup.error) return errorResult(projectLookup.error);
+        input.project_id = projectLookup.id;
+      }
+
       // Pass detected client name for analytics tracking
       const clientName = getDetectedClientName();
-      const result = (await client.initSession(
-        { ...input, client_name: clientName || undefined },
-        ideRoots
-      )) as Record<string, unknown>;
+      // An explicit folder_path expresses "bind to this folder": suppress any
+      // header-injected scope so folder resolution can actually run. If folder
+      // resolution then yields no workspace (typical through the HTTP gateway,
+      // where the server cannot read the caller's local config), restore the
+      // inherited header scope as the fallback.
+      const inheritedOverride = getAuthOverride();
+      const suppressHeaderScope = Boolean(
+        input.folder_path && (inheritedOverride?.workspaceId || inheritedOverride?.projectId)
+      );
+      const runInit = () =>
+        client.initSession(
+          { ...input, client_name: clientName || undefined },
+          ideRoots
+        ) as Promise<Record<string, unknown>>;
+      let result: Record<string, unknown>;
+      if (suppressHeaderScope) {
+        result = await runWithAuthOverride(
+          { ...inheritedOverride, workspaceId: undefined, projectId: undefined },
+          runInit
+        );
+        if (typeof result.workspace_id !== "string" || !result.workspace_id) {
+          result = await runInit();
+          if (typeof result.workspace_id === "string" && result.workspace_id) {
+            (result as any).scope_note =
+              "Folder resolution found no workspace; restored the request's inherited header scope.";
+          }
+        }
+      } else {
+        result = await runInit();
+      }
 
       // Add compact tool reference to help AI know available tools
       result.tools_hint = getCoreToolsHint();


### PR DESCRIPTION
Stacked on #59 — merge that first; this PR then retargets/rebases onto main cleanly.

## Summary
- **Central scope resolution** (new `src/scope.ts`, 19 unit tests): write paths resolve a consistent {workspace, project} pair before the first attempt. Soft (implicit) workspace drift is self-healed by adopting the project's real workspace and persisting the correction; explicit/header/folder-backed workspaces stay authoritative; an explicitly requested but inaccessible project is a hard error. One-shot recovery after stale-scope errors clears/re-resolves the binding from the folder's saved config and retries once, with a `[SCOPE]` note (Rust v0.3.53–58 + v0.5.18 semantics).
- **Project names accepted** wherever a project_id is taken on write paths and init (Rust v0.3.7).
- **init precedence** (v0.3.9 + v0.5.7): explicit `folder_path` suppresses header-injected scope so folder binding runs; header scope is restored as fallback when folder resolution yields no workspace (matters for the HTTP gateway).
- **Plan lookup hardening** (v0.5.14): get_plan/update_plan accept UUID/title/nothing and never dead-end (candidate listing on miss, substantive-preferred auto-resolve); capture_plan rejects degenerate step titles with per-title reasons.
- **Search scope loudness + index identity** (v0.5.7 + v0.5.17): `[SCOPE_UNRELIABLE]` banner on backend-flagged invalid scope; local index registry records git HEAD + normalized remote identity at ingest; folder→project binding requires matching remote identity (blocks cross-repo twin binding); IndexKeeper re-ingests when HEAD moves out-of-session.
- Verified already equivalent (no change): entity scope inheritance, init re-bind, per-initialize profile reset (v0.5.16).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 177/177 (30 new: scope resolution, plan titles, git identity)
- [x] `npm run build` clean
- [x] `npx tsx scripts/registration-smoke.mts` — SMOKE_PASS (36 tools, surface unchanged)
- [x] Leak gate over the pass-2 diff — zero internal-stack-name hits
- [ ] Manual probes against production API before publish: create_doc with drifted soft workspace (expect `[SCOPE]` heal note); `project_id` by name; `get_plan` with no args (latest actionable) and bogus title (candidate listing); gateway init with header scope + folder_path