### PR TITLE
Rust MCP parity pass 4: metadata/UX polish (0.4.79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.4.79
+
+**Rust MCP parity pass 4: metadata/UX polish cluster (v0.3.11–v0.5.27).**
+
+### Grounding Quality (v0.3.29 + v0.5.27)
+
+- Ground-bundle items never render as bare "Untitled": display titles fall back from title → summary → first meaningful content line → a typed id.
+- Operational hook telemetry (`operation`/`command_execution`/`file_operation`) older than 7 days — unknown age counts as stale — is dropped from the ground bundle so months-old telemetry cannot bury real prior work. Hook captures already posted `event_type=operation` (verified, no change needed).
+
+### Model Awareness (v0.3.44 + v0.3.49 subsets)
+
+- When the MCP client surfaces its model at initialize, API requests carry `X-ContextStream-Model` so server-side events attribute to the real model; the header is omitted when the model is unknown (existing behavior).
+- Known 1M-window models raise the context-pressure threshold to ~650k instead of the conservative 70k default; unknown/older models keep the default exactly.
+
+### Tier Gating (v0.3.38)
+
+- Tier-gated tools return a structured `plan_restricted` block (current plan, required tier, upgrade URL) alongside the text nudge, so clients can render an upgrade prompt without parsing error text.
+
+### Tool-Description Teaching (v0.3.11 + v0.3.13)
+
+- The memory tool description now teaches that docs/runbooks/specs/decisions live in memory (never on disk) and routes tickets/bugs/incidents/releases to the `entity` tool.
+
+### Verified Without Change
+
+- Full-body rendering in `get_task`/`get_event`/`get_todo`/`get_transcript` (v0.3.28): the TS renderer never truncated.
+- Hook telemetry classification as `operation` (v0.5.27 hook half): already the default in the shared hook capture helper.
+
+### Deferred
+
+- v0.3.27 icon metadata (niche MCP client support), v0.3.40 freshness-aware grounding (server-rendered), v0.3.69/70 media summary polish.
+
 ## 0.4.78
 
 **Rust MCP parity pass 3: search-quality cluster (v0.3.45–v0.5.26).**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextstream/mcp-server",
   "mcpName": "io.github.contextstreamio/mcp-server",
-  "version": "0.4.78",
+  "version": "0.4.79",
   "description": "ContextStream MCP server - v0.4.x with consolidated domain tools plus per-action write surfaces (~75% token reduction vs individual tools). Code context, memory, search, Q&A, and AI tools.",
   "type": "module",
   "license": "MIT",

--- a/src/http.ts
+++ b/src/http.ts
@@ -70,6 +70,16 @@ export interface RequestOptions {
   workspaceId?: string;
 }
 
+// The agent's model id, when the MCP client surfaced one at initialize.
+// Forwarded as X-ContextStream-Model so server-side events attribute to the
+// real model; omitted (existing behavior) when unknown.
+let activeModelId: string | null = null;
+
+export function setActiveModelId(modelId: string | null | undefined): void {
+  const trimmed = typeof modelId === "string" ? modelId.trim() : "";
+  activeModelId = trimmed ? trimmed : null;
+}
+
 const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
 const MAX_RETRIES = 3;
 const BASE_DELAY = 1000;
@@ -114,6 +124,7 @@ export async function request<T>(
   };
   if (apiKey) headers["X-API-Key"] = apiKey;
   if (jwt) headers["Authorization"] = `Bearer ${jwt}`;
+  if (activeModelId) headers["X-ContextStream-Model"] = activeModelId;
   const workspaceId =
     authOverride?.workspaceId ||
     options.workspaceId ||

--- a/src/metadata-polish.test.ts
+++ b/src/metadata-polish.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  displayTitle,
+  isStaleOperationalGroundingItem,
+  isLargeContextModel,
+} from "./tools.js";
+
+describe("displayTitle", () => {
+  it("prefers a real title and never renders bare Untitled", () => {
+    expect(displayTitle({ title: "Fix scope drift" })).toBe("Fix scope drift");
+    expect(displayTitle({ title: "Untitled", summary: "Scope drift fix" })).toBe(
+      "Scope drift fix"
+    );
+  });
+
+  it("falls back to the first meaningful content line, clipped", () => {
+    expect(displayTitle({ content: "\n\nAdopted workspace from project.\nmore" })).toBe(
+      "Adopted workspace from project."
+    );
+    const long = "x".repeat(120);
+    expect(displayTitle({ content: long }).length).toBeLessThanOrEqual(80);
+  });
+
+  it("falls back to a typed id, never Untitled", () => {
+    expect(displayTitle({ event_type: "decision", id: "abcdef12-3456" })).toBe(
+      "decision abcdef12"
+    );
+    expect(displayTitle({})).toBe("item");
+  });
+});
+
+describe("isStaleOperationalGroundingItem", () => {
+  it("only applies to operational kinds", () => {
+    expect(isStaleOperationalGroundingItem({ event_type: "decision" })).toBe(false);
+    expect(
+      isStaleOperationalGroundingItem({ event_type: "decision", occurred_at: "2020-01-01" })
+    ).toBe(false);
+  });
+
+  it("drops old or age-unknown operational telemetry, keeps fresh", () => {
+    expect(isStaleOperationalGroundingItem({ event_type: "operation" })).toBe(true);
+    expect(
+      isStaleOperationalGroundingItem({
+        event_type: "operation",
+        occurred_at: "2020-01-01T00:00:00Z",
+      })
+    ).toBe(true);
+    expect(
+      isStaleOperationalGroundingItem({
+        event_type: "operation",
+        occurred_at: new Date().toISOString(),
+      })
+    ).toBe(false);
+  });
+});
+
+describe("isLargeContextModel", () => {
+  it("recognizes 1M-window model ids", () => {
+    expect(isLargeContextModel("claude-opus-4-8")).toBe(true);
+    expect(isLargeContextModel("claude-opus-4.8-thinking-high")).toBe(true);
+    expect(isLargeContextModel("claude-fable-5")).toBe(true);
+    expect(isLargeContextModel("claude-sonnet-5[1m]")).toBe(true);
+  });
+
+  it("keeps unknown and older models on the default", () => {
+    expect(isLargeContextModel("claude-sonnet-5")).toBe(false);
+    expect(isLargeContextModel("claude-haiku-4-5-20251001")).toBe(false);
+    expect(isLargeContextModel("")).toBe(false);
+  });
+});

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -30,7 +30,7 @@ import {
   installAllEditorHooks,
   type SupportedEditor,
 } from "./hooks-config.js";
