### PR TITLE
feat(answer): expose receipts and feedback

### DIFF
--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -3,6 +3,9 @@
 use chrono::Utc;
 use mcp_types::{
     agentic::{ComplianceEventRecorded, ComplianceEventRequest},
+    answer::{
+        AnswerFeedbackRequestV1, AnswerFeedbackResponseV1, AnswerRequestV1, AnswerResponseV1,
+    },
     api::*,
     AccountContextSnapshot, AccountContextSource, AuthOverride, Config, ConfigOverride, Error,
     ErrorCode, Result, SessionKey, TeamDiscussion, TeamPriorityItem, TrafficClass,
@@ -2502,6 +2505,23 @@ impl ContextStreamClient {
         self.request("GET", path, None::<()>, None).await
     }
 
+    /// Make exactly one GET request with no network/status retry and no
+    /// session-refresh replay. Receipt recovery must expose current authority
+    /// and availability rather than hiding either behind client behavior.
+    pub async fn get_once<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        self.request_with_replay(
+            "GET",
+            path,
+            None::<()>,
+            Some(RequestOptions {
+                retries: Some(0),
+                ..RequestOptions::default()
+            }),
+            false,
+        )
+        .await
+    }
+
     /// Make a GET request and return the raw response body as text.
     pub async fn get_text(&self, path: &str, accept: Option<&str>) -> Result<String> {
         self.request_text("GET", path, None::<()>, None, accept)
@@ -2522,6 +2542,26 @@ impl ContextStreamClient {
     /// Make a POST request.
     pub async fn post<T: DeserializeOwned, B: Serialize>(&self, path: &str, body: B) -> Result<T> {
         self.request("POST", path, Some(body), None).await
+    }
+
+    /// Make exactly one POST request with no network/status retry and no
+    /// session-refresh replay. Use this for one-use execution authorities.
+    pub async fn post_once<T: DeserializeOwned, B: Serialize>(
+        &self,
+        path: &str,
+        body: B,
+    ) -> Result<T> {
+        self.request_with_replay(
+            "POST",
+            path,
+            Some(body),
+            Some(RequestOptions {
+                retries: Some(0),
+                ..RequestOptions::default()
+            }),
+            false,
+        )
+        .await
     }
 
     /// Make a POST request with options.
@@ -2939,6 +2979,18 @@ impl ContextStreamClient {
         body: Option<B>,
         options: Option<RequestOptions>,
     ) -> Result<T> {
+        self.request_with_replay(method, path, body, options, true)
+            .await
+    }
+
+    async fn request_with_replay<T: DeserializeOwned, B: Serialize>(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<B>,
+        options: Option<RequestOptions>,
+        allow_auth_refresh_replay: bool,
+    ) -> Result<T> {
         let options = options.unwrap_or_default();
         let config = self.config().await;
 
@@ -3105,7 +3157,7 @@ impl ContextStreamClient {
             // A session refresh is an authentication repair, not a generic
             // endpoint retry. Preserve exactly one immediate replay even when
             // callers set `retries: 0` to suppress terminal 5xx/backoff.
-            if status.as_u16() == 403 && !auth_refresh_replayed {
+            if allow_auth_refresh_replay && status.as_u16() == 403 && !auth_refresh_replayed {
                 auth_refresh_replayed = true;
                 let hook = self.session_refresh_hook.read().await.clone();
                 if let Some(hook) = hook {
@@ -14691,6 +14743,7 @@ impl ContextStreamClient {
             serde_json::json!({"name":"init","category":"session","description":"Initialize session scope and return project context.","key_parameters":["folder_path","workspace_id","project_id","session_id"],"example":"init(folder_path=\"/path/to/project\", session_id=\"session-123\")"}),
             serde_json::json!({"name":"context","category":"session","description":"Get task-specific rules, lessons, preferences, and relevant prior work.","key_parameters":["user_message","session_id","mode","save_exchange"],"example":"context(user_message=\"fix the login regression\", session_id=\"session-123\")"}),
             serde_json::json!({"name":"search","category":"search","description":"Search indexed source code with keyword, semantic, pattern, refactor, and exhaustive modes.","key_parameters":["query","mode","project_id","workspace_id","include_content"],"example":"search(query=\"AuthService\", mode=\"refactor\", output_format=\"paths\")"}),
+            serde_json::json!({"name":"answer","category":"ai","description":"Ask a natural-language question across authorized ContextStream knowledge with current-truth, evidence, freshness, and coverage metadata.","actions":["query","recent_changes"],"key_parameters":["action","question","workspace_ids","project_ids","visibility","timezone"],"example":"answer(action=\"recent_changes\", question=\"What changed recently?\")"}),
             serde_json::json!({"name":"instruct","category":"session","description":"Read and acknowledge session-scoped injected instructions.","actions":["get","ack"],"key_parameters":["action","session_id","ids"],"example":"instruct(action=\"get\", session_id=\"session-123\")"}),
             serde_json::json!({"name":"session","category":"session","description":"Ground, capture, recall, and restore durable session context; manage lessons and plans; access Daily Recaps.","actions":["capture","retro_capture","capture_lesson","get_lessons","update_lesson","delete_lesson","recall","ground","set_account_mode","remember","user_context","summary","compress","delta","smart_search","decision_trace","restore_context","capture_plan","get_plan","update_plan","list_plans","list_recaps","trigger_recap","list_suggested_rules","suggested_rule_action","suggested_rules_stats"],"key_parameters":["action","workspace_id","project_id","session_id"],"example":"session(action=\"ground\", user_message=\"continue the refactor\")"}),
             serde_json::json!({"name":"memory","category":"memory","description":"Manage durable nodes, events, tasks, todos, docs, diagrams, and transcripts.","key_parameters":["action","workspace_id","project_id"],"example":"memory(action=\"list_docs\", doc_type=\"runbook\")"}),
@@ -14819,6 +14872,49 @@ impl ContextStreamClient {
     // project knowledge, answered by ContextCode (the upstream model
     // identifier is private to the API server's branding firewall).
     // ========================================================================
+
+    /// `POST /api/v1/answers` — execute one public natural-language Answer
+    /// request. This deliberately bypasses every client retry and auth-refresh
+    /// replay because the server binds execution to one-use durable authority.
+    pub async fn answer_query(&self, request: AnswerRequestV1) -> Result<AnswerResponseV1> {
+        self.post_once("/answers", request).await
+    }
+
+    /// `GET /api/v1/answers/receipts/:request_id` — recover one durable
+    /// terminal Answer without replaying the original execution.
+    pub async fn answer_receipt(&self, request_id: Uuid) -> Result<AnswerResponseV1> {
+        let response: AnswerResponseV1 = self
+            .get_once(&format!("/answers/receipts/{request_id}"))
+            .await?;
+        if response.request_id() != request_id {
+            return Err(Error::Validation(
+                "Answer receipt request_id does not match the request".to_owned(),
+            ));
+        }
+        Ok(response)
+    }
+
+    /// `POST /api/v1/answers/feedback` — record one client-idempotent,
+    /// receipt-bound signal. This is one-shot even though an explicit caller
+    /// retry with the same feedback ID is safe at the server.
+    pub async fn answer_feedback(
+        &self,
+        request: AnswerFeedbackRequestV1,
+    ) -> Result<AnswerFeedbackResponseV1> {
+        let expected = request.clone();
+        let response: AnswerFeedbackResponseV1 =
+            self.post_once("/answers/feedback", request).await?;
+        if response.feedback_id != expected.feedback_id
+            || response.request_id != expected.request_id
+            || response.target != expected.target
+            || response.signal != expected.signal
+        {
+            return Err(Error::Validation(
+                "Answer feedback acknowledgement does not match the request".to_owned(),
+            ));
+        }
+        Ok(response)
+    }
 
     /// `POST /v1/qa_agent/ask` — full retrieve-and-call flow. Persists
     /// question + answer, returns the answer text + citations + token
@@ -19964,6 +20060,311 @@ mod tests {
         (ContextStreamClient::new(config), server)
     }
 
+    fn answer_clarification_response() -> serde_json::Value {
+        serde_json::json!({
+            "status": "clarification_required",
+            "schema_version": "answer.v1",
+            "request_id": Uuid::from_u128(1),
+            "application_id": null,
+            "clarification": {
+                "clarification_id": Uuid::from_u128(2),
+                "kind": "scope_required",
+                "prompt": "Which workspace?",
+                "candidate_scopes": [],
+                "created_at": "2026-09-02T00:00:00Z"
+            }
+        })
+    }
+
+    fn answer_feedback_request() -> AnswerFeedbackRequestV1 {
+        AnswerFeedbackRequestV1 {
+            schema_version: mcp_types::AnswerFeedbackSchemaVersionV1::V1,
+            feedback_id: Uuid::from_u128(51),
+            request_id: Uuid::from_u128(1),
+            target: mcp_types::AnswerFeedbackTargetV1::Answer {},
+            signal: mcp_types::AnswerFeedbackSignalV1::Relevant,
+        }
+    }
+
+    fn answer_feedback_response(request: &AnswerFeedbackRequestV1) -> serde_json::Value {
+        serde_json::json!({
+            "schema_version": "answer.feedback.v1",
+            "feedback_id": request.feedback_id,
+            "request_id": request.request_id,
+            "target": { "target": "answer" },
+            "signal": "relevant",
+            "status": "accepted",
+            "effect": "recorded_only",
+            "recorded_at": "2026-09-02T00:01:00Z"
+        })
+    }
+
+    #[tokio::test]
+    async fn answer_query_posts_once_with_authority_free_wire_contract() {
+        let (client, server) = client_with_http_sequence(vec![(
+            "200 OK",
+            serde_json::json!({
+                "success": true,
+                "data": answer_clarification_response(),
+                "metadata": {
+                    "request_id": "request-envelope-id",
+                    "timestamp": "2026-09-02T00:00:00Z",
+                    "duration_ms": 4,
+                    "version": "v1"
+                }
+            })
+            .to_string(),
+        )])
+        .await;
+        let request =
+            AnswerRequestV1::coflow_recent_changes(None, "America/Los_Angeles", None, None, None);
+
+        let response = client.answer_query(request).await.expect("answer response");
+
+        assert!(matches!(
+            response,
+            AnswerResponseV1::ClarificationRequired { request_id, .. }
+                if request_id == Uuid::from_u128(1)
+        ));
+        let requests = server.await.expect("answer server task");
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].starts_with("POST /api/v1/answers "));
+        let body = requests[0]
+            .split_once("\r\n\r\n")
+            .map(|(_, body)| body)
+            .expect("answer request body");
+        let wire: serde_json::Value = serde_json::from_str(body).expect("answer request JSON");
+        assert_eq!(wire["question"], "What changed recently?");
+        assert_eq!(wire["scope_mode"], "auto");
+        assert_eq!(wire["requested_scope"]["visibility"], "account");
+        assert_eq!(
+            wire["requested_scope"]["workspace_ids"],
+            serde_json::json!([])
+        );
+        assert_eq!(
+            wire["requested_scope"]["project_ids"],
+            serde_json::json!([])
+        );
+        for forbidden in [
+            "actor",
+            "application_id",
+            "authorization",
+            "effective_scopes",
+            "tenant_route",
+            "model",
+        ] {
+            assert!(
+                wire.get(forbidden).is_none(),
+                "forbidden field: {forbidden}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn answer_query_does_not_retry_retryable_http_statuses() {
+        let (client, server) = client_with_http_sequence(vec![(
+            "503 Service Unavailable",
+            serde_json::json!({
+                "error": {"code": "unavailable", "message": "answer unavailable"}
+            })
+            .to_string(),
+        )])
+        .await;
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(750),
+            client.answer_query(AnswerRequestV1::coflow_recent_changes(
+                None, "UTC", None, None, None,
+            )),
+        )
+        .await
+        .expect("one-shot Answer request must not enter retry backoff");
+
+        assert!(matches!(result, Err(Error::Http { status: 503, .. })));
+        let requests = server.await.expect("answer server task");
+        assert_eq!(
+            requests.len(),
+            1,
+            "Answer must make exactly one API attempt"
+        );
+    }
+
+    #[tokio::test]
+    async fn answer_query_does_not_retry_transport_failures() {
+        let (client, shutdown, server) = client_with_counted_http_behavior(None).await;
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(750),
+            client.answer_query(AnswerRequestV1::coflow_recent_changes(
+                None, "UTC", None, None, None,
+            )),
+        )
+        .await
+        .expect("one-shot Answer transport failure must not enter retry backoff");
+
+        assert!(
+            matches!(&result, Err(Error::Network(_))),
+            "the connection close must return a transport error, got {result:?}"
+        );
+        shutdown
+            .send(())
+            .expect("counted HTTP server must still be running");
+        let requests = server.await.expect("counted HTTP server task");
+        assert_eq!(
+            requests.len(),
+            1,
+            "Answer must make exactly one API attempt after a transport failure"
+        );
+        assert!(requests[0].starts_with("POST /api/v1/answers "));
+    }
+
+    #[tokio::test]
+    async fn answer_query_does_not_replay_after_session_refresh() {
+        let (client, server) = client_with_http_sequence(vec![(
+            "403 Forbidden",
+            serde_json::json!({
+                "error": {"code": "forbidden", "message": "authority rejected"}
+            })
+            .to_string(),
+        )])
+        .await;
+        let refreshes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let refreshes_for_hook = Arc::clone(&refreshes);
+        client
+            .set_session_refresh_hook(Arc::new(move || {
+                let refreshes = Arc::clone(&refreshes_for_hook);
+                Box::pin(async move {
+                    refreshes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    true
+                })
+            }))
+            .await;
+
+        let result = client
+            .answer_query(AnswerRequestV1::coflow_recent_changes(
+                None, "UTC", None, None, None,
+            ))
+            .await;
+
+        assert!(matches!(result, Err(Error::Http { status: 403, .. })));
+        assert_eq!(refreshes.load(std::sync::atomic::Ordering::SeqCst), 0);
+        let requests = server.await.expect("answer server task");
+        assert_eq!(requests.len(), 1, "Answer must not replay after a 403");
+    }
+
+    #[tokio::test]
+    async fn answer_receipt_gets_once_and_validates_request_identity() {
+        let request_id = Uuid::from_u128(1);
+        let (client, server) = client_with_http_sequence(vec![(
+            "200 OK",
+            serde_json::json!({
+                "success": true,
+                "data": answer_clarification_response(),
+                "metadata": {
+                    "request_id": "receipt-envelope-id",
+                    "timestamp": "2026-09-02T00:00:00Z",
+                    "duration_ms": 2,
+                    "version": "v1"
+                }
+            })
+            .to_string(),
+        )])
+        .await;
+
+        let response = client
+            .answer_receipt(request_id)
+            .await
+            .expect("Answer receipt");
+        assert_eq!(response.request_id(), request_id);
+        let requests = server.await.expect("receipt server task");
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].starts_with(&format!("GET /api/v1/answers/receipts/{request_id} ")));
+    }
+
+    #[tokio::test]
+    async fn answer_receipt_does_not_retry_retryable_http_statuses() {
+        let (client, server) = client_with_http_sequence(vec![(
+            "503 Service Unavailable",
+            serde_json::json!({
+                "error": {"code": "unavailable", "message": "receipt unavailable"}
+            })
+            .to_string(),
+        )])
+        .await;
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(750),
+            client.answer_receipt(Uuid::from_u128(1)),
+        )
+        .await
+        .expect("one-shot receipt must not enter retry backoff");
+
+        assert!(matches!(result, Err(Error::Http { status: 503, .. })));
+        let requests = server.await.expect("receipt server task");
+        assert_eq!(requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn answer_feedback_posts_once_and_validates_the_acknowledgement() {
+        let request = answer_feedback_request();
+        let (client, server) = client_with_http_sequence(vec![(
+            "200 OK",
+            serde_json::json!({
+                "success": true,
+                "data": answer_feedback_response(&request),
+                "metadata": {
+                    "request_id": "feedback-envelope-id",
+                    "timestamp": "2026-09-02T00:01:00Z",
+                    "duration_ms": 3,
+                    "version": "v1"
+                }
+            })
+            .to_string(),
+        )])
+        .await;
+
+        let response = client
+            .answer_feedback(request.clone())
+            .await
+            .expect("Answer feedback");
+        assert_eq!(response.feedback_id, request.feedback_id);
+        assert_eq!(response.request_id, request.request_id);
+        assert_eq!(
+            response.effect,
+            mcp_types::AnswerFeedbackEffectV1::RecordedOnly
+        );
+        let requests = server.await.expect("feedback server task");
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].starts_with("POST /api/v1/answers/feedback "));
+    }
+
+    #[tokio::test]
+    async fn answer_feedback_does_not_retry_or_accept_identity_drift() {
+        let request = answer_feedback_request();
+        let mut drifted = answer_feedback_response(&request);
+        drifted["feedback_id"] = serde_json::json!(Uuid::from_u128(99));
+        let (client, server) = client_with_http_sequence(vec![(
+            "200 OK",
+            serde_json::json!({
+                "success": true,
+                "data": drifted,
+                "metadata": {
+                    "request_id": "feedback-envelope-id",
+                    "timestamp": "2026-09-02T00:01:00Z",
+                    "duration_ms": 3,
+                    "version": "v1"
+                }
+            })
+            .to_string(),
+        )])
+        .await;
+
+        let result = client.answer_feedback(request).await;
+        assert!(matches!(result, Err(Error::Validation(_))));
+        let requests = server.await.expect("feedback drift server task");
+        assert_eq!(requests.len(), 1);
+    }
+
     #[tokio::test]
     async fn flash_get_forwards_same_instruction_session_project_switch() {
         let (client, server) = client_with_http_sequence(vec![
@@ -23552,12 +23953,12 @@ mod tests {
             })
             .unwrap_or_default();
 
-        // Canonical catalog: 22 tools (coordination added in v0.5.93, feed
-        // added with Context Feeds).
+        // Canonical catalog: 23 tools (including Context Feeds and Answer).
         // Aliases atlas_chart / atlas_job remain accepted at call-time for
         // back-compat but are intentionally absent. The dropped `ram` alias
         // must NOT reappear.
-        assert_eq!(names.len(), 22);
+        assert_eq!(names.len(), 23);
+        assert!(names.contains(&"answer"));
         assert!(names.contains(&"instruct"));
         assert!(names.contains(&"skill"));
         assert!(names.contains(&"capsule"));

--- a/crates/mcp-client/src/lib.rs
+++ b/crates/mcp-client/src/lib.rs
@@ -189,6 +189,13 @@ pub use ingest_guard::{
     IngestRootRejection, IngestRootRejectionReason, ALLOW_BROAD_INGEST_ENV, SENSITIVE_DIR_NAMES,
 };
 pub use mcp_types::agentic::{ComplianceEventRecorded, ComplianceEventRequest};
+pub use mcp_types::answer::{
+    AnswerContextScopeV1, AnswerFeedbackEffectV1, AnswerFeedbackRequestV1,
+    AnswerFeedbackResponseV1, AnswerFeedbackSchemaVersionV1, AnswerFeedbackSignalV1,
+    AnswerFeedbackStatusV1, AnswerFeedbackTargetV1, AnswerLatencyBudgetRequestV1,
+    AnswerPlanClientContextV1, AnswerRequestV1, AnswerResponseBudgetRequestV1,
+    AnswerResponseModeV1, AnswerResponseV1, AnswerScopeModeV1, AnswerVisibilityV1,
+};
 pub use parity::{
     normalize_decisions_envelope, CreateDecisionParams, CreateLessonParams, DecisionActionParams,
     ListDecisionsParams, ListLessonsParams, UpdateLessonParams, DECISION_ACTIONS,

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -78,6 +78,7 @@ pub fn build_registry(
         session.clone(),
         index_keeper,
     );
+    domains::answer::register_answer_tools(&mut registry, client.clone());
     domains::memory::register_memory_tools(&mut registry, client.clone(), session.clone());
     domains::graph::register_graph_tools(&mut registry, client.clone(), session.clone());
     domains::workspace::register_workspace_tools(&mut registry, client.clone());
@@ -2336,6 +2337,7 @@ mod tests {
     }
 
     const V0_5_62_BROAD_TOOL_NAMES: &[&str] = &[
+        "answer",
         "capsule",
         "capture_plan",
         "context",
@@ -2377,6 +2379,7 @@ mod tests {
     const V0_5_62_ROUTER_TOOL_NAMES: &[&str] = &["execute_operation", "operations"];
 
     const V0_5_62_OPENAI_AGENTIC_TOOL_NAMES: &[&str] = &[
+        "answer",
         "batch_operations",
         "capsule",
         "context",
@@ -2401,6 +2404,10 @@ mod tests {
     // baseline; entries intentionally advance when an additive, versioned
     // input capability is added.
     const EXPECTED_BROAD_SCHEMA_CONTRACTS: &[(&str, &str)] = &[
+        (
+            "answer",
+            "47f91fa2cab8d8769f4940a23a714965f3abfbe9abf032237adb1b2fdec43f6a",
+        ),
         (
             "capsule",
             "c680655059bf1f41e916674fe9610f1e6947f7fdda1a833ac9624770eb6b015a",

--- a/crates/mcp-tools/src/domains/answer.rs
+++ b/crates/mcp-tools/src/domains/answer.rs
@@ -1,0 +1,825 @@
+//! Natural-language Answer API MCP surface.
+//!
+//! The tool accepts only public, untrusted request hints. Effective identity,
+//! scope, application grants, source selection, provider/model routing, and
+//! one-use execution authority are resolved by the ContextStream API.
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use async_trait::async_trait;
+use mcp_client::{
+    AnswerContextScopeV1, AnswerFeedbackRequestV1, AnswerFeedbackResponseV1,
+    AnswerFeedbackSchemaVersionV1, AnswerFeedbackSignalV1, AnswerFeedbackTargetV1,
+    AnswerLatencyBudgetRequestV1, AnswerPlanClientContextV1, AnswerRequestV1,
+    AnswerResponseBudgetRequestV1, AnswerResponseModeV1, AnswerResponseV1, AnswerScopeModeV1,
+    AnswerVisibilityV1, ContextStreamClient,
+};
+use mcp_types::{
+    tool::{ToolAnnotations, ToolCategory, ToolMetadata, ToolResult},
+    Error, Result,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::{registry::ToolHandler, schema::SchemaBuilder};
+
+const VALID_ACTIONS: &[&str] = &["query", "recent_changes", "receipt", "feedback"];
+const VALID_SCOPE_MODES: &[&str] = &["auto", "explicit"];
+const VALID_VISIBILITIES: &[&str] = &["personal", "project", "workspace", "account"];
+const VALID_RESPONSE_MODES: &[&str] = &["concise", "detailed", "structured"];
+const VALID_FEEDBACK_SIGNALS: &[&str] = &[
+    "relevant",
+    "useful_but_not_now",
+    "wrong_project",
+    "superseded",
+    "never_for_topic",
+    "promote_to_universal_rule",
+];
+
+const TOOL_DESCRIPTION: &str = "Ask ContextStream a natural-language question across the user's authorized context and receive one current, evidence-backed answer. Use receipt to recover an already-executed request without replay, and feedback to record an explicit receipt-bound signal; feedback acknowledgement means recorded_only. Use search instead for exact code/file discovery. Requested logical scope never grants authority: ContextStream resolves fresh effective authority server-side. Every Answer API request is sent exactly once with no transparent retry or replay.";
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerInput {
+    pub action: Option<String>,
+    pub question: Option<String>,
+    pub scope_mode: Option<String>,
+    pub account_id: Option<String>,
+    pub workspace_ids: Option<Vec<String>>,
+    pub project_ids: Option<Vec<String>>,
+    pub visibility: Option<String>,
+    pub timezone: Option<String>,
+    pub current_workspace_id: Option<String>,
+    pub current_project_id: Option<String>,
+    pub response_mode: Option<String>,
+    pub response_budget: Option<AnswerResponseBudgetInput>,
+    pub latency_budget: Option<AnswerLatencyBudgetInput>,
+    pub request_id: Option<String>,
+    pub feedback_id: Option<String>,
+    pub target: Option<AnswerFeedbackTargetInput>,
+    pub signal: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "target", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AnswerFeedbackTargetInput {
+    Answer {},
+    Item { item_id: String },
+    Citation { citation_id: String },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerResponseBudgetInput {
+    pub max_items: u32,
+    pub max_citations: u32,
+    pub max_output_tokens: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerLatencyBudgetInput {
+    pub total_ms: u32,
+    pub retrieval_ms: u32,
+    pub synthesis_ms: u32,
+    pub authority_reserve_ms: u32,
+}
+
+pub struct AnswerTool {
+    client: ContextStreamClient,
+}
+
+impl AnswerTool {
+    pub fn new(client: ContextStreamClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl ToolHandler for AnswerTool {
+    async fn execute(&self, input: Value) -> Result<ToolResult> {
+        let input: AnswerInput =
+            serde_json::from_value(input).map_err(|error| Error::Validation(error.to_string()))?;
+        match normalized_action(&input)?.as_str() {
+            "receipt" => {
+                let request_id = build_receipt_request_id(&input)?;
+                let response = self.client.answer_receipt(request_id).await?;
+                let text = format_response(&response);
+                let structured = serde_json::to_value(&response).unwrap_or_default();
+                Ok(ToolResult::with_structured(text, structured))
+            }
+            "feedback" => {
+                let request = build_feedback_request(&input)?;
+                let response = self.client.answer_feedback(request).await?;
+                let text = format_feedback_response(&response);
+                let structured = serde_json::to_value(&response).unwrap_or_default();
+                Ok(ToolResult::with_structured(text, structured))
+            }
+            "query" | "recent_changes" => {
+                let request = build_request(input)?;
+                let response = self.client.answer_query(request).await?;
+                let text = format_response(&response);
+                let structured = serde_json::to_value(&response).unwrap_or_default();
+                Ok(ToolResult::with_structured(text, structured))
+            }
+            _ => unreachable!("normalized_action validates the closed action set"),
+        }
+    }
+
+    fn metadata(&self) -> &ToolMetadata {
+        static METADATA: std::sync::OnceLock<ToolMetadata> = std::sync::OnceLock::new();
+        METADATA.get_or_init(|| ToolMetadata {
+            name: "answer".to_owned(),
+            title: "Natural-Language Answer".to_owned(),
+            description: TOOL_DESCRIPTION.to_owned(),
+            category: ToolCategory::Ai,
+            annotations: ToolAnnotations {
+                read_only: false,
+                destructive: false,
+                requires_confirmation: false,
+                idempotent: false,
+                long_running: true,
+                open_world: true,
+            },
+            is_pro: false,
+            required_tier: None,
+        })
+    }
+
+    fn input_schema(&self) -> Value {
+        let uuid_array = |description: &str| {
+            json!({
+                "type": "array",
+                "description": description,
+                "items": { "type": "string", "format": "uuid" },
+                "uniqueItems": true
+            })
+        };
+        let mut schema = SchemaBuilder::new()
+            .description(TOOL_DESCRIPTION)
+            .string_enum(
+                "action",
+                "query requires question; recent_changes uses the canonical question; receipt requires request_id; feedback requires request_id, feedback_id, and signal. Defaults to query.",
+                VALID_ACTIONS,
+                false,
+            )
+            .string("question", "Natural-language context question", false)
+            .string_enum(
+                "scope_mode",
+                "Requested scope mode. Defaults to auto; this never grants authority.",
+                VALID_SCOPE_MODES,
+                false,
+            )
+            .uuid("account_id", "Optional requested account ID", false)
+            .property(
+                "workspace_ids",
+                uuid_array("Requested workspace IDs; empty means all currently authorized workspaces in account scope"),
+                false,
+            )
+            .property(
+                "project_ids",
+                uuid_array("Requested project IDs; empty means all currently authorized projects in the requested workspaces"),
+                false,
+            )
+            .string_enum(
+                "visibility",
+                "Requested visibility; inferred from supplied IDs and otherwise defaults to account",
+                VALID_VISIBILITIES,
+                false,
+            )
+            .string(
+                "timezone",
+                "IANA timezone used to interpret relative time. Defaults to UTC.",
+                false,
+            )
+            .uuid(
+                "current_workspace_id",
+                "Optional current-workspace relevance hint; not authority",
+                false,
+            )
+            .uuid(
+                "current_project_id",
+                "Optional current-project relevance hint; not authority",
+                false,
+            )
+            .string_enum(
+                "response_mode",
+                "Requested response mode",
+                VALID_RESPONSE_MODES,
+                false,
+            )
+            .property(
+                "response_budget",
+                json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["max_items", "max_citations", "max_output_tokens"],
+                    "properties": {
+                        "max_items": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "max_citations": { "type": "integer", "minimum": 1, "maximum": 250 },
+                        "max_output_tokens": { "type": "integer", "minimum": 64, "maximum": 8192 }
+                    }
+                }),
+                false,
+            )
+            .property(
+                "latency_budget",
+                json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["total_ms", "retrieval_ms", "synthesis_ms", "authority_reserve_ms"],
+                    "properties": {
+                        "total_ms": { "type": "integer", "minimum": 100, "maximum": 30000 },
+                        "retrieval_ms": { "type": "integer", "minimum": 1, "maximum": 30000 },
+                        "synthesis_ms": { "type": "integer", "minimum": 1, "maximum": 30000 },
+                        "authority_reserve_ms": { "type": "integer", "minimum": 1, "maximum": 30000 }
+                    }
+                }),
+                false,
+            )
+            .uuid(
+                "request_id",
+                "Receipt request ID for action=receipt or action=feedback",
+                false,
+            )
+            .uuid(
+                "feedback_id",
+                "Caller-generated idempotency ID required for action=feedback",
+                false,
+            )
+            .property(
+                "target",
+                json!({
+                    "description": "Feedback target. Defaults to the whole answer.",
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["target"],
+                            "properties": { "target": { "const": "answer" } }
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["target", "item_id"],
+                            "properties": {
+                                "target": { "const": "item" },
+                                "item_id": { "type": "string", "format": "uuid" }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["target", "citation_id"],
+                            "properties": {
+                                "target": { "const": "citation" },
+                                "citation_id": { "type": "string", "format": "uuid" }
+                            }
+                        }
+                    ]
+                }),
+                false,
+            )
+            .string_enum(
+                "signal",
+                "Receipt-bound feedback signal for action=feedback",
+                VALID_FEEDBACK_SIGNALS,
+                false,
+            )
+            .build();
+        schema["additionalProperties"] = json!(false);
+        schema["properties"]["question"]["minLength"] = json!(1);
+        schema["properties"]["question"]["maxLength"] = json!(8192);
+        schema["properties"]["timezone"]["maxLength"] = json!(64);
+        schema["allOf"] = json!([
+            {
+                "if": {
+                    "required": ["action"],
+                    "properties": { "action": { "const": "receipt" } }
+                },
+                "then": { "required": ["request_id"] }
+            },
+            {
+                "if": {
+                    "required": ["action"],
+                    "properties": { "action": { "const": "feedback" } }
+                },
+                "then": { "required": ["request_id", "feedback_id", "signal"] }
+            }
+        ]);
+        schema
+    }
+}
+
+fn parse_uuid(value: Option<String>, field: &str) -> Result<Option<Uuid>> {
+    value
+        .map(|raw| {
+            Uuid::parse_str(raw.trim())
+                .map_err(|_| Error::Validation(format!("{field} must be a UUID")))
+        })
+        .transpose()
+}
+
+fn parse_uuid_set(values: Option<Vec<String>>, field: &str) -> Result<BTreeSet<Uuid>> {
+    values
+        .unwrap_or_default()
+        .into_iter()
+        .map(|raw| {
+            Uuid::parse_str(raw.trim())
+                .map_err(|_| Error::Validation(format!("every {field} entry must be a UUID")))
+        })
+        .collect()
+}
+
+fn normalized_action(input: &AnswerInput) -> Result<String> {
+    let action = input
+        .action
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("query")
+        .to_ascii_lowercase();
+    if !VALID_ACTIONS.contains(&action.as_str()) {
+        return Err(Error::Validation(format!(
+            "action must be one of: {}",
+            VALID_ACTIONS.join(", ")
+        )));
+    }
+    Ok(action)
+}
+
+fn parse_required_uuid(value: Option<&String>, field: &str) -> Result<Uuid> {
+    let raw = value
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| Error::Validation(format!("{field} is required")))?;
+    let id =
+        Uuid::parse_str(raw).map_err(|_| Error::Validation(format!("{field} must be a UUID")))?;
+    if id.is_nil() {
+        return Err(Error::Validation(format!("{field} must not be nil")));
+    }
+    Ok(id)
+}
+
+fn has_query_fields(input: &AnswerInput) -> bool {
+    input.question.is_some()
+        || input.scope_mode.is_some()
+        || input.account_id.is_some()
+        || input.workspace_ids.is_some()
+        || input.project_ids.is_some()
+        || input.visibility.is_some()
+        || input.timezone.is_some()
+        || input.current_workspace_id.is_some()
+        || input.current_project_id.is_some()
+        || input.response_mode.is_some()
+        || input.response_budget.is_some()
+        || input.latency_budget.is_some()
+}
+
+fn build_receipt_request_id(input: &AnswerInput) -> Result<Uuid> {
+    if has_query_fields(input)
+        || input.feedback_id.is_some()
+        || input.target.is_some()
+        || input.signal.is_some()
+    {
+        return Err(Error::Validation(
+            "action=receipt accepts only action and request_id".to_owned(),
+        ));
+    }
+    parse_required_uuid(input.request_id.as_ref(), "request_id")
+}
+
+fn build_feedback_request(input: &AnswerInput) -> Result<AnswerFeedbackRequestV1> {
+    if has_query_fields(input) {
+        return Err(Error::Validation(
+            "action=feedback does not accept query, scope, budget, or timezone fields".to_owned(),
+        ));
+    }
+    let signal = match input.signal.as_deref().map(str::trim) {
+        Some("relevant") => AnswerFeedbackSignalV1::Relevant,
+        Some("useful_but_not_now") => AnswerFeedbackSignalV1::UsefulButNotNow,
+        Some("wrong_project") => AnswerFeedbackSignalV1::WrongProject,
+        Some("superseded") => AnswerFeedbackSignalV1::Superseded,
+        Some("never_for_topic") => AnswerFeedbackSignalV1::NeverForTopic,
+        Some("promote_to_universal_rule") => AnswerFeedbackSignalV1::PromoteToUniversalRule,
+        Some(_) => {
+            return Err(Error::Validation(format!(
+                "signal must be one of: {}",
+                VALID_FEEDBACK_SIGNALS.join(", ")
+            )))
+        }
+        None => return Err(Error::Validation("signal is required".to_owned())),
+    };
+    let target = match input.target.as_ref() {
+        None | Some(AnswerFeedbackTargetInput::Answer {}) => AnswerFeedbackTargetV1::Answer {},
+        Some(AnswerFeedbackTargetInput::Item { item_id }) => AnswerFeedbackTargetV1::Item {
+            item_id: parse_required_uuid(Some(item_id), "target.item_id")?,
+        },
+        Some(AnswerFeedbackTargetInput::Citation { citation_id }) => {
+            AnswerFeedbackTargetV1::Citation {
+                citation_id: parse_required_uuid(Some(citation_id), "target.citation_id")?,
+            }
+        }
+    };
+    Ok(AnswerFeedbackRequestV1 {
+        schema_version: AnswerFeedbackSchemaVersionV1::V1,
+        feedback_id: parse_required_uuid(input.feedback_id.as_ref(), "feedback_id")?,
+        request_id: parse_required_uuid(input.request_id.as_ref(), "request_id")?,
+        target,
+        signal,
+    })
+}
+
+fn build_request(input: AnswerInput) -> Result<AnswerRequestV1> {
+    let action = normalized_action(&input)?;
+    if !matches!(action.as_str(), "query" | "recent_changes") {
+        return Err(Error::Validation(
+            "build_request only accepts query or recent_changes".to_owned(),
+        ));
+    }
+    if input.request_id.is_some()
+        || input.feedback_id.is_some()
+        || input.target.is_some()
+        || input.signal.is_some()
+    {
+        return Err(Error::Validation(
+            "query actions do not accept receipt or feedback fields".to_owned(),
+        ));
+    }
+    let question = input
+        .question
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .or_else(|| (action == "recent_changes").then(|| "What changed recently?".to_owned()))
+        .ok_or_else(|| Error::Validation("question is required for action=query".to_owned()))?;
+
+    let scope_mode = match input.scope_mode.as_deref().map(str::trim) {
+        None | Some("") | Some("auto") => AnswerScopeModeV1::Auto,
+        Some("explicit") => AnswerScopeModeV1::Explicit,
+        Some(_) => {
+            return Err(Error::Validation(format!(
+                "scope_mode must be one of: {}",
+                VALID_SCOPE_MODES.join(", ")
+            )))
+        }
+    };
+    let workspace_ids = parse_uuid_set(input.workspace_ids, "workspace_ids")?;
+    let project_ids = parse_uuid_set(input.project_ids, "project_ids")?;
+    let visibility = match input.visibility.as_deref().map(str::trim) {
+        Some("personal") => AnswerVisibilityV1::Personal,
+        Some("project") => AnswerVisibilityV1::Project,
+        Some("workspace") => AnswerVisibilityV1::Workspace,
+        Some("account") => AnswerVisibilityV1::Account,
+        None | Some("") if !project_ids.is_empty() => AnswerVisibilityV1::Project,
+        None | Some("") if !workspace_ids.is_empty() => AnswerVisibilityV1::Workspace,
+        None | Some("") => AnswerVisibilityV1::Account,
+        Some(_) => {
+            return Err(Error::Validation(format!(
+                "visibility must be one of: {}",
+                VALID_VISIBILITIES.join(", ")
+            )))
+        }
+    };
+    let response_mode = match input.response_mode.as_deref().map(str::trim) {
+        None | Some("") if action == "recent_changes" => Some(AnswerResponseModeV1::Structured),
+        None | Some("") => None,
+        Some("concise") => Some(AnswerResponseModeV1::Concise),
+        Some("detailed") => Some(AnswerResponseModeV1::Detailed),
+        Some("structured") => Some(AnswerResponseModeV1::Structured),
+        Some(_) => {
+            return Err(Error::Validation(format!(
+                "response_mode must be one of: {}",
+                VALID_RESPONSE_MODES.join(", ")
+            )))
+        }
+    };
+    let timezone = input
+        .timezone
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "UTC".to_owned());
+
+    let response_budget = input.response_budget.map(|budget| {
+        if !(1..=100).contains(&budget.max_items)
+            || !(1..=250).contains(&budget.max_citations)
+            || !(64..=8_192).contains(&budget.max_output_tokens)
+        {
+            return Err(Error::Validation(
+                "response_budget requires max_items 1..=100, max_citations 1..=250, and max_output_tokens 64..=8192"
+                    .to_owned(),
+            ));
+        }
+        Ok(AnswerResponseBudgetRequestV1 {
+            max_items: budget.max_items,
+            max_citations: budget.max_citations,
+            max_output_tokens: budget.max_output_tokens,
+        })
+    }).transpose()?;
+    let latency_budget = input.latency_budget.map(|budget| {
+        let components = budget
+            .retrieval_ms
+            .checked_add(budget.synthesis_ms)
+            .and_then(|value| value.checked_add(budget.authority_reserve_ms));
+        if !(100..=30_000).contains(&budget.total_ms)
+            || budget.retrieval_ms == 0
+            || budget.synthesis_ms == 0
+            || budget.authority_reserve_ms == 0
+            || components != Some(budget.total_ms)
+        {
+            return Err(Error::Validation(
+                "latency_budget requires total_ms 100..=30000, positive components, and retrieval_ms + synthesis_ms + authority_reserve_ms = total_ms"
+                    .to_owned(),
+            ));
+        }
+        Ok(AnswerLatencyBudgetRequestV1 {
+            total_ms: budget.total_ms,
+            retrieval_ms: budget.retrieval_ms,
+            synthesis_ms: budget.synthesis_ms,
+            authority_reserve_ms: budget.authority_reserve_ms,
+        })
+    }).transpose()?;
+
+    Ok(AnswerRequestV1 {
+        question,
+        scope_mode,
+        requested_scope: AnswerContextScopeV1 {
+            account_id: parse_uuid(input.account_id, "account_id")?,
+            workspace_ids,
+            project_ids,
+            visibility,
+        },
+        client_context: AnswerPlanClientContextV1 {
+            timezone,
+            current_workspace_id: parse_uuid(input.current_workspace_id, "current_workspace_id")?,
+            current_project_id: parse_uuid(input.current_project_id, "current_project_id")?,
+        },
+        response_mode,
+        response_budget,
+        latency_budget,
+    })
+}
+
+fn format_response(response: &AnswerResponseV1) -> String {
+    match response {
+        AnswerResponseV1::Completed {
+            request_id,
+            answer,
+            items,
+            citations,
+            conflicts,
+            freshness,
+            coverage,
+            degradation,
+            latency,
+            ..
+        } => {
+            let mut lines = vec![answer.trim().to_owned(), String::new()];
+            lines.push(format!(
+                "Evidence: {} item(s), {} citation(s), {} conflict(s); coverage {}/{} source slot(s).",
+                items.len(),
+                citations.len(),
+                conflicts.len(),
+                coverage.iter().filter(|entry| matches!(entry.status, mcp_types::AnswerCoverageStatusV1::Complete)).count(),
+                coverage.len(),
+            ));
+            lines.push(format!(
+                "As of: {} · Latency: {} ms · Request: {}",
+                freshness.as_of.to_rfc3339(),
+                latency.total_ms,
+                request_id,
+            ));
+            if degradation.partial {
+                lines.push("Partial result: inspect structured coverage and degradation metadata before acting.".to_owned());
+            }
+            lines.join("\n")
+        }
+        AnswerResponseV1::ClarificationRequired {
+            request_id,
+            clarification,
+            ..
+        } => format!(
+            "Clarification required: {}\n\nCandidate scopes: {} · Request: {}",
+            clarification.prompt,
+            clarification.candidate_scopes.len(),
+            request_id,
+        ),
+    }
+}
+
+fn format_feedback_response(response: &AnswerFeedbackResponseV1) -> String {
+    format!(
+        "Feedback recorded for Answer request {}. Effect: recorded_only. Feedback ID: {}.",
+        response.request_id, response.feedback_id
+    )
+}
+
+pub fn register_answer_tools(
+    registry: &mut crate::registry::ToolRegistry,
+    client: ContextStreamClient,
+) {
+    registry.register("answer", Arc::new(AnswerTool::new(client)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TestFixtures;
+
+    fn tool() -> AnswerTool {
+        AnswerTool::new(ContextStreamClient::new(TestFixtures::test_config()))
+    }
+
+    #[test]
+    fn metadata_is_non_destructive_but_not_read_only_or_retry_safe() {
+        let metadata = tool().metadata().clone();
+        assert_eq!(metadata.name, "answer");
+        assert_eq!(metadata.category, ToolCategory::Ai);
+        assert!(!metadata.annotations.read_only);
+        assert!(!metadata.annotations.destructive);
+        assert!(!metadata.annotations.requires_confirmation);
+        assert!(!metadata.annotations.idempotent);
+        assert!(metadata.annotations.long_running);
+        assert!(metadata.description.contains("exactly once"));
+        assert!(metadata.description.contains("recorded_only"));
+    }
+
+    #[test]
+    fn schema_is_closed_and_exposes_cross_workspace_scope_and_budgets() {
+        let schema = tool().input_schema();
+        assert_eq!(schema["additionalProperties"], false);
+        for field in [
+            "action",
+            "question",
+            "scope_mode",
+            "account_id",
+            "workspace_ids",
+            "project_ids",
+            "visibility",
+            "timezone",
+            "response_mode",
+            "response_budget",
+            "latency_budget",
+            "request_id",
+            "feedback_id",
+            "target",
+            "signal",
+        ] {
+            assert!(schema["properties"].get(field).is_some(), "missing {field}");
+        }
+        assert_eq!(schema["properties"]["workspace_ids"]["uniqueItems"], true);
+        assert_eq!(schema["allOf"].as_array().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn recent_changes_defaults_to_authority_free_account_auto_scope() {
+        let request =
+            build_request(serde_json::from_value(json!({ "action": "recent_changes" })).unwrap())
+                .unwrap();
+        let wire = serde_json::to_value(request).unwrap();
+
+        assert_eq!(wire["question"], "What changed recently?");
+        assert_eq!(wire["scope_mode"], "auto");
+        assert_eq!(wire["requested_scope"]["visibility"], "account");
+        assert_eq!(wire["requested_scope"]["workspace_ids"], json!([]));
+        assert_eq!(wire["requested_scope"]["project_ids"], json!([]));
+        assert_eq!(wire["client_context"]["timezone"], "UTC");
+        for forbidden in [
+            "actor",
+            "application_id",
+            "authorization",
+            "effective_scopes",
+            "tenant_route",
+            "model",
+        ] {
+            assert!(wire.get(forbidden).is_none());
+        }
+    }
+
+    #[test]
+    fn query_requires_nonempty_question_and_rejects_unknown_fields() {
+        assert!(build_request(serde_json::from_value(json!({})).unwrap()).is_err());
+        assert!(serde_json::from_value::<AnswerInput>(json!({
+            "action": "query",
+            "question": "current truth?",
+            "tenant_route": "forged"
+        }))
+        .is_err());
+        let query_with_receipt_field: AnswerInput = serde_json::from_value(json!({
+            "action": "query",
+            "question": "current truth?",
+            "request_id": Uuid::from_u128(9)
+        }))
+        .unwrap();
+        assert!(build_request(query_with_receipt_field).is_err());
+    }
+
+    #[test]
+    fn receipt_requires_one_non_nil_request_id_and_rejects_query_fields() {
+        let request_id = Uuid::from_u128(10);
+        let valid: AnswerInput = serde_json::from_value(json!({
+            "action": "receipt",
+            "request_id": request_id
+        }))
+        .unwrap();
+        assert_eq!(build_receipt_request_id(&valid).unwrap(), request_id);
+
+        let mixed: AnswerInput = serde_json::from_value(json!({
+            "action": "receipt",
+            "request_id": request_id,
+            "question": "run this again"
+        }))
+        .unwrap();
+        assert!(build_receipt_request_id(&mixed).is_err());
+        let nil: AnswerInput = serde_json::from_value(json!({
+            "action": "receipt",
+            "request_id": Uuid::nil()
+        }))
+        .unwrap();
+        assert!(build_receipt_request_id(&nil).is_err());
+    }
+
+    #[test]
+    fn feedback_requires_client_idempotency_and_preserves_recorded_only_semantics() {
+        let request_id = Uuid::from_u128(11);
+        let feedback_id = Uuid::from_u128(12);
+        let input: AnswerInput = serde_json::from_value(json!({
+            "action": "feedback",
+            "request_id": request_id,
+            "feedback_id": feedback_id,
+            "target": { "target": "answer" },
+            "signal": "relevant"
+        }))
+        .unwrap();
+        let request = build_feedback_request(&input).unwrap();
+        assert_eq!(request.request_id, request_id);
+        assert_eq!(request.feedback_id, feedback_id);
+        assert_eq!(request.target, AnswerFeedbackTargetV1::Answer {});
+        assert_eq!(request.signal, AnswerFeedbackSignalV1::Relevant);
+
+        let missing_feedback_id: AnswerInput = serde_json::from_value(json!({
+            "action": "feedback",
+            "request_id": request_id,
+            "signal": "relevant"
+        }))
+        .unwrap();
+        assert!(build_feedback_request(&missing_feedback_id).is_err());
+
+        let mixed: AnswerInput = serde_json::from_value(json!({
+            "action": "feedback",
+            "request_id": request_id,
+            "feedback_id": feedback_id,
+            "signal": "relevant",
+            "timezone": "UTC"
+        }))
+        .unwrap();
+        assert!(build_feedback_request(&mixed).is_err());
+    }
+
+    #[test]
+    fn request_budget_validation_matches_the_server_contract() {
+        let valid = serde_json::from_value(json!({
+            "action": "query",
+            "question": "What is current?",
+            "response_budget": {
+                "max_items": 100,
+                "max_citations": 250,
+                "max_output_tokens": 8192
+            },
+            "latency_budget": {
+                "total_ms": 1500,
+                "retrieval_ms": 900,
+                "synthesis_ms": 500,
+                "authority_reserve_ms": 100
+            }
+        }))
+        .unwrap();
+        assert!(build_request(valid).is_ok());
+
+        for invalid in [
+            json!({
+                "action": "query",
+                "question": "What is current?",
+                "response_budget": {
+                    "max_items": 0,
+                    "max_citations": 50,
+                    "max_output_tokens": 1200
+                }
+            }),
+            json!({
+                "action": "query",
+                "question": "What is current?",
+                "latency_budget": {
+                    "total_ms": 1500,
+                    "retrieval_ms": 900,
+                    "synthesis_ms": 500,
+                    "authority_reserve_ms": 99
+                }
+            }),
+        ] {
+            let input = serde_json::from_value(invalid).unwrap();
+            assert!(build_request(input).is_err());
+        }
+    }
+}

--- a/crates/mcp-tools/src/domains/mod.rs
+++ b/crates/mcp-tools/src/domains/mod.rs
@@ -1,6 +1,7 @@
 //! Domain-specific tool implementations.
 
 pub mod account_mode;
+pub mod answer;
 pub mod atlas_jobs;
 pub mod atlas_warm_cache;
 pub mod capsule;
@@ -33,6 +34,7 @@ pub mod workspace_drift;
 mod parity_eval_tests;
 
 // Re-export all domain tools
+pub use answer::*;
 pub use atlas_jobs::*;
 pub use capsule::*;
 pub use charts::*;

--- a/crates/mcp-tools/src/registry.rs
+++ b/crates/mcp-tools/src/registry.rs
@@ -120,6 +120,12 @@ fn acceleration_observation_action(name: &str, input: &Value) -> Option<&'static
         "search_semantic" => Some("semantic"),
         "search_hybrid" => Some("hybrid"),
         "search_keyword" => Some("keyword"),
+        "answer" => Some(match input_action(input) {
+            Some("recent_changes") => "recent_changes",
+            Some("receipt") => "receipt",
+            Some("feedback") => "feedback",
+            _ => "query",
+        }),
         "session_recall" => Some("recall"),
         "memory_search" => Some("search"),
         "session" => match input_action(input) {
@@ -282,6 +288,7 @@ fn acceleration_observation_request(
         "search_semantic" => "search_semantic",
         "search_hybrid" => "search_hybrid",
         "search_keyword" => "search_keyword",
+        "answer" => "answer",
         "session_recall" => "session_recall",
         "memory_search" => "memory_search",
         "session" => "session",
@@ -1514,6 +1521,35 @@ fn discovery_hints(name: &str, metadata: &ToolMetadata) -> DiscoveryHints {
             parallel_safe: true,
             batch_safe: true,
         },
+        "answer" => DiscoveryHints {
+            aliases: &[
+                "ask contextstream",
+                "natural language context query",
+                "what changed recently",
+                "recover answer receipt",
+                "answer feedback",
+            ],
+            tags: &[
+                "answer",
+                "current truth",
+                "recent changes",
+                "cross-workspace",
+                "evidence",
+                "receipt",
+                "feedback",
+            ],
+            when_to_use: "Synthesize one evidence-backed answer across the caller's authorized ContextStream knowledge, recover a durable Answer receipt without replay, or record explicit receipt-bound feedback.",
+            avoid_when: "Do not use for exact code/file discovery; use search. Do not retry a failed query, receipt, or feedback transport automatically; feedback acknowledgement means recorded_only.",
+            examples: &[
+                "what changed recently across my team's workspaces?",
+                "what is the current truth about our rollout?",
+                "recover the durable result for this Answer request ID",
+                "record that this Answer cited the wrong project",
+            ],
+            latency_class: "medium",
+            parallel_safe: false,
+            batch_safe: false,
+        },
         "memory" => DiscoveryHints {
             aliases: &[
                 "notes",
@@ -1818,6 +1854,8 @@ const LIGHT_TOOLS: &[&str] = &[
     "session_recall",
     // Search
     "search",
+    // Natural-language context answers
+    "answer",
     // Memory
     "memory",
     "memory_search",
@@ -1913,6 +1951,7 @@ const OPENAI_AGENTIC_CORE_TOOLS: &[&str] = &[
     "session",
     "instruct",
     "search",
+    "answer",
     "memory",
     "media",
     // Capsule creation must remain directly reachable on compact OpenAI/Codex
@@ -1935,6 +1974,7 @@ const CONSOLIDATED_TOOLS: &[&str] = &[
     "session",
     "instruct",
     "search",
+    "answer",
     "memory",
     "graph",
     "workspace",
@@ -1993,6 +2033,7 @@ const CORE_BUNDLE: &[&str] = &[
     "session",
     "instruct",
     "search",
+    "answer",
     "help",
     "generate_rules",
     "memory",
@@ -2002,7 +2043,7 @@ const CORE_BUNDLE: &[&str] = &[
 
 /// Tool bundles for progressive disclosure
 static TOOL_BUNDLES: phf::Map<&'static str, &'static [&'static str]> = phf::phf_map! {
-    "core" => &["init", "context", "session", "search", "help", "generate_rules", "media", "coordination"],
+    "core" => &["init", "context", "session", "search", "answer", "help", "generate_rules", "media", "coordination"],
     "session" => &["session_capture", "session_recall", "session_compress", "instruct"],
     "memory" => &["memory", "memory_search", "memory_decisions", "memory_timeline", "memory_create_node"],
     "search" => &["search", "search_semantic", "search_hybrid", "search_keyword"],

--- a/crates/mcp-tools/src/registry_tests.rs
+++ b/crates/mcp-tools/src/registry_tests.rs
@@ -715,6 +715,7 @@ mod constants_tests {
         assert!(LIGHT_TOOLS.contains(&"context"));
         assert!(LIGHT_TOOLS.contains(&"session"));
         assert!(LIGHT_TOOLS.contains(&"search"));
+        assert!(LIGHT_TOOLS.contains(&"answer"));
     }
 
     #[test]
@@ -746,6 +747,7 @@ mod constants_tests {
         assert!(CONSOLIDATED_TOOLS.contains(&"context"));
         assert!(CONSOLIDATED_TOOLS.contains(&"session"));
         assert!(CONSOLIDATED_TOOLS.contains(&"search"));
+        assert!(CONSOLIDATED_TOOLS.contains(&"answer"));
         assert!(CONSOLIDATED_TOOLS.contains(&"memory"));
         assert!(CONSOLIDATED_TOOLS.contains(&"graph"));
         assert!(CONSOLIDATED_TOOLS.contains(&"workspace"));
@@ -762,6 +764,7 @@ mod constants_tests {
         assert!(CORE_BUNDLE.contains(&"context"));
         assert!(CORE_BUNDLE.contains(&"session"));
         assert!(CORE_BUNDLE.contains(&"search"));
+        assert!(CORE_BUNDLE.contains(&"answer"));
         assert!(CORE_BUNDLE.contains(&"help"));
     }
 }
@@ -1052,9 +1055,43 @@ fn test_discovery_hints_graph_code_health_keywords() {
 }
 
 #[test]
+fn test_discovery_hints_answer_recent_changes_and_safety() {
+    use mcp_types::tool::{ToolAnnotations, ToolCategory, ToolMetadata};
+
+    let metadata = ToolMetadata {
+        name: "answer".to_string(),
+        title: "Natural-Language Answer".to_string(),
+        description: "Answer authorized context questions".to_string(),
+        category: ToolCategory::Ai,
+        annotations: ToolAnnotations::default(),
+        is_pro: false,
+        required_tier: None,
+    };
+    let hints = discovery_hints("answer", &metadata);
+    assert!(hints.aliases.contains(&"what changed recently"));
+    assert!(hints.tags.contains(&"current truth"));
+    assert!(hints.tags.contains(&"cross-workspace"));
+    assert!(hints.tags.contains(&"receipt"));
+    assert!(hints.tags.contains(&"feedback"));
+    assert!(hints.avoid_when.contains("Do not retry"));
+    assert!(hints.avoid_when.contains("recorded_only"));
+    assert!(!hints.parallel_safe);
+    assert!(!hints.batch_safe);
+}
+
+#[test]
 fn test_capsule_is_direct_on_openai_surface_but_not_in_light_toolset() {
     assert!(!LIGHT_TOOLS.contains(&"capsule"));
     assert!(OPENAI_AGENTIC_CORE_TOOLS.contains(&"capsule"));
+}
+
+#[test]
+fn test_answer_is_direct_on_primary_agent_surfaces() {
+    assert!(LIGHT_TOOLS.contains(&"answer"));
+    assert!(OPENAI_AGENTIC_CORE_TOOLS.contains(&"answer"));
+    assert!(CONSOLIDATED_TOOLS.contains(&"answer"));
+    assert!(CORE_BUNDLE.contains(&"answer"));
+    assert!(TOOL_BUNDLES["core"].contains(&"answer"));
 }
 
 #[test]

--- a/crates/mcp-types/src/answer.rs
+++ b/crates/mcp-types/src/answer.rs
@@ -1,0 +1,547 @@
+//! Public ContextStream Answer API v1 wire types used by MCP clients.
+//!
+//! These types intentionally contain requested logical scope only. Actor
+//! identity, effective authorization, tenant routes, provider/model choices,
+//! and durable execution receipts remain server-owned.
+
+use std::collections::BTreeSet;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerScopeModeV1 {
+    Explicit,
+    Auto,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerVisibilityV1 {
+    Personal,
+    Project,
+    Workspace,
+    Account,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerContextScopeV1 {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<Uuid>,
+    pub workspace_ids: BTreeSet<Uuid>,
+    pub project_ids: BTreeSet<Uuid>,
+    pub visibility: AnswerVisibilityV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerPlanClientContextV1 {
+    pub timezone: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_workspace_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_project_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerResponseModeV1 {
+    Concise,
+    Detailed,
+    Structured,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerResponseBudgetRequestV1 {
+    pub max_items: u32,
+    pub max_citations: u32,
+    pub max_output_tokens: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerLatencyBudgetRequestV1 {
+    pub total_ms: u32,
+    pub retrieval_ms: u32,
+    pub synthesis_ms: u32,
+    pub authority_reserve_ms: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerRequestV1 {
+    pub question: String,
+    pub scope_mode: AnswerScopeModeV1,
+    pub requested_scope: AnswerContextScopeV1,
+    pub client_context: AnswerPlanClientContextV1,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_mode: Option<AnswerResponseModeV1>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_budget: Option<AnswerResponseBudgetRequestV1>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_budget: Option<AnswerLatencyBudgetRequestV1>,
+}
+
+impl AnswerRequestV1 {
+    /// Build the account-wide auto-scope request used by CoFlow's
+    /// "What changed recently?" journey. Empty ID sets request all currently
+    /// authorized scopes; they never grant additional access.
+    pub fn coflow_recent_changes(
+        question: Option<String>,
+        timezone: impl Into<String>,
+        account_id: Option<Uuid>,
+        current_workspace_id: Option<Uuid>,
+        current_project_id: Option<Uuid>,
+    ) -> Self {
+        Self {
+            question: question.unwrap_or_else(|| "What changed recently?".to_owned()),
+            scope_mode: AnswerScopeModeV1::Auto,
+            requested_scope: AnswerContextScopeV1 {
+                account_id,
+                workspace_ids: BTreeSet::new(),
+                project_ids: BTreeSet::new(),
+                visibility: AnswerVisibilityV1::Account,
+            },
+            client_context: AnswerPlanClientContextV1 {
+                timezone: timezone.into(),
+                current_workspace_id,
+                current_project_id,
+            },
+            response_mode: Some(AnswerResponseModeV1::Structured),
+            response_budget: None,
+            latency_budget: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AnswerSchemaVersionV1 {
+    #[serde(rename = "answer.v1")]
+    V1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerIntentV1 {
+    CurrentTruth,
+    RecentChanges,
+    DecisionTrace,
+    ActiveWork,
+    StatusRisk,
+    OpenCoordination,
+    SemanticRetrieval,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerSourceClassV1 {
+    Assertions,
+    Documents,
+    Decisions,
+    Events,
+    Tasks,
+    Transcripts,
+    Code,
+    Entities,
+    Coordination,
+    LiveState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerTimeRuleV1 {
+    Recently,
+    LastHours,
+    LastDays,
+    LastWeeks,
+    Today,
+    Yesterday,
+    ThisWeek,
+    PointInTimeNow,
+    HistoryThroughNow,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerTimeInterpretationV1 {
+    pub since: Option<DateTime<Utc>>,
+    pub until: Option<DateTime<Utc>>,
+    pub anchor: DateTime<Utc>,
+    pub timezone: String,
+    pub natural_language: String,
+    pub rule: AnswerTimeRuleV1,
+    pub quantity: Option<u32>,
+    pub confidence_basis_points: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerPlanInterpretationV1 {
+    pub plan_id: Uuid,
+    pub intent: AnswerIntentV1,
+    pub intent_confidence_basis_points: u16,
+    pub requested_scope: AnswerContextScopeV1,
+    pub time: AnswerTimeInterpretationV1,
+    pub response_mode: AnswerResponseModeV1,
+    pub source_classes: BTreeSet<AnswerSourceClassV1>,
+    pub omitted_source_classes: BTreeSet<AnswerSourceClassV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerResolvedScopeV1 {
+    pub scope_ref: u16,
+    pub scope: AnswerContextScopeV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerTruthStatusV1 {
+    Current,
+    Stale,
+    Disputed,
+    Invalid,
+    Historical,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerItemV1 {
+    pub item_id: Uuid,
+    pub statement: String,
+    pub truth_status: AnswerTruthStatusV1,
+    pub source_class: AnswerSourceClassV1,
+    pub scope_ref: u16,
+    pub occurred_at: DateTime<Utc>,
+    pub observed_at: DateTime<Utc>,
+    pub score_basis_points: u16,
+    pub citation_ids: BTreeSet<Uuid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerCitationV1 {
+    pub citation_id: Uuid,
+    pub source_class: AnswerSourceClassV1,
+    pub source_ref: String,
+    pub label: String,
+    pub observed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerConflictV1 {
+    pub subject: String,
+    pub competing_item_ids: BTreeSet<Uuid>,
+    pub resolution: AnswerTruthStatusV1,
+    pub explanation: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerFreshnessV1 {
+    pub as_of: DateTime<Utc>,
+    pub oldest_observed_at: Option<DateTime<Utc>>,
+    pub newest_observed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerWatermarkV1 {
+    pub source_class: AnswerSourceClassV1,
+    pub scope_ref: u16,
+    pub captured_at: DateTime<Utc>,
+    pub complete_through: Option<DateTime<Utc>>,
+    pub token: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerCoverageStatusV1 {
+    Complete,
+    Partial,
+    Unavailable,
+    TimedOut,
+    BudgetExceeded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerCoverageV1 {
+    pub source_class: AnswerSourceClassV1,
+    pub scope_ref: u16,
+    pub status: AnswerCoverageStatusV1,
+    pub matched_count: u32,
+    pub returned_count: u32,
+    pub truncated_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerDegradationReasonV1 {
+    SourceUnavailable,
+    SourceTimedOut,
+    SourceBudgetExceeded,
+    IncompleteHorizon,
+    OutputTruncated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerDegradationV1 {
+    pub partial: bool,
+    pub reasons: BTreeSet<AnswerDegradationReasonV1>,
+    pub omitted_source_classes: BTreeSet<AnswerSourceClassV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerTruncationV1 {
+    pub eligible_item_count: u32,
+    pub emitted_item_count: u32,
+    pub item_truncated_count: u32,
+    pub available_citation_count: u32,
+    pub emitted_citation_count: u32,
+    pub citation_truncated_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AnswerTokenizerV1 {
+    #[serde(rename = "o200k_base")]
+    O200kBase,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerOutputBudgetV1 {
+    pub tokenizer: AnswerTokenizerV1,
+    pub max_output_tokens: u32,
+    pub exact_output_tokens: u32,
+    pub max_serialized_bytes: u32,
+    pub serialized_bytes: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerLatencyV1 {
+    pub total_ms: u32,
+    pub authority_ms: u32,
+    pub retrieval_ms: u32,
+    pub synthesis_ms: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerCacheStatusV1 {
+    Hit,
+    Miss,
+    Bypass,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerCacheV1 {
+    pub status: AnswerCacheStatusV1,
+    pub age_ms: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerClarificationKindV1 {
+    AmbiguousIntent,
+    ScopeRequired,
+    ConflictingScopeLanguage,
+    ScopeSelectionMismatch,
+    ConflictingTimeLanguage,
+    UnsupportedTimeExpression,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerClarificationV1 {
+    pub clarification_id: Uuid,
+    pub kind: AnswerClarificationKindV1,
+    pub prompt: String,
+    pub candidate_scopes: Vec<AnswerContextScopeV1>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AnswerResponseV1 {
+    Completed {
+        schema_version: AnswerSchemaVersionV1,
+        request_id: Uuid,
+        answer_id: Uuid,
+        application_id: Option<Uuid>,
+        plan: AnswerPlanInterpretationV1,
+        resolved_scopes: Vec<AnswerResolvedScopeV1>,
+        answer: String,
+        items: Vec<AnswerItemV1>,
+        citations: Vec<AnswerCitationV1>,
+        conflicts: Vec<AnswerConflictV1>,
+        freshness: AnswerFreshnessV1,
+        watermarks: Vec<AnswerWatermarkV1>,
+        coverage: Vec<AnswerCoverageV1>,
+        degradation: AnswerDegradationV1,
+        truncation: AnswerTruncationV1,
+        output_budget: AnswerOutputBudgetV1,
+        latency: AnswerLatencyV1,
+        cache: AnswerCacheV1,
+        next_cursor: Option<String>,
+        generated_at: DateTime<Utc>,
+    },
+    ClarificationRequired {
+        schema_version: AnswerSchemaVersionV1,
+        request_id: Uuid,
+        application_id: Option<Uuid>,
+        clarification: AnswerClarificationV1,
+    },
+}
+
+impl AnswerResponseV1 {
+    pub fn request_id(&self) -> Uuid {
+        match self {
+            Self::Completed { request_id, .. } | Self::ClarificationRequired { request_id, .. } => {
+                *request_id
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AnswerFeedbackSchemaVersionV1 {
+    #[serde(rename = "answer.feedback.v1")]
+    V1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "target", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AnswerFeedbackTargetV1 {
+    Answer {},
+    Item { item_id: Uuid },
+    Citation { citation_id: Uuid },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerFeedbackSignalV1 {
+    Relevant,
+    UsefulButNotNow,
+    WrongProject,
+    Superseded,
+    NeverForTopic,
+    PromoteToUniversalRule,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerFeedbackRequestV1 {
+    pub schema_version: AnswerFeedbackSchemaVersionV1,
+    pub feedback_id: Uuid,
+    pub request_id: Uuid,
+    pub target: AnswerFeedbackTargetV1,
+    pub signal: AnswerFeedbackSignalV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerFeedbackStatusV1 {
+    Accepted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerFeedbackEffectV1 {
+    RecordedOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerFeedbackResponseV1 {
+    pub schema_version: AnswerFeedbackSchemaVersionV1,
+    pub feedback_id: Uuid,
+    pub request_id: Uuid,
+    pub target: AnswerFeedbackTargetV1,
+    pub signal: AnswerFeedbackSignalV1,
+    pub status: AnswerFeedbackStatusV1,
+    pub effect: AnswerFeedbackEffectV1,
+    pub recorded_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coflow_request_is_authority_free_account_auto_scope() {
+        let request = AnswerRequestV1::coflow_recent_changes(
+            None,
+            "America/Los_Angeles",
+            Some(Uuid::from_u128(1)),
+            Some(Uuid::from_u128(2)),
+            None,
+        );
+        let wire = serde_json::to_value(request).unwrap();
+
+        assert_eq!(wire["question"], "What changed recently?");
+        assert_eq!(wire["scope_mode"], "auto");
+        assert_eq!(wire["requested_scope"]["visibility"], "account");
+        assert_eq!(
+            wire["requested_scope"]["workspace_ids"],
+            serde_json::json!([])
+        );
+        assert_eq!(
+            wire["requested_scope"]["project_ids"],
+            serde_json::json!([])
+        );
+        for forbidden in [
+            "actor",
+            "application_id",
+            "authorization",
+            "effective_scopes",
+            "tenant_route",
+            "model",
+        ] {
+            assert!(wire.get(forbidden).is_none());
+        }
+    }
+
+    #[test]
+    fn response_discriminator_is_closed() {
+        let valid = serde_json::json!({
+            "status": "clarification_required",
+            "schema_version": "answer.v1",
+            "request_id": Uuid::from_u128(1),
+            "application_id": null,
+            "clarification": {
+                "clarification_id": Uuid::from_u128(2),
+                "kind": "scope_required",
+                "prompt": "Which workspace?",
+                "candidate_scopes": [],
+                "created_at": "2026-09-02T00:00:00Z"
+            }
+        });
+        assert!(serde_json::from_value::<AnswerResponseV1>(valid.clone()).is_ok());
+
+        let mut forged = valid;
+        forged["tenant_route"] = serde_json::json!("private");
+        assert!(serde_json::from_value::<AnswerResponseV1>(forged).is_err());
+    }
+
+    #[test]
+    fn feedback_answer_target_rejects_extra_fields() {
+        let valid = serde_json::json!({"target": "answer"});
+        assert!(serde_json::from_value::<AnswerFeedbackTargetV1>(valid.clone()).is_ok());
+
+        let mut forged = valid;
+        forged["item_id"] = serde_json::json!(Uuid::from_u128(3));
+        assert!(serde_json::from_value::<AnswerFeedbackTargetV1>(forged).is_err());
+    }
+}

--- a/crates/mcp-types/src/lib.rs
+++ b/crates/mcp-types/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod acceleration_layer;
 pub mod account_mode;
 pub mod agentic;
+pub mod answer;
 pub mod api;
 pub mod atlas_layer;
 pub mod config;
@@ -29,6 +30,7 @@ pub use account_mode::{
     TeamDiscussion, TeamPriorityItem, TranscriptTopicSignal,
 };
 pub use agentic::{ComplianceEventRecorded, ComplianceEventRequest, RUNTIME_CONTEXTSTREAM_MCP};
+pub use answer::*;
 pub use atlas_layer::{
     noop_layer, AtlasArchiveError, AtlasArchiveHit, AtlasArchiveProvider, AtlasArchiveScope,
     AtlasFederationError, AtlasFederationProvider, AtlasFederationScope, AtlasLayer,


### PR DESCRIPTION
## Summary

- expose ContextStream Answer actions for query, recent changes, receipt recovery, and feedback
- keep Answer mutations one-shot with no retry or session-refresh replay
- validate request and receipt identity, use strict closed schemas, and report recorded-only feedback honestly
- retain the concurrently shipped Context Feeds surface in the combined 23-tool catalog

## Validation

- cargo fmt --all --check
- cargo clippy --locked --workspace --all-targets -- -D warnings
- cargo test --locked --workspace --all-targets
- npm test
- python3 .github/scripts/public_boundary.py .
- python3 .github/scripts/test_workflows.py

Signed-off-by: escott- <escott05@gmail.com>