### PR TITLE
Rust MCP parity pass 3: search-quality cluster (0.4.78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.4.78
+
+**Rust MCP parity pass 3: search-quality cluster (v0.3.45–v0.5.26).**
+
+### Search-First Contract (v0.5.23)
+
+- Every agent-facing surface that permitted a preemptive "index not ready → use local tools" fallback (generated rules blocks, hook reminder text) now states the reactive-only contract: run `search(...)` first even while the index is still building (keyword hits return immediately); fall back to local tools ONLY after search itself returns 0 results/errors on a retry, for known-new edits, or on explicit user request. The rules version tracks the package version, so managed rule blocks regenerate on next run.
+
+### Code-Intent Gating (v0.3.52)
+
+- Identifier-shaped queries (snake_case, camelCase, PascalCase, `::`/dotted member access — even as a lone token) suppress memory/doc blending on workspace-scoped searches, so a symbol lookup no longer ranks docs or branding assets alongside code. Conservative: prose and plain memory words are unaffected. The consolidated `search` tool now exposes `include_memory` for explicit opt-in/out.
+
+### Zero-Result Rewrite Recovery (v0.5.26)
+
+- When the backend recovers an empty natural-language search by retrying query rewrites, the output carries an honest provenance line ("0 direct hits — recovered via server-side rewrites: …") and a `rewrite_recovery` structured block. Older backends omit the fields and behavior is unchanged.
+
+### Freshness Guard (v0.3.45 + v0.3.63)
+
+- Search results whose local file no longer exists under the active folder are pruned, with a note.
+- A non-silent `[INDEX_HEALTH]` advisory reports how many tracked files changed since the last index (git-status based, mtime-gated against the recorded `indexed_at`, bounded and best-effort). IndexKeeper's incremental pass continues to re-ingest changed files in the background; this pass adds the visibility.
+
+### Deferred (need their own pass)
+
+- v0.3.34 "untouchable search quality v2" ranking/cache-freshness overhaul and v0.5.10 stale-index-root auto-heal: each is a ~400-line search-engine-side rework in the Rust tree; the TS server already carries partial equivalents from 0.4.72 (mode escalation, artifact filtering, ripgrep pre-fetch, IndexKeeper). Porting the remainder faithfully needs a dedicated pass.
+
 ## 0.4.77
 
 **Rust MCP parity pass 2: scope & routing correctness (v0.3.6–v0.5.18 cluster).**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextstream/mcp-server",
   "mcpName": "io.github.contextstreamio/mcp-server",
-  "version": "0.4.77",
+  "version": "0.4.78",
   "description": "ContextStream MCP server - v0.4.x with consolidated domain tools plus per-action write surfaces (~75% token reduction vs individual tools). Code context, memory, search, Q&A, and AI tools.",
   "type": "module",
   "license": "MIT",

--- a/src/code-intent.test.ts
+++ b/src/code-intent.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { queryHasCodeIntent } from "./tools.js";
+
+describe("queryHasCodeIntent", () => {
+  it("recognizes lone identifier-shaped tokens", () => {
+    expect(queryHasCodeIntent("search_first_redirect_decision")).toBe(true);
+    expect(queryHasCodeIntent("resolveWriteScope")).toBe(true);
+    expect(queryHasCodeIntent("SessionManager")).toBe(true);
+    expect(queryHasCodeIntent("scope::resolve_write_scope")).toBe(true);
+    expect(queryHasCodeIntent("client.getProject")).toBe(true);
+  });
+
+  it("leaves prose and plain memory words unaffected", () => {
+    expect(queryHasCodeIntent("decisions")).toBe(false);
+    expect(queryHasCodeIntent("hexagon logo")).toBe(false);
+    expect(queryHasCodeIntent("how does auth work here")).toBe(false);
+    expect(queryHasCodeIntent("")).toBe(false);
+  });
+
+  it("recognizes identifiers embedded in multi-word queries", () => {
+    expect(queryHasCodeIntent("where is resolveWriteScope used")).toBe(true);
+    expect(queryHasCodeIntent("find delete_all handler")).toBe(true);
+  });
+});

--- a/src/hooks/user-prompt-submit.ts
+++ b/src/hooks/user-prompt-submit.ts
@@ -55,14 +55,13 @@ const FULL_REMINDER = `[CONTEXTSTREAM RULES - MANDATORY]
    - On subsequent messages, default to context() first. Narrow bypass: immediate read-only ContextStream calls when context is fresh and no state-changing tool has run.
 
 2. FOR CODE SEARCH: Check index status, then search appropriately
-   ⚠️ BEFORE searching: mcp__contextstream__project(action="index_status")
-   ✅ IF indexed & fresh: Use mcp__contextstream__search(mode="auto", query="...") BEFORE Glob/Grep/Read/Explore/Task/EnterPlanMode
-   ✅ IF NOT indexed OR stale: wait for background refresh up to ~20s, retry mcp__contextstream__search(mode="auto", query="..."), then allow local tools only after the grace window
-   ✅ IF search still returns 0 results after retry/window: fallback to local tools (Glob/Grep/Read)
+   ✅ Use mcp__contextstream__search(mode="auto", query="...") BEFORE Glob/Grep/Read/Explore/Task/EnterPlanMode
+   ✅ Run search even while the index is still building — keyword hits return immediately, results fill in as you work
+   ✅ IF search itself returns 0 results/errors: retry once, THEN fall back to local tools (Glob/Grep/Read)
 
 3. WHEN LOCAL TOOLS (Glob/Grep/Read) ARE OK:
-   ✅ Stale/not-indexed grace window has elapsed (~20s default, configurable)
    ✅ ContextStream search still returns 0 results or errors after retry
+   ✅ The file was just written this turn (known-new, not yet indexed)
    ✅ User explicitly requests local tools
 
 4. FOR PLANS & TASKS: Use ContextStream, not file-based plans
@@ -663,8 +662,8 @@ Returns: \`indexed\` (true/false), \`last_indexed_at\`, \`file_count\`
 → Use \`search(mode="auto", query="...")\`
 
 **IF indexed=false OR last_indexed_at is stale (>7 days):**
-→ Wait up to ~20s for background refresh, retry \`search(mode="auto", query="...")\`
-→ After grace window: local tools are allowed if search still misses
+→ Run \`search(mode="auto", query="...")\` anyway — keyword hits return immediately while indexing builds
+→ Local tools only if search itself returns 0 results/errors on a retry
 
 **IF search still returns 0 results or errors after retry/window:**
 → Fallback to local tools (Glob/Grep/Read)

--- a/src/project-index-utils.ts
+++ b/src/project-index-utils.ts
@@ -1,5 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 
 const execFileAsync = promisify(execFile);
 
@@ -47,6 +49,50 @@ export function normalizeGitRemote(url: string): string | null {
     .replace(/\.git\/?$/, "")
     .replace(/\/+$/, "");
   return unified || null;
+}
+
+/**
+ * Count tracked files with local modifications that postdate the last index —
+ * the drift signal for "results may be stale". Deleted files count
+ * unconditionally; modified files count when their mtime is newer than
+ * indexedAtMs (pass 0 to disable the mtime gate). Bounded and best-effort:
+ * non-git folders and probe failures return 0.
+ */
+export async function countDirtyFilesSince(
+  folderPath: string,
+  indexedAtMs: number
+): Promise<number> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", folderPath, "status", "--porcelain"], {
+      timeout: 2_000,
+      maxBuffer: 256 * 1024,
+    });
+    const entries = stdout.split("\n").filter(Boolean).slice(0, 200);
+    let count = 0;
+    for (const entry of entries) {
+      const statusCode = entry.slice(0, 2);
+      const relPath = entry.slice(3).trim();
+      if (!relPath) continue;
+      if (statusCode.includes("D")) {
+        count += 1;
+        continue;
+      }
+      if (indexedAtMs <= 0) {
+        count += 1;
+        continue;
+      }
+      try {
+        const stat = await fs.stat(path.join(folderPath, relPath));
+        if (stat.mtimeMs > indexedAtMs) count += 1;
+      } catch {
+        // Unstat-able (renamed/removed mid-check) counts as drift.
+        count += 1;
+      }
+    }
+    return count;
+  } catch {
+    return 0;
+  }
 }
 
 export type IndexFreshness = "fresh" | "recent" | "aging" | "stale" | "missing" | "unknown";

--- a/src/rules-templates.ts
+++ b/src/rules-templates.ts
@@ -208,7 +208,7 @@ Use \`context()\` by default to get task-specific rules, lessons from past mista
 2. **PreToolUse blocking** - If you try to use Glob/Grep/Search/Explore:
    - Hook returns error: \`STOP: Use mcp__contextstream__search(mode="auto") instead\`
    - **You MUST use the suggested ContextStream tool instead**
-  - For stale/not-indexed projects, wait for background refresh (up to ~20s), retry search, then allow local tools only after the grace window
+  - Run search FIRST even while the index is still building (keyword hits return immediately); fall back to local tools ONLY after search itself returns 0 results/errors on a retry, for known-new edits, or on explicit user request
 
 3. **PostToolUse indexing** - After Edit/Write operations:
    - Changed files are automatically re-indexed
@@ -245,7 +245,7 @@ STOP → Call search(mode="auto", query="...") FIRST
 
 ✅ **ALWAYS DO THIS:**
 1. \`search(mode="auto", query="what you're looking for")\`
-2. Only use local tools (Glob/Grep/Read) after stale/not-indexed refresh grace window elapses (~20s) or ContextStream still returns **0 results** after retry
+2. Only use local tools (Glob/Grep/Read) after \`search(...)\` itself returns **0 results**/errors on a retry — never preemptively because the index "isn't built yet"
 3. Use Read ONLY for exact file edits after you know the file path
 
 This applies to **EVERY search** throughout the **ENTIRE conversation**, not just the first message.
@@ -508,7 +508,7 @@ session(action="capture", event_type="session_snapshot", title="Pre-compaction s
 
 ### Search & Code Intelligence (ContextStream-first)
 
-⚠️ **STOP: Before using Search/Glob/Grep/Read/Explore** → Call \`search(mode="auto")\` FIRST. For stale/not-indexed projects, wait ~20s for background refresh and retry search before local fallback.
+⚠️ **STOP: Before using Search/Glob/Grep/Read/Explore** → Call \`search(mode="auto")\` FIRST — even while the index is still building (keyword hits return immediately). Fall back to local tools ONLY after search itself returns 0 results/errors on a retry, for known-new edits, or on explicit user request.
 
 **❌ WRONG workflow (wastes tokens, slow):**
 \`\`\`
@@ -527,7 +527,7 @@ search(mode="auto", query="function implementation") → done (results include c
 2. \`search(mode="auto", query="...", limit=3)\` or \`search(mode="keyword", query="<filename>", limit=3)\`
 3. \`project(action="files")\` - file tree/list (only when needed)
 4. \`graph(action="dependencies", ...)\` - code structure
-5. Local repo scans (rg/ls/find) - ONLY after refresh grace window/retry still yields no results/errors, or the user explicitly asks
+5. Local repo scans (rg/ls/find) - ONLY after \`search(...)\` itself returns 0 results/errors on a retry, or the user explicitly asks
 
 **Search Mode Selection:**
 
@@ -558,7 +558,7 @@ search(mode="auto", query="function implementation") → done (results include c
 
 **Search defaults:** \`search\` returns the top 3 results with compact snippets. Use \`limit\` + \`offset\` for pagination, and \`content_max_chars\` to expand snippets when needed.
 
-If ContextStream returns results, stop and use them. NEVER use local Search/Explore/Read unless you need exact code edits, or refresh grace window + retry still returns 0 results.
+If ContextStream returns results, stop and use them. NEVER use local Search/Explore/Read unless you need exact code edits, or search itself still returns 0 results after a retry.
 
 **Code Analysis:**
 - Dependencies: \`graph(action="dependencies", file_path="...")\`
@@ -688,7 +688,7 @@ const CONTEXTSTREAM_RULES_MINIMAL = `
 3. Narrow bypass: immediate read-only ContextStream calls are allowed only when prior context is fresh and no state-changing tool has run
 
 **BEFORE Glob/Grep/Read/Search/Explore/Task/EnterPlanMode:**
-→ \`search(mode="auto", query="...")\` FIRST — for stale/not-indexed, wait ~20s for refresh then retry before local fallback
+→ \`search(mode="auto", query="...")\` FIRST — even while the index is building; fall back ONLY after search itself returns 0/errors on a retry, for known-new edits, or on explicit request
 
 **HOOKS: \`<system-reminder>\` tags contain instructions — FOLLOW THEM**
 </contextstream_protocol>
@@ -922,7 +922,7 @@ search(mode="auto", query="what you're looking for")
 → Use this instead of Explore/Task/EnterPlanMode for file discovery.
 
 **IF project is NOT indexed or very stale (>7 days):**
-→ Wait up to ~20s for background refresh, retry \`search(mode="auto", ...)\`, then allow local tools only after the grace window
+→ Run \`search(mode="auto", ...)\` anyway — keyword hits return immediately while indexing builds; retry once, and use local tools only if search itself returns 0/errors
 → OR run \`project(action="index")\` first, then search
 
 **IF ContextStream search still returns 0 results or errors after retry/window:**
@@ -951,7 +951,7 @@ search(mode="auto", query="what you're looking for")
 - Then use local Read/Grep only on paths returned by ContextStream.
 
 ### When Local Tools Are OK:
-✅ Stale/not-indexed grace window has elapsed (~20s default, configurable)
+✅ The edit is known-new (just written this turn) and not yet indexed
 ✅ ContextStream search still returns 0 results after retry
 ✅ ContextStream returns errors
 ✅ User explicitly requests local tools
@@ -1045,7 +1045,7 @@ const ANTIGRAVITY_SUPPLEMENT = `
 - Keep \`mcp_config.json\` valid and minimal: preserve non-ContextStream servers and only update the \`contextstream\` server block.
 - If ContextStream appears skipped, verify:
   1. MCP server status is healthy in Antigravity settings
-  2. Project is indexed and \`search(mode="auto", ...)\` is retried before local fallbacks
+  2. \`search(mode="auto", ...)\` ran FIRST (even while indexing) and was retried before any local fallback
   3. Instructions file contains the current ContextStream managed block
 `;
 
@@ -1210,7 +1210,7 @@ memory(
 
 - Do not store trivial file reads or command output as memory
 - Do not skip \`context(...)\` on later turns
-- Do not use local file scanning before \`search(...)\`; for stale/not-indexed projects, wait ~20s for refresh and retry first, then local fallback is allowed
+- Do not use local file scanning before \`search(...)\`; fall back ONLY after search itself returns 0 results/errors on a retry — never because the index isn't built yet
 - Do not use editor-only task lists as the persistent record; mirror important work in ContextStream
 `;
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -63,6 +63,7 @@ import {
   indexHistoryEntryCount,
   readGitHead,
   readGitRemoteIdentity,
+  countDirtyFilesSince,
 } from "./project-index-utils.js";
 import { resolveTodoCompletionUpdate } from "./todo-utils.js";
 import { globalHotPathStore } from "./hot-paths.js";
@@ -2701,6 +2702,24 @@ const SCOPE_RETRY_CONSOLIDATED_ACTIONS = new Set([
   "create",
   "list",
 ]);
+
+// Identifier-shaped queries are code intent even as a lone token: a symbol
+// lookup like `search_first_redirect_decision` must not blend memory/media
+// hits into workspace-scoped results. Conservative — prose and plain memory
+// words (e.g. "decisions") are unaffected.
+export function queryHasCodeIntent(query: string): boolean {
+  const trimmed = query.trim();
+  if (!trimmed) return false;
+  const tokens = trimmed.split(/\s+/);
+  const tokenHasIdentifierShape = (token: string): boolean =>
+    /^[a-z0-9]+(?:_[a-z0-9]+)+$/i.test(token) || // snake_case
+    /^[a-z]+(?:[A-Z][a-z0-9]*)+$/.test(token) || // camelCase
+    /^(?:[A-Z][a-z0-9]+){2,}$/.test(token) || // PascalCase
+    token.includes("::") ||
+    /^[\w$]+\.[\w$.]+$/.test(token); // dotted member access
+  if (tokens.length === 1) return tokenHasIdentifierShape(tokens[0]);
+  return tokens.some(tokenHasIdentifierShape);
+}
 
 // A degenerate step/task title turns prose into unsearchable junk tasks —
 // reject at capture time with a per-title reason.
@@ -6894,6 +6913,7 @@ Access: Free`,
     content_max_chars?: number;
     context_lines?: number;
     exact_match_boost?: number;
+    include_memory?: boolean;
     output_format?: "full" | "paths" | "minimal" | "count";
     hot_paths_hint?: {
       entries: Array<{ path: string; score: number; source: "history" | "active" }>;
@@ -6920,15 +6940,25 @@ Access: Free`,
       typeof input.exact_match_boost === "number" && input.exact_match_boost >= 1
         ? Math.min(input.exact_match_boost, 10)
         : undefined;
+    const resolvedProjectId = resolveProjectId(input.project_id);
+    // Identifier-shaped queries suppress memory/media blending on
+    // workspace-scoped searches unless the caller opts in explicitly.
+    const includeMemory =
+      typeof input.include_memory === "boolean"
+        ? input.include_memory
+        : !resolvedProjectId && queryHasCodeIntent(input.query)
+          ? false
+          : undefined;
     return {
       query: input.query,
       workspace_id: resolveWorkspaceId(input.workspace_id),
-      project_id: resolveProjectId(input.project_id),
+      project_id: resolvedProjectId,
       limit,
       offset,
       content_max_chars: contentMax,
       context_lines: contextLines,
       exact_match_boost: exactMatchBoost,
+      include_memory: includeMemory,
       output_format: input.output_format,
       hot_paths_hint: input.hot_paths_hint,
     };
@@ -12449,6 +12479,7 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
           project_id: z.string().uuid().optional(),
           limit: z.number().optional().describe("Max results to return (default: 3)"),
           offset: z.number().optional().describe("Offset for pagination"),
+          include_memory: z.boolean().optional().describe("Include memory/doc matches in search results (defaults to false for project-scoped and identifier-shaped searches)"),
           content_max_chars: z
             .number()
             .optional()
@@ -13062,6 +13093,49 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
           }
         }
 