-import { HttpError } from "./http.js";
+import { HttpError, setActiveModelId } from "./http.js";
 import { forgetLocalConfig, resolveWorkspace } from "./workspace-config.js";
 import {
   isScopeError,
@@ -2703,6 +2703,55 @@ const SCOPE_RETRY_CONSOLIDATED_ACTIONS = new Set([
   "list",
 ]);
 
+// Grounding/recall items must never render as bare "Untitled": fall back
+// from title to summary to the first meaningful content line to a typed id.
+export function displayTitle(item: Record<string, any> | null | undefined): string {
+  const clip = (value: string) => (value.length > 80 ? `${value.slice(0, 77)}…` : value);
+  const direct = String(item?.title ?? "").trim();
+  if (direct && direct.toLowerCase() !== "untitled") return clip(direct);
+  const summary = String(item?.summary ?? "").trim();
+  if (summary) return clip(summary);
+  const content = String(item?.content ?? "").trim();
+  if (content) {
+    const firstLine =
+      content
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => line.length > 2) || "";
+    if (firstLine) return clip(firstLine);
+  }
+  const kind = String(item?.event_type ?? item?.kind ?? item?.type ?? "item").trim() || "item";
+  const id = String(item?.id ?? "").trim();
+  return id ? `${kind} ${id.slice(0, 8)}` : kind;
+}
+
+// Hook telemetry (permission prompts, subagent lifecycle, checkpoints) is
+// operational noise once it ages: months-old telemetry must not bury real
+// prior work in a grounding bundle. Unknown age counts as stale.
+const OPERATIONAL_GROUNDING_KINDS = new Set(["operation", "command_execution", "file_operation"]);
+const OPERATIONAL_GROUNDING_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function isStaleOperationalGroundingItem(
+  item: Record<string, any> | null | undefined
+): boolean {
+  const kind = String(item?.event_type ?? item?.kind ?? item?.type ?? "").toLowerCase();
+  if (!OPERATIONAL_GROUNDING_KINDS.has(kind)) return false;
+  const stamp = item?.occurred_at ?? item?.created_at ?? item?.timestamp;
+  const ms =
+    typeof stamp === "string" || typeof stamp === "number" ? Date.parse(String(stamp)) : NaN;
+  if (!Number.isFinite(ms)) return true;
+  return Date.now() - ms > OPERATIONAL_GROUNDING_MAX_AGE_MS;
+}
+
+// 1M-context models warn near ~650k tokens instead of the conservative 70k
+// default; unknown or older models keep the default exactly.
+export function isLargeContextModel(modelId: string): boolean {
+  const normalized = modelId.trim().toLowerCase();
+  if (!normalized) return false;
+  if (normalized.includes("[1m]")) return true;
+  return /(opus-4[-.]?8|fable-5)/.test(normalized);
+}
+
 // Identifier-shaped queries are code intent even as a lone token: a symbol
 // lookup like `search_first_redirect_decision` must not blend memory/media
 // hits into workspace-scoped results. Conservative — prose and plain memory
