### PR TITLE
Setup wizard: zero-prompt --yes, background project setup, doctor verification (0.4.81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.4.81
+
+**Setup wizard: zero-prompt `--yes`, background project setup, doctor verification — plus cross-component interop fixes.**
+
+### Setup Wizard
+
+- **`setup --yes` (or `-y`)** runs the entire wizard with zero prompts: every prompt's documented default applies. The outdated-version gate proceeds with a warning instead of exiting; missing credentials fail fast with an actionable message (set `CONTEXTSTREAM_API_KEY` or run setup interactively once); a single listed workspace is auto-selected (multiple → skip); undetected editors are skipped. `--editors=<csv>` pre-answers the editor selection (and force-configures the named editors even when undetected); `--no-doctor` skips final verification.
+- **Project setup never blocks onboarding:** indexing now runs in a detached child process and the wizard returns immediately — search works right away (keyword first, semantic as the index builds), with progress available via `project(action="index_status")` or `contextstream-mcp doctor`. The indexing section is retitled PROJECT SETUP.
+- **The wizard ends with VERIFYING YOUR SETUP:** the `doctor` diagnostics run inline against the just-configured auth, so any misconfiguration surfaces with its next-step hint while you're still in the terminal. Findings are advisory — setup still exits 0.
+- **New `contextstream-mcp index [path]` command** — previously the skip-hint referenced a command that did not exist; it now indexes a folder on demand and is the target of the wizard's background child.
+
+### Cross-Component Interop
+
+- `readSavedCredentials` accepts the legacy `{api_key, saved_at}` credentials shape (no `version`/`api_url`) — a key saved by one ContextStream component now works in all of them.
+- Folder-mapping resolution understands exact-folder entries (`{path, workspace_id, project_id, …}`) written by other components alongside glob patterns, carries their project scope through `resolveWorkspace`, and skips malformed entries instead of crashing.
+- `doctor` recognizes the setup wizard's managed-rules markers.
+
 ## 0.4.80 (continued) — parity passes 6–8
 
 **Rust MCP parity passes 6–8 (final): deep search, editor surfaces, polish audit.** Folded into the unpublished 0.4.80 release.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextstream/mcp-server",
   "mcpName": "io.github.contextstreamio/mcp-server",
-  "version": "0.4.80",
+  "version": "0.4.81",
   "description": "ContextStream MCP server - v0.4.x with consolidated domain tools plus per-action write surfaces (~75% token reduction vs individual tools). Code context, memory, search, Q&A, and AI tools.",
   "type": "module",
   "license": "MIT",

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -35,12 +35,18 @@ export async function readSavedCredentials(): Promise<SavedCredentialsV1 | null>
     const parsed: unknown = JSON.parse(raw);
     if (!isRecord(parsed)) return null;
 
+    // Other ContextStream components write a legacy shape ({api_key, saved_at}
+    // with no version/api_url). Accept it — a key saved without a URL belongs
+    // to the default API — so a key saved by one component works in all.
     const version = parsed.version;
-    if (version !== 1) return null;
+    if (version !== undefined && version !== 1) return null;
 
-    const apiUrl = typeof parsed.api_url === "string" ? normalizeApiUrl(parsed.api_url) : "";
     const apiKey = typeof parsed.api_key === "string" ? parsed.api_key.trim() : "";
-    if (!apiUrl || !apiKey) return null;
+    if (!apiKey) return null;
+    const apiUrl =
+      typeof parsed.api_url === "string" && parsed.api_url.trim()
+        ? normalizeApiUrl(parsed.api_url)
+        : normalizeApiUrl(process.env.CONTEXTSTREAM_API_URL || "https://api.contextstream.io");
 
     const email = typeof parsed.email === "string" ? parsed.email.trim() : "";
     const createdAt = typeof parsed.created_at === "string" ? parsed.created_at : "";

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -129,7 +129,9 @@ export async function runDoctor(): Promise<void> {
     ruleFilesFound += 1;
     const content = fsSync.readFileSync(filePath, "utf-8");
     const managed =
-      content.includes("contextstream-rules-hash") || content.includes("<contextstream>");
+      content.includes("contextstream-rules-hash") ||
+      content.includes("<contextstream>") ||
+      content.includes("<!-- BEGIN ContextStream -->");
     if (managed) {
       ok(`${editor}: ${template.filename} (managed block present).`);
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,14 +64,18 @@ function printHelp() {
 Usage:
   npx --prefer-online -y @contextstream/mcp-server@latest
   contextstream-mcp
-  contextstream-mcp setup
+  contextstream-mcp setup [--yes] [--dry-run] [--editors=claude,cursor] [--no-doctor]
   contextstream-mcp doctor
+  contextstream-mcp index [path]
   contextstream-mcp http
   contextstream-mcp hook <hook-name>
 
 Commands:
-  setup                      Interactive onboarding wizard (rules + workspace mapping)
+  setup                      Onboarding wizard (rules + workspace mapping). --yes runs zero-prompt
+                             with defaults; --editors=<csv> pre-selects editors; --no-doctor skips
+                             the final verification step
   doctor                     Read-only diagnostics: auth, API, folder scope, index health, rules, hooks
+  index [path]               Index a project folder now (the wizard runs this in the background)
   verify-key [--json]        Verify API key and show account info
   update-hooks [flags]       Update hooks for all editors (Claude, Cursor, Cline, Roo, Kilo)
     --scope=global           Install hooks globally (default)
@@ -189,6 +193,12 @@ async function main() {
   if (args[0] === "doctor") {
     const { runDoctor } = await import("./doctor.js");
     await runDoctor();
+    return;
+  }
+
+  if (args[0] === "index") {
+    const { runIndexCommand } = await import("./setup.js");
+    await runIndexCommand(args[1] || process.cwd());
     return;
   }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1194,7 +1194,7 @@ async function selectProjectForCurrentDirectory(
   cwd: string,
   workspaceId: string | undefined,
   dryRun: boolean,
-  rl: ReturnType<typeof createInterface>
+  question: (query: string) => Promise<string>
 ): Promise<ProjectSelection | undefined> {
   if (!workspaceId || workspaceId === "dry-run") {
     return undefined;
@@ -1269,7 +1269,7 @@ async function selectProjectForCurrentDirectory(
   console.log("\nProject selection (current directory):");
   options.forEach((opt, i) => console.log(`  ${i + 1}) ${opt.label}`));
 
-  const choiceRaw = normalizeInput(await rl.question(`Choose [1-${options.length}] (default 1): `));
+  const choiceRaw = normalizeInput(await question(`Choose [1-${options.length}] (default 1): `));
   const choiceNum = Number.parseInt(choiceRaw || "1", 10);
   const selected = Number.isFinite(choiceNum) ? options[choiceNum - 1] : options[0];
 
@@ -1311,6 +1311,20 @@ async function selectProjectForCurrentDirectory(
   }
 
   return undefined;
+}
+
+/**
+ * `contextstream-mcp index <path>` — resolve the project for a folder and
+ * run indexing with progress. Also the target of the wizard's detached
+ * background project-setup child.
+ */
+export async function runIndexCommand(targetPath: string): Promise<void> {
+  const resolvedPath = path.resolve(targetPath);
+  const { loadConfig } = await import("./config.js");
+  const config = loadConfig();
+  const client = new ContextStreamClient(config);
+  const localConfig = readLocalConfig(resolvedPath);
+  await indexProjectWithProgress(client, resolvedPath, localConfig?.workspace_id);
 }
 
 async function indexProjectWithProgress(
@@ -1506,7 +1520,18 @@ async function indexProjectWithProgress(
 
 export async function runSetupWizard(args: string[]): Promise<void> {
   const dryRun = args.includes("--dry-run");
+  const assumeYes = args.includes("--yes") || args.includes("-y");
+  const skipDoctor = args.includes("--no-doctor");
+  const editorsFlag = args
+    .find((arg) => arg.startsWith("--editors="))
+    ?.slice("--editors=".length)
+    .trim();
   const rl = createInterface({ input: stdin, output: stdout });
+  // Zero-prompt mode: every prompt resolves to "" so each call site's
+  // documented default applies; sites where "" is not the right automated
+  // answer special-case assumeYes explicitly.
+  const question = (query: string): Promise<string> =>
+    assumeYes ? Promise.resolve("") : rl.question(query);
 
   const writeActions: Array<{
     kind: "rules" | "workspace-config" | "mcp-config" | "hooks";
@@ -1524,7 +1549,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
     if (!exists) return true;
 
     const answer = normalizeInput(
-      await rl.question(
+      await question(
         `Rules file already exists at ${filePath}. Replace ContextStream block? [y/N/a/s]: `
       )
     ).toLowerCase();
@@ -1557,12 +1582,19 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
       console.log("");
       const continueAnyway = normalizeInput(
-        await rl.question("Continue with current version anyway? [y/N]: ")
+        await question("Continue with current version anyway? [y/N]: ")
       ).toLowerCase();
       if (continueAnyway !== "y" && continueAnyway !== "yes") {
-        console.log("\nExiting. Run the command above to use the latest version.");
-        rl.close();
-        return;
+        if (assumeYes) {
+          // Automation must not dead-end on the version gate.
+          console.log(
+            "\n--yes: continuing with the current version (rerun via @latest when convenient)."
+          );
+        } else {
+          console.log("\nExiting. Run the command above to use the latest version.");
+          rl.close();
+          return;
+        }
       }
       console.log("");
     }
@@ -1572,7 +1604,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       process.env.CONTEXTSTREAM_API_URL || savedCreds?.api_url || "https://api.contextstream.io"
     );
     const apiUrl = normalizeApiUrl(
-      normalizeInput(await rl.question(`ContextStream API URL [${apiUrlDefault}]: `)) ||
+      normalizeInput(await question(`ContextStream API URL [${apiUrlDefault}]: `)) ||
         apiUrlDefault
     );
 
@@ -1583,7 +1615,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
 
     if (apiKey) {
       const confirm = normalizeInput(
-        await rl.question(
+        await question(
           `Use CONTEXTSTREAM_API_KEY from environment (${maskApiKey(apiKey)})? [Y/n]: `
         )
       );
@@ -1595,7 +1627,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
 
     if (!apiKey && savedCreds?.api_key && normalizeApiUrl(savedCreds.api_url) === apiUrl) {
       const confirm = normalizeInput(
-        await rl.question(
+        await question(
           `Use saved API key from ${credentialsFilePath()} (${maskApiKey(savedCreds.api_key)})? [Y/n]: `
         )
       );
@@ -1605,18 +1637,25 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       }
     }
 
+    if (!apiKey && assumeYes) {
+      // Zero-prompt mode cannot mint credentials or drive a browser flow.
+      throw new Error(
+        "--yes needs credentials: set CONTEXTSTREAM_API_KEY (or run `contextstream-mcp setup` interactively once so the wizard can save one)."
+      );
+    }
+
     if (!apiKey) {
       console.log("\nAuthentication:");
       console.log("  1) Browser login (recommended)");
       console.log("  2) Paste an API key");
-      const authChoice = normalizeInput(await rl.question("Choose [1/2] (default 1): ")) || "1";
+      const authChoice = normalizeInput(await question("Choose [1/2] (default 1): ")) || "1";
 
       if (authChoice === "2") {
         console.log("\nYou need a ContextStream API key to continue.");
         console.log(
           "Create one here (then paste it): https://app.contextstream.io/settings/api-keys\n"
         );
-        apiKey = normalizeInput(await rl.question("CONTEXTSTREAM_API_KEY: "));
+        apiKey = normalizeInput(await question("CONTEXTSTREAM_API_KEY: "));
         apiKeySource = "paste";
       } else {
         const anonClient = new ContextStreamClient(buildClientConfig({ apiUrl }));
@@ -1754,6 +1793,42 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       }
     }
 
+    // Project setup must never block onboarding (soft-wait): indexing runs
+    // in a detached child that survives this wizard exiting. Search works
+    // immediately — keyword first, semantic as the index builds.
+    async function startBackgroundIndexing(projectPath: string): Promise<void> {
+      const projectLabel = path.basename(projectPath);
+      try {
+        const { spawn } = await import("node:child_process");
+        const entry = process.argv[1];
+        if (!entry) throw new Error("cannot resolve CLI entry point");
+        const child = spawn(process.execPath, [entry, "index", projectPath], {
+          detached: true,
+          stdio: "ignore",
+          env: {
+            ...process.env,
+            CONTEXTSTREAM_API_URL: apiUrl,
+            ...(apiKey ? { CONTEXTSTREAM_API_KEY: apiKey } : {}),
+          },
+        });
+        child.unref();
+        console.log(`\nProject setup started in the background for '${projectLabel}'.`);
+        console.log(
+          "Search works immediately — keyword results first, semantic as the index builds."
+        );
+        console.log(
+          'Check progress anytime: project(action="index_status") or `contextstream-mcp doctor`.'
+        );
+      } catch (error) {
+        console.log(
+          `\nCould not start background project setup for '${projectLabel}' (${
+            error instanceof Error ? error.message : String(error)
+          }).`
+        );
+        console.log(`Run it manually: contextstream-mcp index ${projectPath}`);
+      }
+    }
+
     // Workspace selection
     let workspaceId: string | undefined;
     let workspaceName: string | undefined;
@@ -1763,16 +1838,16 @@ export async function runSetupWizard(args: string[]): Promise<void> {
     console.log("  1) Create a new workspace");
     console.log("  2) Select an existing workspace");
     console.log("  3) Skip (rules only, no workspace mapping)");
-    const wsChoice = normalizeInput(await rl.question("Choose [1/2/3] (default 2): ")) || "2";
+    const wsChoice = normalizeInput(await question("Choose [1/2/3] (default 2): ")) || "2";
 
     if (wsChoice === "1") {
-      const name = normalizeInput(await rl.question("Workspace name: "));
+      const name = normalizeInput(await question("Workspace name: "));
       if (!name) throw new Error("Workspace name is required.");
-      const description = normalizeInput(await rl.question("Workspace description (optional): "));
+      const description = normalizeInput(await question("Workspace description (optional): "));
       let visibility = "private";
       while (true) {
         const raw =
-          normalizeInput(await rl.question("Visibility [private/team/org] (default private): ")) ||
+          normalizeInput(await question("Visibility [private/team/org] (default private): ")) ||
           "private";
         const normalized = raw.trim().toLowerCase() === "public" ? "org" : raw.trim().toLowerCase();
         if (normalized === "private" || normalized === "team" || normalized === "org") {
@@ -1812,9 +1887,12 @@ export async function runSetupWizard(args: string[]): Promise<void> {
         items.slice(0, 20).forEach((w, i) => {
           console.log(`  ${i + 1}) ${w.name || "Untitled"}${w.id ? ` (${w.id})` : ""}`);
         });
-        const idxRaw = normalizeInput(
-          await rl.question("Select workspace number (or blank to skip): ")
-        );
+        const idxRaw =
+          assumeYes && items.length === 1
+            ? "1"
+            : normalizeInput(
+                await question("Select workspace number (or blank to skip): ")
+              );
         if (idxRaw) {
           const idx = Number.parseInt(idxRaw, 10);
           const selected = Number.isFinite(idx) ? items[idx - 1] : undefined;
@@ -1832,7 +1910,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
         process.cwd(),
         workspaceId,
         dryRun,
-        rl
+        question
       );
       if (selectedCurrentProject) {
         console.log(
@@ -1870,7 +1948,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
     );
     const currentAutoUpdate = isAutoUpdateEnabled();
     const autoUpdateChoice = normalizeInput(
-      await rl.question(`Enable auto-update? [${currentAutoUpdate ? "Y/n" : "y/N"}]: `)
+      await question(`Enable auto-update? [${currentAutoUpdate ? "Y/n" : "y/N"}]: `)
     ).toLowerCase();
     const autoUpdateEnabled =
       autoUpdateChoice === ""
@@ -1898,11 +1976,27 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       "aider",
       "antigravity",
     ];
-    console.log('\nSelect editors to configure (comma-separated numbers, or "all"):');
-    editors.forEach((e, i) => console.log(`  ${i + 1}) ${EDITOR_LABELS[e]}`));
-    const selectedRaw = normalizeInput(await rl.question("Editors [all]: ")) || "all";
-    const selectedNums = parseNumberList(selectedRaw, editors.length);
-    const selectedEditors = selectedNums.length ? selectedNums.map((n) => editors[n - 1]) : editors;
+    let selectedEditors: EditorKey[];
+    if (editorsFlag) {
+      const requested = editorsFlag
+        .split(",")
+        .map((name) => name.trim().toLowerCase())
+        .filter(Boolean);
+      const unknown = requested.filter((name) => !editors.includes(name as EditorKey));
+      if (unknown.length) {
+        throw new Error(
+          `Unknown editor(s) in --editors: ${unknown.join(", ")}. Known: ${editors.join(", ")}`
+        );
+      }
+      selectedEditors = editors.filter((editor) => requested.includes(editor));
+      console.log(`\nEditors (from --editors): ${selectedEditors.join(", ")}`);
+    } else {
+      console.log('\nSelect editors to configure (comma-separated numbers, or "all"):');
+      editors.forEach((e, i) => console.log(`  ${i + 1}) ${EDITOR_LABELS[e]}`));
+      const selectedRaw = normalizeInput(await question("Editors [all]: ")) || "all";
+      const selectedNums = parseNumberList(selectedRaw, editors.length);
+      selectedEditors = selectedNums.length ? selectedNums.map((n) => editors[n - 1]) : editors;
+    }
 
     const editorDetected = new Map<EditorKey, boolean>();
     for (const editor of selectedEditors) {
@@ -1913,13 +2007,15 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       editorDetected.set("codex", true);
     }
     const undetectedEditors = selectedEditors.filter((editor) => !editorDetected.get(editor));
-    let allowUndetectedEditors = false;
-    if (undetectedEditors.length) {
+    // Editors explicitly named via --editors are configured even when not
+    // detected; plain --yes sticks to detected editors only ("" → No below).
+    let allowUndetectedEditors = Boolean(editorsFlag);
+    if (undetectedEditors.length && !editorsFlag) {
       console.log("\nEditors not detected on this system:");
       undetectedEditors.forEach((editor) => console.log(`- ${EDITOR_LABELS[editor]}`));
       console.log('If your editor is installed but not detected, choose "yes" to force config.');
       const confirm = normalizeInput(
-        await rl.question("Configure these anyway? [y/N]: ")
+        await question("Configure these anyway? [y/N]: ")
       ).toLowerCase();
       allowUndetectedEditors = confirm === "y" || confirm === "yes";
     }
@@ -1944,7 +2040,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
     console.log("  1) Global");
     console.log("  2) Project");
     console.log("  3) Both");
-    const scopeChoice = normalizeInput(await rl.question("Choose [1/2/3] (default 2): ")) || "2";
+    const scopeChoice = normalizeInput(await question("Choose [1/2/3] (default 2): ")) || "2";
     const scope: InstallScope =
       scopeChoice === "1" ? "global" : scopeChoice === "2" ? "project" : "both";
 
@@ -1967,7 +2063,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
     const mcpChoiceDefault = hasCodex && !hasProjectMcpEditors ? "1" : "2";
     const mcpChoice =
       normalizeInput(
-        await rl.question(
+        await question(
           `Choose [${hasCodex && !hasProjectMcpEditors ? "1/2" : "1/2/3/4"}] (default ${mcpChoiceDefault}): `
         )
       ) || mcpChoiceDefault;
@@ -1986,7 +2082,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
 
     if (enforceCopilotCanonicalPair) {
       const confirmCopilotPair = normalizeInput(
-        await rl.question(
+        await question(
           "Configure Copilot canonical MCP files (~/.copilot/mcp-config.json + .vscode/mcp.json)? [Y/n]: "
         )
       ).toLowerCase();
@@ -2075,7 +2171,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
             if (desktopPath) {
               const useDesktop =
                 normalizeInput(
-                  await rl.question("Also configure Claude Desktop (GUI app)? [y/N]: ")
+                  await question("Also configure Claude Desktop (GUI app)? [y/N]: ")
                 ).toLowerCase() === "y";
               if (useDesktop) {
                 if (dryRun) {
@@ -2310,7 +2406,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       console.log("\nProject setup...");
 
       const addCwd = normalizeInput(
-        await rl.question(`Add current folder as a project? [Y/n] (${process.cwd()}): `)
+        await question(`Add current folder as a project? [Y/n] (${process.cwd()}): `)
       );
       if (addCwd.toLowerCase() !== "n" && addCwd.toLowerCase() !== "no") {
         projectPaths.add(path.resolve(process.cwd()));
@@ -2320,17 +2416,17 @@ export async function runSetupWizard(args: string[]): Promise<void> {
         console.log("\n  1) Add another project path");
         console.log("  2) Add all projects under a folder");
         console.log("  3) Continue");
-        const choice = normalizeInput(await rl.question("Choose [1/2/3] (default 3): ")) || "3";
+        const choice = normalizeInput(await question("Choose [1/2/3] (default 3): ")) || "3";
         if (choice === "3") break;
 
         if (choice === "1") {
-          const p = normalizeInput(await rl.question("Project folder path: "));
+          const p = normalizeInput(await question("Project folder path: "));
           if (p) projectPaths.add(path.resolve(p));
           continue;
         }
 
         if (choice === "2") {
-          const parent = normalizeInput(await rl.question("Parent folder path: "));
+          const parent = normalizeInput(await question("Parent folder path: "));
           if (!parent) continue;
           const parentAbs = path.resolve(parent);
           const projects = await discoverProjectsUnderFolder(parentAbs);
@@ -2344,7 +2440,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
           projects.slice(0, 25).forEach((p) => console.log(`- ${p}`));
           if (projects.length > 25) console.log(`…and ${projects.length - 25} more`);
 
-          const confirm = normalizeInput(await rl.question("Add these projects? [Y/n]: "));
+          const confirm = normalizeInput(await question("Add these projects? [Y/n]: "));
           if (confirm.toLowerCase() === "n" || confirm.toLowerCase() === "no") continue;
           projects.forEach((p) => projectPaths.add(p));
         }
@@ -2361,7 +2457,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       workspaceId !== "dry-run" &&
       projects.length > 1 &&
       normalizeInput(
-        await rl.question("Also create a parent folder mapping for auto-detection? [y/N]: ")
+        await question("Also create a parent folder mapping for auto-detection? [y/N]: ")
       ).toLowerCase() === "y";
 
     for (const projectPath of projects) {
@@ -2565,7 +2661,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
 
           if (filesIndexed === 0 || isStale) {
             console.log("\n" + "─".repeat(60));
-            console.log("PROJECT INDEXING");
+            console.log("PROJECT SETUP");
             console.log("─".repeat(60));
             if (filesIndexed === 0) {
               console.log(
@@ -2581,7 +2677,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
             console.log("Your code is private and securely stored.\n");
 
             const indexChoice = normalizeInput(
-              await rl.question("Perform indexing now? [Y/n]: ")
+              await question("Perform indexing now? [Y/n]: ")
             ).toLowerCase();
 
             const indexingEnabled = indexChoice !== "n" && indexChoice !== "no";
@@ -2594,10 +2690,10 @@ export async function runSetupWizard(args: string[]): Promise<void> {
             });
 
             if (indexingEnabled) {
-              await indexProjectWithProgress(client, process.cwd(), cwdConfig.workspace_id);
+              await startBackgroundIndexing(process.cwd());
             } else {
               console.log(
-                "\nIndexing skipped for now. You can start it later with: contextstream-mcp index <path>"
+                "\nProject setup skipped for now. Start it later with: contextstream-mcp index <path>"
               );
             }
           }
@@ -2607,7 +2703,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       }
     } else if (projects.length > 0 && !dryRun) {
       console.log("\n" + "─".repeat(60));
-      console.log("PROJECT INDEXING");
+      console.log("PROJECT SETUP");
       console.log("─".repeat(60));
       console.log(
         "Indexing enables semantic code search and AI-powered graph knowledge for rich AI context."
@@ -2619,7 +2715,7 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       console.log("Your code is private and securely stored.\n");
 
       const indexChoice = normalizeInput(
-        await rl.question("Update index for full-featured context now? [Y/n]: ")
+        await question("Update index for full-featured context now? [Y/n]: ")
       ).toLowerCase();
 
       const indexingEnabled = indexChoice !== "n" && indexChoice !== "no";
@@ -2638,11 +2734,11 @@ export async function runSetupWizard(args: string[]): Promise<void> {
 
       if (indexingEnabled) {
         for (const projectPath of projects) {
-          await indexProjectWithProgress(client, projectPath, workspaceId);
+          await startBackgroundIndexing(projectPath);
         }
       } else {
         console.log(
-          "\nIndexing skipped for now. You can start it later with: contextstream-mcp index <path>"
+          "\nProject setup skipped for now. Start it later with: contextstream-mcp index <path>"
         );
       }
     }
@@ -2676,6 +2772,31 @@ export async function runSetupWizard(args: string[]): Promise<void> {
       console.log(
         "- If Rust MCP is installed, replace the command in both files with `contextstream-mcp` and set args to []."
       );
+    }
+
+    if (!dryRun && !skipDoctor) {
+      console.log("\n" + "─".repeat(60));
+      console.log("VERIFYING YOUR SETUP");
+      console.log("─".repeat(60));
+      try {
+        // Verification must see the auth this wizard just configured, even
+        // when the key came from the saved-credentials file or a paste.
+        if (apiKey && !process.env.CONTEXTSTREAM_API_KEY) {
+          process.env.CONTEXTSTREAM_API_KEY = apiKey;
+        }
+        if (!process.env.CONTEXTSTREAM_API_URL) {
+          process.env.CONTEXTSTREAM_API_URL = apiUrl;
+        }
+        const { runDoctor } = await import("./doctor.js");
+        await runDoctor();
+      } catch (error) {
+        console.log(
+          `Verification could not run: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+      // Doctor findings are advisory inside setup — a fresh project's
+      // still-building index must not fail the wizard.
+      process.exitCode = 0;
     }
 
     console.log("");

--- a/src/workspace-config.ts
+++ b/src/workspace-config.ts
@@ -18,9 +18,16 @@ export interface WorkspaceConfig {
 }
 
 export interface ParentMapping {
-  pattern: string; // e.g., "/home/user/dev/projects/*"
+  pattern?: string; // e.g., "/home/user/dev/projects/*"
   workspace_id: string;
-  workspace_name: string;
+  workspace_name?: string;
+  /**
+   * Interop: other ContextStream components write exact-folder entries
+   * ({path, workspace_id, project_id, ...}) instead of glob patterns.
+   */
+  path?: string;
+  project_id?: string;
+  project_name?: string;
 }
 
 export interface FallbackWorkspaceRef {
@@ -178,7 +185,7 @@ export function forgetLocalConfig(repoPath: string): {
   return {
     local_config_removed: removed,
     config_path: configPath,
-    matching_parent_pattern: mapping?.pattern ?? null,
+    matching_parent_pattern: mapping?.pattern ?? mapping?.path ?? null,
   };
 }
 
@@ -201,11 +208,15 @@ export function writeGlobalMappings(mappings: ParentMapping[]): boolean {
  * Add a new parent folder mapping
  */
 export function addGlobalMapping(mapping: ParentMapping): boolean {
+  if (typeof mapping.pattern !== "string" || !mapping.pattern.trim()) return false;
   const normalizedPattern = path.normalize(mapping.pattern);
   const store = readGlobalStore();
   const mappings = store.mappings;
-  // Remove any existing mapping with same pattern
-  const filtered = mappings.filter((m) => path.normalize(m.pattern) !== normalizedPattern);
+  // Remove any existing pattern mapping with the same pattern; leave
+  // exact-folder interop entries (no pattern) untouched.
+  const filtered = mappings.filter(
+    (m) => typeof m.pattern !== "string" || path.normalize(m.pattern) !== normalizedPattern
+  );
   filtered.push({ ...mapping, pattern: normalizedPattern });
   return writeGlobalStore({ ...store, mappings: filtered });
 }
@@ -234,6 +245,20 @@ export function findMatchingMapping(repoPath: string): ParentMapping | null {
   const normalizedRepo = path.normalize(repoPath);
 
   for (const mapping of mappings) {
+    // Interop: exact-folder entries carry `path` (plus project info) rather
+    // than a glob pattern. Match the folder itself or any subfolder.
+    if (typeof mapping.path === "string" && mapping.path.trim()) {
+      const normalizedExact = path.normalize(mapping.path);
+      if (
+        normalizedRepo === normalizedExact ||
+        normalizedRepo.startsWith(normalizedExact + path.sep)
+      ) {
+        return mapping;
+      }
+      continue;
+    }
+
+    if (typeof mapping.pattern !== "string" || !mapping.pattern.trim()) continue;
     const normalizedPattern = path.normalize(mapping.pattern);
 
     // Handle wildcard patterns like "/home/user/dev/projects/*" (or "C:\\dev\\projects\\*")
@@ -265,13 +290,16 @@ export function resolveWorkspace(repoPath: string): {
     return { config: localConfig, source: "local_config" };
   }
 
-  // Step 2: Check parent folder mappings
+  // Step 2: Check parent folder mappings (glob patterns or exact-folder
+  // interop entries, which may also carry project scope)
   const mapping = findMatchingMapping(repoPath);
   if (mapping) {
     return {
       config: {
         workspace_id: mapping.workspace_id,
         workspace_name: mapping.workspace_name,
+        project_id: mapping.project_id,
+        project_name: mapping.project_name,
       },
       source: "parent_mapping",
     };


### PR DESCRIPTION
Makes the npm package's setup wizard match — and in one place beat — the native MCP's wizard, per the approved plan.

## Summary
- **`setup --yes` / `-y`:** the entire wizard runs with zero prompts using each prompt's documented default. Special cases handled explicitly: outdated-version gate proceeds with a warning; missing credentials fail fast with an actionable message; a single listed workspace auto-selects (multiple → skip); undetected editors are skipped unless named. `--editors=<csv>` pre-answers editor selection (and force-configures named editors); `--no-doctor` skips verification.
- **Background project setup (soft-wait):** indexing runs in a detached child via the new `contextstream-mcp index [path]` command (which the help text previously referenced but didn't exist) — the wizard returns immediately with progress pointers. Section retitled PROJECT SETUP.
- **Doctor as the final wizard step** (the better-than-native part): VERIFYING YOUR SETUP runs the doctor diagnostics inline against the just-configured auth; findings are advisory (setup exits 0).
- **Interop fixes found by live testing:** the wizard/doctor now read credentials (`{api_key, saved_at}` legacy shape) and exact-folder mappings (`{path, workspace_id, project_id, …}`) written by other ContextStream components — previously the key was silently unusable and malformed-shape mappings crashed `resolveWorkspace`; doctor recognizes the wizard's managed-rules markers.

## Test plan
- [x] `npm run typecheck` / `npm test` (197/197) / `npm run build` clean; registration smoke SMOKE_PASS
- [x] `setup --yes --dry-run` with stdin closed: full flow, zero prompts, 18 dry-run writes
- [x] `setup --yes --dry-run --editors=claude,cursor`: selection honored; `--editors=foo` errors listing known editors
- [x] Credential-less `--yes` (isolated HOME): fails fast with the actionable one-liner
- [x] Live `setup --yes` in a scratch folder: zero prompts, PROJECT SETUP returns immediately with background message, VERIFYING YOUR SETUP shows accurate results (auth ✓ team plan, 10/10 managed rule files ✓), exit 0
- [x] `doctor` in a fresh folder no longer crashes on interop mapping entries
- [x] Leak gate over the diff — zero hits; all commits escott-, no trailers