+        // Freshness guard: prune hits whose local file was deleted since the
+        // index, and surface a non-silent advisory when tracked files changed
+        // after the last index (IndexKeeper's incremental pass re-ingests
+        // them in the background).
+        let indexHealthNote: string | undefined;
+        if (folderPath) {
+          const beforePrune = results.length;
+          results = results.filter((r: any) => {
+            if (typeof r?.file_path !== "string" || !r.file_path) return true;
+            if (path.isAbsolute(r.file_path)) return true;
+            try {
+              return fs.existsSync(path.join(folderPath, r.file_path));
+            } catch {
+              return true;
+            }
+          });
+          if (results.length < beforePrune) {
+            indexHealthNote = appendNote(
+              indexHealthNote,
+              `Pruned ${beforePrune - results.length} hit(s) whose local file no longer exists.`
+            );
+          }
+          try {
+            const indexStatusFile = await readIndexStatus();
+            const indexEntry = indexStatusFile.projects?.[path.resolve(folderPath)];
+            if (indexEntry?.indexed_at) {
+              const indexedAtMs = Date.parse(indexEntry.indexed_at);
+              const dirtyCount = await countDirtyFilesSince(
+                folderPath,
+                Number.isFinite(indexedAtMs) ? indexedAtMs : 0
+              );
+              if (dirtyCount > 0) {
+                indexHealthNote = appendNote(
+                  indexHealthNote,
+                  `[INDEX_HEALTH] ${dirtyCount} file(s) changed since last index — background refresh runs automatically; retry search if a just-edited symbol is missing.`
+                );
+              }
+            }
+          } catch {
+            // Best-effort advisory only.
+          }
+        }
+
         if (results.length === 0 && !scopeInvalid) {
           const escalationModes: Array<typeof selected.executedMode> = (() => {
             switch (selected.executedMode) {
@@ -13150,6 +13224,9 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
         }
         if (modeFallbackNote && !(CONCISE_TOOL_TEXT && results.length > 0)) {
           lines.push(modeFallbackNote);
+        }
+        if (indexHealthNote) {
+          lines.push(indexHealthNote);
         }
         if (hotPathsHint?.entries?.length && !CONCISE_TOOL_TEXT) {
           lines.push(
@@ -13245,6 +13322,31 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
             fallback_behavior: "baseline ranking only",
           };
         }
+        // Honest provenance when the server recovered an empty NL search via
+        // fast-tier query rewrites. Older backends omit the fields and
+        // behavior is unchanged.
+        const rawSearchEnvelope = ((selected.result as any)?.data ??
+          selected.result ??
+          {}) as Record<string, any>;
+        if (rawSearchEnvelope.recovered_via_rewrite === true) {
+          const rewrittenQueries = Array.isArray(rawSearchEnvelope.rewritten_queries)
+            ? rawSearchEnvelope.rewritten_queries.filter(
+                (q: unknown): q is string => typeof q === "string"
+              )
+            : [];
+          const rewriteList = rewrittenQueries
+            .slice(0, 3)
+            .map((q) => `"${q}"`)
+            .join(", ");
+          lines.push(
+            `0 direct hits — recovered via server-side rewrites${rewriteList ? `: ${rewriteList}` : ""}.`
+          );
+          (structuredData as any).rewrite_recovery = {
+            recovered_via_rewrite: true,
+            rewritten_queries: rewrittenQueries,
+          };
+        }
+
         const resultWithMeta = {
           ...(selected.result as any),
           data: structuredData,


### PR DESCRIPTION
Stacked on #60 (which stacks on #59) — merge in order; this PR then retargets cleanly.

## Summary
- **Search-first contract (v0.5.23):** all generated-rules and hook surfaces that previously permitted a preemptive 'wait ~20s then local fallback' now state the reactive-only contract — search first even while the index builds; local tools only after search itself returns 0/errors on a retry, for known-new edits, or on explicit request. 13 permissive phrasings rewritten across rules-templates and the user-prompt-submit hook.
- **Code-intent gating (v0.3.52):** identifier-shaped queries (snake_case/camelCase/PascalCase/`::`/dotted, incl. lone tokens) suppress memory/doc blending on workspace-scoped searches; plain words like 'decisions' unaffected. Consolidated `search` gains `include_memory` for explicit control.
- **Rewrite-recovery provenance (v0.5.26):** honest '0 direct hits — recovered via server-side rewrites: …' line + `rewrite_recovery` structured block when the backend flags it; older backends unchanged.
- **Freshness guard (v0.3.45 + v0.3.63):** deleted-file hits pruned with a note; `[INDEX_HEALTH] N file(s) changed since last index` advisory (git-status based, mtime-gated, bounded) while IndexKeeper re-ingests in the background.
- **Deferred with changelog notes:** v0.3.34 ranking/cache overhaul and v0.5.10 stale-root auto-heal (~400-line Rust reworks each; TS carries partial 0.4.72 equivalents).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 180/180 (3 new code-intent tests)
- [x] `npm run build` clean
- [x] `npx tsx scripts/registration-smoke.mts` — SMOKE_PASS (36 tools, surface unchanged apart from the new include_memory param)
- [x] Leak gate over the pass-3 diff — zero hits
- [ ] Manual probes before publish: workspace-scoped identifier search (no memory noise), search in a repo with uncommitted edits (expect [INDEX_HEALTH] advisory), regenerated rules contain no 'wait ~20s' phrasing