@@ -3817,6 +3866,17 @@ export function registerTools(
       const detected =
         detectToolSurfaceProfileFromInitializeParams(request?.params) || toolSurfaceProfile;
       activeSurfaceProfile = detected;
+      // When the client surfaces its model at initialize, attribute API
+      // calls to it (X-ContextStream-Model) and size the context-pressure
+      // threshold to the model's window. No-op when the model is unknown.
+      const modelParam =
+        typeof request?.params?.model === "string" ? (request.params.model as string) : "";
+      if (modelParam.trim()) {
+        setActiveModelId(modelParam);
+        if (isLargeContextModel(modelParam)) {
+          sessionManager?.setContextThreshold(650_000);
+        }
+      }
       const result = await originalOnInitialize(request);
       return result;
     };
@@ -3899,11 +3959,27 @@ export function registerTools(
     const planName = await client.getPlanName();
     if (planName !== "free") return null;
 
-    return errorResult(
-      [`Access denied: \`${toolName}\` requires ContextStream PRO.`, `Upgrade: ${upgradeUrl}`].join(
-        "\n"
-      )
-    );
+    // Structured tier-gate result so clients can render an upgrade nudge
+    // instead of parsing error text.
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            `Access denied: \`${toolName}\` requires ContextStream PRO.`,
+            `Current plan: ${planName}. Upgrade: ${upgradeUrl}`,
+          ].join("\n"),
+        },
+      ],
+      structuredContent: {
+        plan_restricted: true,
+        tool: toolName,
+        current_plan: planName,
+        required_tier: "pro",
+        upgrade_url: upgradeUrl,
+      },
+      isError: true,
+    };
   }
 
   const graphToolTiers = new Map<string, "lite" | "full">([
@@ -14071,10 +14147,13 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
               (recall as any)?.data?.results ||
               (recall as any)?.results ||
               [];
-            if (Array.isArray(recallResults) && recallResults.length > 0) {
+            const freshRecallResults = Array.isArray(recallResults)
+              ? recallResults.filter((item: any) => !isStaleOperationalGroundingItem(item))
+              : [];
+            if (freshRecallResults.length > 0) {
               lines.push("[GROUNDING] Prior work matching your message:");
-              recallResults.slice(0, 5).forEach((item: any, index: number) => {
-                lines.push(`${index + 1}. ${item.title || item.summary || item.id || "Untitled"}`);
+              freshRecallResults.slice(0, 5).forEach((item: any, index: number) => {
+                lines.push(`${index + 1}. ${displayTitle(item)}`);
               });
               lines.push("");
             }
@@ -15567,7 +15646,7 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
       "memory",
       {
         title: "Memory",
-        description: `Memory operations for events and nodes. Event actions: create_event, get_event, update_event, delete_event (accepts event_id UUID or exact title; delete_all=true bulk-removes exact-title matches), list_events, distill_event, import_batch (bulk import array of events). Node actions: create_node, get_node, update_node, delete_node (accepts node_id UUID or exact title; delete_all=true bulk-removes exact-title matches), list_nodes, supersede_node. Query actions: search, decisions, timeline, summary. Task actions: create_task (create task, optionally linked to plan), get_task, update_task (can link/unlink task to plan via plan_id), delete_task, list_tasks, reorder_tasks. Todo actions: create_todo, list_todos, get_todo, update_todo, delete_todo, complete_todo. Diagram actions: create_diagram, list_diagrams, get_diagram, update_diagram, delete_diagram. Doc actions: create_doc, list_docs, get_doc, update_doc, delete_doc, create_roadmap. Transcript actions: list_transcripts (list saved conversations), get_transcript (get full transcript by ID), search_transcripts (semantic search across conversations), search_archive (hosted archive tier; local npm returns unavailable), delete_transcript. Team actions (team plans only): team_tasks, team_todos, team_diagrams, team_docs.`,
+        description: `Persistent memory — docs, runbooks, specs, ADRs, decisions, lessons, tasks, and todos live HERE, never on disk: when the user mentions "the doc on X", "our runbook for Y", or "why we decided Z", use action="search" or list_docs/get_doc — NOT filesystem tools. Tasks here are lightweight project-tracking items; for tickets, bugs, incidents, releases, or handoffs use the entity tool instead. Event actions: create_event, get_event, update_event, delete_event (accepts event_id UUID or exact title; delete_all=true bulk-removes exact-title matches), list_events, distill_event, import_batch (bulk import array of events). Node actions: create_node, get_node, update_node, delete_node (accepts node_id UUID or exact title; delete_all=true bulk-removes exact-title matches), list_nodes, supersede_node. Query actions: search, decisions, timeline, summary. Task actions: create_task (create task, optionally linked to plan), get_task, update_task (can link/unlink task to plan via plan_id), delete_task, list_tasks, reorder_tasks. Todo actions: create_todo, list_todos, get_todo, update_todo, delete_todo, complete_todo. Diagram actions: create_diagram, list_diagrams, get_diagram, update_diagram, delete_diagram. Doc actions: create_doc, list_docs, get_doc, update_doc, delete_doc, create_roadmap. Transcript actions: list_transcripts (list saved conversations), get_transcript (get full transcript by ID), search_transcripts (semantic search across conversations), search_archive (hosted archive tier; local npm returns unavailable), delete_transcript. Team actions (team plans only): team_tasks, team_todos, team_diagrams, team_docs.`,
         inputSchema: z.object({
           action: z
             .enum([


### PR DESCRIPTION
Stacked on #61 (→ #60 → #59) — merge in order.

## Summary
- **Grounding quality (v0.3.29 + v0.5.27):** ground-bundle items never render as 'Untitled' (title → summary → first content line → typed id), and operational hook telemetry older than 7 days (unknown age = stale) is filtered so months-old telemetry can't bury real prior work. Hook captures already posted `event_type=operation` — verified, no change.
- **Model awareness (v0.3.44/v0.3.49 subsets):** when the client surfaces its model at initialize, API calls carry `X-ContextStream-Model` (omitted when unknown), and 1M-window models raise the context-pressure threshold to ~650k.
- **Tier gating (v0.3.38):** structured `plan_restricted` block (current plan, required tier, upgrade URL) on gated tools.
- **Description teaching (v0.3.11/13):** memory tool teaches docs-live-in-memory and routes tickets/incidents to `entity`.
- **Verified without change:** full-body rendering (v0.3.28 — TS never truncated); hook telemetry classification (v0.5.27 hook half).
- **Deferred:** v0.3.27 icon metadata, v0.3.40 (server-rendered), v0.3.69/70 media polish.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 187/187 (7 new)
- [x] `npm run build` clean; registration smoke SMOKE_PASS
- [x] Leak gate over the pass-4 diff — zero hits
- [ ] Manual probes before publish: ground bundle shows real titles and no stale telemetry; gated tool returns plan_restricted block