### PR TITLE
docs: open README with the manifesto epigraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 <h1 align="center">ContextStream MCP Server</h1>
 
 <p align="center">
+  <em>Intelligence without context is unreliable. Autonomy without context is chaos.<br/>
+  And context without trust becomes surveillance.</em>
+</p>
+
+<p align="center">
   <strong>Give every coding agent persistent memory, semantic code search, and the right project context on every turn.</strong>
 </p>
 


### PR DESCRIPTION
Adds the manifesto triad directly under the title:

> Intelligence without context is unreliable. Autonomy without context is chaos. And context without trust becomes surveillance.

Rendered as a centered italic epigraph in the README's existing HTML style, placed after the `mcp-name` registry comment and logo so the registry identifier stays on line 1.