### PR TITLE
Rust MCP parity passes 6-8: deep search, editor surfaces, polish audit (folded into 0.4.80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.4.81
+## 0.4.80 (continued) — parity passes 6–8
 
-**Rust MCP parity passes 6–8 (final): deep search, editor surfaces, polish audit.**
+**Rust MCP parity passes 6–8 (final): deep search, editor surfaces, polish audit.** Folded into the unpublished 0.4.80 release.
 
 ### Deep Search (v0.3.34 + v0.5.10 portable subsets)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.4.81
+
+**Rust MCP parity passes 6–8 (final): deep search, editor surfaces, polish audit.**
+
+### Deep Search (v0.3.34 + v0.5.10 portable subsets)
+
+- **Post-rank token fusion** (semantic/hybrid): results are re-scored by query-token hits in content/path/location plus exact-query and path boosts, so exact matches surface above merely-similar hits; reorders are noted and recorded.
+- **Adaptive retry thresholds:** identifier/symbol queries accept lower-confidence hybrid results before a semantic retry (0.4/0.48), natural-language questions demand more (0.6); semantic displaces hybrid for code-shaped queries only when it wins by a wider margin (0.04).
+- Result lines carry a **confidence band** (high/medium/low) next to the score, and structured output records `fallback_stages` (requested/executed mode, token fusion, server rewrite recovery).
+- **Auto-heal stale index roots:** when a folder has no local index binding but a recorded binding elsewhere shares its exact git remote identity (repo moved/renamed/recloned), both folder-to-project binders adopt that project here and refresh the binding. Name/path-leaf similarity never binds.
+
+### Editor Surfaces (v0.5.25 + v0.5.27 subsets)
+
+- **Cursor rules** now write to `.cursor/rules/contextstream.mdc` with `alwaysApply` frontmatter — Cursor Agent mode does not read `.cursorrules` at all, so managed rules were invisible exactly where they mattered most. Existing `.cursorrules` blocks are left in place for older Cursor versions but are no longer created.
+- **Cursor hook responses** use the current permission schema (`{permission, agent_message, user_message}`) instead of the ignored legacy `{decision, reason}` shape; the Cursor hook installer appends `--editor=cursor` so hook runtimes can tell Cursor apart from Claude Code.
+- **New `contextstream-mcp doctor` command:** read-only diagnostics across auth, API reachability, folder scope binding, local index health (git identity/HEAD drift included), editor rule files, and installed hooks — one ✓/✗ line per check with a next-step hint, and it runs without credentials (diagnosing missing auth is part of the job).
+
+### Verified Without Change / Deferred
+
+- Media list/search summaries (v0.3.69/70): the media tool already renders actionable formatted output for both; only the download-URL enrichment for top items is unported.
+- v0.3.27 per-call display titles and icon metadata: the substantive parts (per-action tools, branded titles) shipped in 0.4.76; transport-level call-title/icon cosmetics depend on MCP client/SDK support and stay deferred.
+- Setup `--yes` zero-prompt path (v0.5.27): the interactive wizard's prompts are call-site-specific; a faithful non-interactive path needs its own pass.
+- Cursor schemas for non-permission hooks (sessionStart `additional_context` casing, `postToolUse` spec): the deny/allow contract — the inert steering channel — is fixed; the remainder is tracked.
+
 ## 0.4.80
 
 **Rust MCP parity pass 5: session-state cluster.**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextstream/mcp-server",
   "mcpName": "io.github.contextstreamio/mcp-server",
-  "version": "0.4.80",
+  "version": "0.4.81",
   "description": "ContextStream MCP server - v0.4.x with consolidated domain tools plus per-action write surfaces (~75% token reduction vs individual tools). Code context, memory, search, Q&A, and AI tools.",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextstream/mcp-server",
   "mcpName": "io.github.contextstreamio/mcp-server",
-  "version": "0.4.81",
+  "version": "0.4.80",
   "description": "ContextStream MCP server - v0.4.x with consolidated domain tools plus per-action write surfaces (~75% token reduction vs individual tools). Code context, memory, search, Q&A, and AI tools.",
   "type": "module",
   "license": "MIT",

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,7 +23,7 @@ import {
 } from "./workspace-config.js";
 import { globalCache, CacheKeys, CacheTTL } from "./cache.js";
 import { markProjectIndexed, clearProjectIndex, readIndexStatus } from "./hooks-config.js";
-import { readGitHead, readGitRemoteIdentity } from "./project-index-utils.js";
+import { readGitHead, readGitRemoteIdentity, findTwinBindingByRemote } from "./project-index-utils.js";
 import { VERSION, getUpdateNotice, getVersionWarning, getVersionInstructions, type VersionNotice } from "./version.js";
 
 const uuidSchema = z.string().uuid();
@@ -2931,6 +2931,24 @@ export class ContextStreamClient {
       const matchLen = resolvedProjectPath.length;
       if (!bestMatch || matchLen > bestMatch.matchLen) {
         bestMatch = { projectId, matchLen };
+      }
+    }
+
+    if (!bestMatch) {
+      // Auto-heal stale index roots: adopt a recorded binding whose git
+      // remote identity matches this folder (repo moved/renamed/recloned).
+      currentRemotePromise ??= readGitRemoteIdentity(resolvedFolder);
+      const currentRemote = await currentRemotePromise;
+      const twin = findTwinBindingByRemote(currentRemote, resolvedFolder, Object.entries(projects));
+      if (twin) {
+        void (async () => {
+          await markProjectIndexed(resolvedFolder, {
+            project_id: twin.projectId,
+            git_remote: currentRemote ?? undefined,
+            git_head: (await readGitHead(resolvedFolder)) ?? undefined,
+          });
+        })().catch(() => {});
+        return twin.projectId;
       }
     }
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,181 @@
+/**
+ * `contextstream-mcp doctor` — read-only diagnostics for every local
+ * surface: auth, API reachability, folder scope binding, local index
+ * health, editor rule files, and installed hooks. Prints ✓/✗ lines with a
+ * next-step hint for each failure.
+ */
+import * as fsSync from "node:fs";
+import * as path from "node:path";
+import { loadConfig } from "./config.js";
+import { ContextStreamClient } from "./client.js";
+import { VERSION } from "./version.js";
+import { resolveWorkspace } from "./workspace-config.js";
+import { readIndexStatus } from "./hooks-config.js";
+import {
+  readGitHead,
+  readGitRemoteIdentity,
+  countDirtyFilesSince,
+} from "./project-index-utils.js";
+import { TEMPLATES } from "./rules-templates.js";
+
+export async function runDoctor(): Promise<void> {
+  const cwd = process.cwd();
+  const lines: string[] = [`ContextStream MCP doctor v${VERSION}`, ""];
+  let failures = 0;
+  const ok = (message: string) => lines.push(`  ✓ ${message}`);
+  const warn = (message: string, hint?: string) => {
+    failures += 1;
+    lines.push(`  ✗ ${message}`);
+    if (hint) lines.push(`    → ${hint}`);
+  };
+
+  // 1. Auth & API reachability. loadConfig throws when no credentials are
+  // present — diagnosing exactly that is this command's job, so continue
+  // with the local checks either way.
+  lines.push("Auth & API");
+  let config: ReturnType<typeof loadConfig> | null = null;
+  try {
+    config = loadConfig();
+  } catch {
+    config = null;
+  }
+  if (!config || (!config.apiKey && !config.jwt)) {
+    warn(
+      "No credentials found (CONTEXTSTREAM_API_KEY / CONTEXTSTREAM_JWT unset).",
+      "Set CONTEXTSTREAM_API_KEY, or run `contextstream-mcp setup`."
+    );
+  } else {
+    ok(`Credentials present (${config.apiKey ? "API key" : "JWT"}).`);
+    try {
+      const client = new ContextStreamClient(config);
+      const plan = await client.getPlanName();
+      ok(`API reachable — plan: ${plan}.`);
+    } catch (error) {
+      warn(
+        `API not reachable: ${error instanceof Error ? error.message : String(error)}`,
+        `Check CONTEXTSTREAM_API_URL (${config.apiUrl}).`
+      );
+    }
+  }
+
+  // 2. Folder scope binding
+  lines.push("", `Folder scope (${cwd})`);
+  const resolved = resolveWorkspace(cwd);
+  if (resolved.config?.workspace_id) {
+    const scopeLabel = `${resolved.config.workspace_name || resolved.config.workspace_id}${
+      resolved.config.project_name ? ` / ${resolved.config.project_name}` : ""
+    }`;
+    ok(`Workspace bound via ${resolved.source}: ${scopeLabel}.`);
+  } else {
+    warn(
+      "No workspace binding for this folder.",
+      'Run init(folder_path="...") from your MCP client, or `contextstream-mcp setup`.'
+    );
+  }
+
+  // 3. Local index health
+  lines.push("", "Local index");
+  const status = await readIndexStatus();
+  const entry = status.projects?.[path.resolve(cwd)];
+  if (!entry) {
+    warn(
+      "No local index record for this folder.",
+      'Search still works via the API; run project(action="ingest_local") to enable local freshness tracking.'
+    );
+  } else {
+    const indexedAtMs = entry.indexed_at ? Date.parse(entry.indexed_at) : NaN;
+    const ageHours = Number.isFinite(indexedAtMs)
+      ? Math.floor((Date.now() - indexedAtMs) / 3_600_000)
+      : null;
+    ok(
+      `Indexed ${ageHours !== null ? `${ageHours}h ago` : "(unknown age)"}${
+        entry.project_id ? ` → project ${entry.project_id}` : ""
+      }.`
+    );
+    if (entry.git_remote) {
+      const currentRemote = await readGitRemoteIdentity(cwd);
+      if (currentRemote && currentRemote !== entry.git_remote) {
+        warn(
+          "Git remote identity differs from the recorded binding.",
+          'This folder will not bind to the recorded project (twin gate). Re-run project(action="ingest_local") here if intentional.'
+        );
+      } else {
+        ok("Git remote identity matches the recorded binding.");
+      }
+    }
+    if (entry.git_head) {
+      const currentHead = await readGitHead(cwd);
+      if (currentHead && currentHead !== entry.git_head) {
+        const dirtyCount = await countDirtyFilesSince(
+          cwd,
+          Number.isFinite(indexedAtMs) ? indexedAtMs : 0
+        );
+        warn(
+          `Git HEAD moved since last ingest${dirtyCount ? ` (+${dirtyCount} dirty file(s))` : ""}.`,
+          "IndexKeeper re-ingests in the background; search output carries [INDEX_HEALTH] until it catches up."
+        );
+      } else {
+        ok("Index HEAD matches the working tree.");
+      }
+    }
+  }
+
+  // 4. Editor rule files
+  lines.push("", "Editor rules");
+  let ruleFilesFound = 0;
+  for (const [editor, template] of Object.entries(TEMPLATES)) {
+    const filePath = path.join(cwd, template.filename);
+    if (!fsSync.existsSync(filePath)) continue;
+    ruleFilesFound += 1;
+    const content = fsSync.readFileSync(filePath, "utf-8");
+    const managed =
+      content.includes("contextstream-rules-hash") || content.includes("<contextstream>");
+    if (managed) {
+      ok(`${editor}: ${template.filename} (managed block present).`);
+    } else {
+      warn(
+        `${editor}: ${template.filename} exists without a managed ContextStream block.`,
+        "Run generate_editor_rules to install/refresh it."
+      );
+    }
+  }
+  if (ruleFilesFound === 0) {
+    warn(
+      "No editor rule files found in this folder.",
+      "Run generate_editor_rules (or `contextstream-mcp setup`)."
+    );
+  }
+
+  // 5. Hooks
+  lines.push("", "Hooks");
+  const hookTargets = [
+    { name: "Claude Code (project)", file: path.join(cwd, ".claude", "settings.json") },
+    { name: "Cursor (project)", file: path.join(cwd, ".cursor", "hooks.json") },
+  ];
+  let hookConfigsFound = 0;
+  for (const target of hookTargets) {
+    if (!fsSync.existsSync(target.file)) continue;
+    const content = fsSync.readFileSync(target.file, "utf-8");
+    if (content.includes("contextstream")) {
+      ok(`${target.name}: ContextStream hooks installed.`);
+      hookConfigsFound += 1;
+    } else {
+      warn(
+        `${target.name}: config present without ContextStream hooks.`,
+        "Re-run `contextstream-mcp setup` to install hooks."
+      );
+    }
+  }
+  if (hookConfigsFound === 0) {
+    lines.push("  – No project-level hook configs found (hooks are optional; setup installs them).");
+  }
+
+  lines.push(
+    "",
+    failures === 0
+      ? "All checks passed."
+      : `${failures} issue(s) found — hints above show the next step for each.`
+  );
+  console.log(lines.join("\n"));
+  if (failures > 0) process.exitCode = 1;
+}

--- a/src/hooks-config.ts
+++ b/src/hooks-config.ts
@@ -2139,21 +2139,24 @@ export async function installCursorHookScripts(options: {
     cleanedHooks[eventName] = filterContextStreamHooks(entries as any[]);
   }
 
-  const preToolUseCommand = getHookCommand("pre-tool-use");
-  const userPromptCommand = getHookCommand("user-prompt-submit");
-  const saveIntentCommand = getHookCommand("on-save-intent");
-  const postToolUseCommand = getHookCommand("post-tool-use");
-  const postToolUseFailureCommand = getHookCommand("post-tool-use-failure");
-  const preCompactCommand = getHookCommand("pre-compact");
-  const sessionStartCommand = getHookCommand("session-start");
-  const sessionEndCommand = getHookCommand("session-end");
-  const stopCommand = getHookCommand("stop");
-  const notificationCommand = getHookCommand("notification");
-  const permissionRequestCommand = getHookCommand("permission-request");
-  const subagentStartCommand = getHookCommand("subagent-start");
-  const subagentStopCommand = getHookCommand("subagent-stop");
-  const taskCompletedCommand = getHookCommand("task-completed");
-  const teammateIdleCommand = getHookCommand("teammate-idle");
+  // Cursor's hook input shape matches Claude Code's, but its response
+  // contract differs — the flag lets hook runtimes emit Cursor-schema output.
+  const cursorHookCommand = (name: string) => `${getHookCommand(name)} --editor=cursor`;
+  const preToolUseCommand = cursorHookCommand("pre-tool-use");
+  const userPromptCommand = cursorHookCommand("user-prompt-submit");
+  const saveIntentCommand = cursorHookCommand("on-save-intent");
+  const postToolUseCommand = cursorHookCommand("post-tool-use");
+  const postToolUseFailureCommand = cursorHookCommand("post-tool-use-failure");
+  const preCompactCommand = cursorHookCommand("pre-compact");
+  const sessionStartCommand = cursorHookCommand("session-start");
+  const sessionEndCommand = cursorHookCommand("session-end");
+  const stopCommand = cursorHookCommand("stop");
+  const notificationCommand = cursorHookCommand("notification");
+  const permissionRequestCommand = cursorHookCommand("permission-request");
+  const subagentStartCommand = cursorHookCommand("subagent-start");
+  const subagentStopCommand = cursorHookCommand("subagent-stop");
+  const taskCompletedCommand = cursorHookCommand("task-completed");
+  const teammateIdleCommand = cursorHookCommand("teammate-idle");
 
   const config: CursorHooksConfig = {
     version: 1,

--- a/src/hooks/pre-tool-use.ts
+++ b/src/hooks/pre-tool-use.ts
@@ -329,12 +329,16 @@ function outputClineAllow(): never {
  * Output for Cursor format (JSON decision based)
  */
 function outputCursorBlock(reason: string): never {
-  console.log(JSON.stringify({ decision: "deny", reason }));
+  // Current Cursor permission schema — the legacy {decision, reason} shape
+  // is silently ignored by Cursor's hook runner.
+  console.log(
+    JSON.stringify({ permission: "deny", agent_message: reason, user_message: reason })
+  );
   process.exit(0);
 }
 
 function outputCursorAllow(): never {
-  console.log(JSON.stringify({ decision: "allow" }));
+  console.log(JSON.stringify({ permission: "allow" }));
   process.exit(0);
 }
 
@@ -364,6 +368,12 @@ function allowTool(
 }
 
 function detectEditorFormat(input: HookInput): "claude" | "cline" | "cursor" {
+  // The Cursor hook installer appends --editor=cursor to the command, since
+  // Cursor's input shape is otherwise indistinguishable from Claude Code's
+  // while its response contract differs.
+  if (process.argv.includes("--editor=cursor")) {
+    return "cursor";
+  }
   // Cline/Roo/Kilo format uses camelCase (hookName, toolName)
   if (input.hookName !== undefined || input.toolName !== undefined) {
     return "cline";

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,11 +65,13 @@ Usage:
   npx --prefer-online -y @contextstream/mcp-server@latest
   contextstream-mcp
   contextstream-mcp setup
+  contextstream-mcp doctor
   contextstream-mcp http
   contextstream-mcp hook <hook-name>
 
 Commands:
   setup                      Interactive onboarding wizard (rules + workspace mapping)
+  doctor                     Read-only diagnostics: auth, API, folder scope, index health, rules, hooks
   verify-key [--json]        Verify API key and show account info
   update-hooks [flags]       Update hooks for all editors (Claude, Cursor, Cline, Roo, Kilo)
     --scope=global           Install hooks globally (default)
@@ -181,6 +183,12 @@ async function main() {
 
   if (args[0] === "setup") {
     await runSetupWizard(args.slice(1));
+    return;
+  }
+
+  if (args[0] === "doctor") {
+    const { runDoctor } = await import("./doctor.js");
+    await runDoctor();
     return;
   }
 

--- a/src/project-index-utils.ts
+++ b/src/project-index-utils.ts
@@ -95,6 +95,31 @@ export async function countDirtyFilesSince(
   }
 }
 
+/**
+ * Auto-heal for stale index roots: when a folder has no index binding but a
+ * recorded binding elsewhere shares its git remote identity (the repo was
+ * moved, renamed, or freshly cloned), that binding's project can be adopted
+ * here. Identity must match exactly; name/path-leaf similarity never binds.
+ */
+export function findTwinBindingByRemote(
+  currentRemote: string | null,
+  resolvedFolder: string,
+  entries: Array<[string, { project_id?: string; git_remote?: string } | undefined]>
+): { path: string; projectId: string } | null {
+  if (!currentRemote) return null;
+  for (const [entryPath, info] of entries) {
+    if (path.resolve(entryPath) === resolvedFolder) continue;
+    if (!info?.git_remote || info.git_remote !== currentRemote) continue;
+    const projectId =
+      typeof info?.project_id === "string" && info.project_id.trim()
+        ? info.project_id.trim()
+        : undefined;
+    if (!projectId) continue;
+    return { path: entryPath, projectId };
+  }
+  return null;
+}
+
 export type IndexFreshness = "fresh" | "recent" | "aging" | "stale" | "missing" | "unknown";
 export type IndexConfidence = "high" | "medium" | "low";
 export type GraphIngestIndexState = "ready" | "indexing" | "stale" | "missing";

--- a/src/rules-templates.ts
+++ b/src/rules-templates.ts
@@ -1233,9 +1233,17 @@ ${rules}
   },
 
   cursor: {
-    filename: ".cursorrules",
-    description: "Cursor AI rules",
-    build: (rules) => `# Cursor Rules
+    // Cursor Agent mode does not read .cursorrules at all; only
+    // .cursor/rules/*.mdc loads in every mode (Chat/Composer/Agent).
+    // Existing .cursorrules blocks are left in place for older Cursor
+    // versions but are no longer created.
+    filename: ".cursor/rules/contextstream.mdc",
+    description: "Cursor AI rules (.cursor/rules MDC — loaded in all Cursor modes)",
+    build: (rules) => `---
+alwaysApply: true
+---
+
+# Cursor Rules
 ${rules}
 `,
   },

--- a/src/search-fusion.test.ts
+++ b/src/search-fusion.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { applyPostRankFusion, scoreConfidenceBand } from "./tools.js";
+import { findTwinBindingByRemote } from "./project-index-utils.js";
+
+describe("applyPostRankFusion", () => {
+  it("promotes an exact-token match above a higher-scored similar hit", () => {
+    const { results, reordered } = applyPostRankFusion(
+      [
+        { file_path: "src/other.ts", content: "something similar", score: 0.7 },
+        { file_path: "src/scope.ts", content: "resolveWriteScope entry", score: 0.62 },
+      ],
+      "resolveWriteScope"
+    );
+    expect(reordered).toBe(true);
+    expect(results[0].file_path).toBe("src/scope.ts");
+  });
+
+  it("is a no-op for short queries and small result sets", () => {
+    const single = applyPostRankFusion([{ score: 0.9 }], "resolveWriteScope");
+    expect(single.reordered).toBe(false);
+    const noTokens = applyPostRankFusion(
+      [{ score: 0.9 }, { score: 0.8 }],
+      "a b"
+    );
+    expect(noTokens.reordered).toBe(false);
+  });
+});
+
+describe("scoreConfidenceBand", () => {
+  it("bands scores and handles unknowns", () => {
+    expect(scoreConfidenceBand(0.9)).toBe("high");
+    expect(scoreConfidenceBand(0.7)).toBe("medium");
+    expect(scoreConfidenceBand(0.2)).toBe("low");
+    expect(scoreConfidenceBand(undefined)).toBe("unknown");
+  });
+});
+
+describe("findTwinBindingByRemote", () => {
+  const entries: Array<[string, { project_id?: string; git_remote?: string }]> = [
+    ["/old/place/repo", { project_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", git_remote: "github.com/org/repo" }],
+    ["/other", { project_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", git_remote: "github.com/org/other" }],
+    ["/no-identity", { project_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc" }],
+  ];
+
+  it("adopts a binding with the same remote identity at a different path", () => {
+    const twin = findTwinBindingByRemote("github.com/org/repo", "/new/place/repo", entries);
+    expect(twin).toMatchObject({ path: "/old/place/repo" });
+  });
+
+  it("never binds without identity or on mismatch", () => {
+    expect(findTwinBindingByRemote(null, "/new", entries)).toBeNull();
+    expect(findTwinBindingByRemote("github.com/org/unrelated", "/new", entries)).toBeNull();
+  });
+
+  it("skips the current folder itself", () => {
+    expect(
+      findTwinBindingByRemote("github.com/org/repo", "/old/place/repo", entries)
+    ).toBeNull();
+  });
+});

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -64,6 +64,7 @@ import {
   readGitHead,
   readGitRemoteIdentity,
   countDirtyFilesSince,
+  findTwinBindingByRemote,
 } from "./project-index-utils.js";
 import { resolveTodoCompletionUpdate } from "./todo-utils.js";
 import { globalHotPathStore } from "./hot-paths.js";
@@ -2825,6 +2826,49 @@ export function isLargeContextModel(modelId: string): boolean {
   return /(opus-4[-.]?8|fable-5)/.test(normalized);
 }
 
+// Post-rank token fusion: boost results whose content/path/location contain
+// query tokens (or the exact normalized query), then stable-sort so exact
+// matches surface above merely-similar ones. Ties fall back to base score,
+// then original order.
+export function applyPostRankFusion(
+  results: Array<Record<string, any>>,
+  query: string
+): { results: Array<Record<string, any>>; reordered: boolean } {
+  if (!Array.isArray(results) || results.length < 2) return { results, reordered: false };
+  const tokens = query
+    .toLowerCase()
+    .split(/[^a-z0-9_$.]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3);
+  if (tokens.length === 0) return { results, reordered: false };
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const rows = results.map((item, idx) => {
+    const base = typeof item?.score === "number" ? item.score : 0;
+    const pathText = String(item?.file_path ?? "").toLowerCase();
+    const haystack = `${String(item?.content ?? "").toLowerCase()} ${pathText} ${String(
+      item?.location ?? ""
+    ).toLowerCase()}`;
+    const tokenHits = tokens.filter((token) => haystack.includes(token)).length;
+    const exactBoost =
+      normalizedQuery.length >= 3 && haystack.includes(normalizedQuery) ? 0.16 : 0;
+    const pathBoost = tokens.some((token) => pathText.includes(token)) ? 0.06 : 0;
+    const fusion = base + Math.min(tokenHits, 3) * 0.08 + exactBoost + pathBoost;
+    return { idx, fusion, base, item };
+  });
+
+  rows.sort((a, b) => b.fusion - a.fusion || b.base - a.base || a.idx - b.idx);
+  const reordered = rows.some((row, newIdx) => row.idx !== newIdx);
+  return { results: rows.map((row) => row.item), reordered };
+}
+
+export function scoreConfidenceBand(score: unknown): "high" | "medium" | "low" | "unknown" {
+  if (typeof score !== "number" || Number.isNaN(score)) return "unknown";
+  if (score >= 0.85) return "high";
+  if (score >= 0.6) return "medium";
+  return "low";
+}
+
 // Identifier-shaped queries are code intent even as a lone token: a symbol
 // lookup like `search_first_redirect_decision` must not blend memory/media
 // hits into workspace-scoped results. Conservative — prose and plain memory
@@ -5182,6 +5226,24 @@ export function registerTools(
   const HYBRID_LOW_CONFIDENCE_SCORE = 0.55;
   const SEMANTIC_SWITCH_MIN_IMPROVEMENT = 0.02;
 
+  // Adaptive retry thresholds, shaped by the query: identifier/symbol
+  // lookups accept lower-confidence hybrid hits before a semantic retry,
+  // while natural-language questions demand more confidence; semantic only
+  // displaces hybrid for code-shaped queries when it wins by a wider margin.
+  function adaptiveHybridRetryThreshold(query: string): number {
+    if (isIdentifierQuery(query)) return 0.4;
+    if (containsCodeIdentifiers(query)) return 0.48;
+    const lower = query.trim().toLowerCase();
+    if (QUESTION_WORDS.some((word) => lower.startsWith(word))) return 0.6;
+    return HYBRID_LOW_CONFIDENCE_SCORE;
+  }
+
+  function adaptiveSemanticSwitchImprovement(query: string): number {
+    return containsCodeIdentifiers(query) || isIdentifierQuery(query)
+      ? 0.04
+      : SEMANTIC_SWITCH_MIN_IMPROVEMENT;
+  }
+
   function isIdentifierQuery(query: string): boolean {
     const trimmed = query.trim();
     if (!trimmed || trimmed.length < 2 || trimmed.includes(" ")) return false;
@@ -5379,17 +5441,21 @@ export function registerTools(
     }
     if (isIdentifierQuery(query)) return false;
     const { results } = extractSearchEnvelope(result);
-    return results.length === 0 || maxResultScore(result) < HYBRID_LOW_CONFIDENCE_SCORE;
+    return results.length === 0 || maxResultScore(result) < adaptiveHybridRetryThreshold(query);
   }
 
-  function shouldPreferSemanticResults(hybridResult: any, semanticResult: any): boolean {
+  function shouldPreferSemanticResults(
+    query: string,
+    hybridResult: any,
+    semanticResult: any
+  ): boolean {
     const hybrid = extractSearchEnvelope(hybridResult);
     const semantic = extractSearchEnvelope(semanticResult);
     if (semantic.results.length === 0) return false;
     if (hybrid.results.length === 0) return true;
     const hybridTop = maxResultScore(hybridResult);
     const semanticTop = maxResultScore(semanticResult);
-    return semanticTop > hybridTop + SEMANTIC_SWITCH_MIN_IMPROVEMENT;
+    return semanticTop > hybridTop + adaptiveSemanticSwitchImprovement(query);
   }
 
   function shouldRetryKeywordWithSemantic(query: string): boolean {
@@ -5628,6 +5694,28 @@ export function registerTools(
       const matchLen = resolvedProjectPath.length;
       if (!bestMatch || matchLen > bestMatch.matchLen) {
         bestMatch = { projectId, matchLen };
+      }
+    }
+
+    if (!bestMatch) {
+      // Auto-heal stale index roots: the folder moved/renamed but its git
+      // remote identity matches a recorded binding — adopt it here.
+      currentRemotePromise ??= readGitRemoteIdentity(resolvedFolder);
+      const currentRemote = await currentRemotePromise;
+      const twin = findTwinBindingByRemote(
+        currentRemote,
+        resolvedFolder,
+        Object.entries(projects)
+      );
+      if (twin) {
+        void (async () => {
+          await markProjectIndexed(resolvedFolder, {
+            project_id: twin.projectId,
+            git_remote: currentRemote ?? undefined,
+            git_head: (await readGitHead(resolvedFolder)) ?? undefined,
+          });
+        })().catch(() => {});
+        return twin.projectId;
       }
     }
 
@@ -12848,7 +12936,7 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
           if (shouldRetrySemanticFallback(input.query, dispatchMode, result)) {
             try {
               const semanticResult = await executeSearchMode("semantic", baseParams);
-              if (shouldPreferSemanticResults(result, semanticResult)) {
+              if (shouldPreferSemanticResults(input.query, result, semanticResult)) {
                 result = semanticResult;
                 executedMode = "semantic";
                 fallbackNote = appendNote(
@@ -13350,6 +13438,24 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
         }
         total = results.length;
 
+        // Post-rank token fusion (semantic/hybrid): exact-token matches
+        // surface above merely-similar hits.
+        let fusionReordered = false;
+        if (
+          (selected.executedMode === "semantic" || selected.executedMode === "hybrid") &&
+          results.length > 1
+        ) {
+          const fusion = applyPostRankFusion(results, input.query);
+          if (fusion.reordered) {
+            fusionReordered = true;
+            results = fusion.results;
+            modeFallbackNote = appendNote(
+              modeFallbackNote,
+              "Reordered results by exact-token fusion."
+            );
+          }
+        }
+
         const resultPaths = results
           .map((item: any) => (typeof item?.file_path === "string" ? item.file_path : ""))
           .filter(Boolean);
@@ -13395,7 +13501,10 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
               ? `${filePath}:${startLine}`
               : r.location || filePath || r.breadcrumb || "";
             const language = r.language || r.metadata?.language || "";
-            const score = r.score ? `${(r.score * 100).toFixed(0)}%` : "";
+            const score =
+              typeof r.score === "number"
+                ? `${(r.score * 100).toFixed(0)}% ${scoreConfidenceBand(r.score)}`
+                : "";
             const langTag = language ? `[${language}]` : "";
             lines.push(`${i + 1}. ${location} ${langTag} ${score}`.trim());
           });
@@ -13495,6 +13604,16 @@ Output formats: full (default, includes content), paths (file paths only - 80% t
             rewritten_queries: rewrittenQueries,
           };
         }
+
+        // Honest record of the stages that produced this result set.
+        (structuredData as any).fallback_stages = [
+          `requested:${requestedMode}`,
+          ...(selected.executedMode !== requestedMode
+            ? [`executed:${selected.executedMode}`]
+            : []),
+          ...(fusionReordered ? ["token_fusion"] : []),
+          ...((structuredData as any).rewrite_recovery ? ["server_rewrite_recovery"] : []),
+        ];
 
         const resultWithMeta = {
           ...(selected.result as any),


### PR DESCRIPTION
Final parity pass before publish — closes out every remaining item from the v0.2.92 → v0.5.27 backlog.

## Summary
- **Deep search (v0.3.34 + v0.5.10 portable subsets):** post-rank token fusion so exact-token matches outrank merely-similar hits; adaptive retry thresholds shaped by query (identifier 0.4 / code-ish 0.48 / NL question 0.6; semantic-switch margin 0.04 for code queries); confidence bands (high/medium/low) on result lines; `fallback_stages` in structured output; auto-heal of stale index roots — a moved/renamed/recloned repo re-binds to its project via exact git-remote identity (never by name/path-leaf).
- **Editor surfaces (v0.5.25 + v0.5.27 subsets):** Cursor rules move to `.cursor/rules/contextstream.mdc` with `alwaysApply` frontmatter (Agent mode never read `.cursorrules`); Cursor hook deny/allow responses use the current `{permission, agent_message, user_message}` schema with an `--editor=cursor` installer flag for detection; new `contextstream-mcp doctor` command — read-only ✓/✗ diagnostics for auth, API, folder scope, index health (git identity/HEAD drift), rules files, and hooks, runnable without credentials.
- **Polish audit:** media list/search summaries verified already-equivalent; v0.3.27 icons/call-titles, setup `--yes`, and the non-permission Cursor hook schemas documented as deferred with reasons.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 197/197 (6 new: fusion, bands, twin finder)
- [x] `npm run build` clean; registration smoke SMOKE_PASS
- [x] `contextstream-mcp doctor` run live in this repo — correct scope/index detection, per-check hints, works without credentials
- [x] Leak gate over the full branch diff — zero hits
- [ ] Before publish: identifier search shows fusion ordering + bands; clone this repo to a second path and confirm auto-heal re-bind; regenerate Cursor rules in a Cursor project and confirm `.cursor/rules/contextstream.mdc`