### PR TITLE
MCP parity: typed decisions and lessons, one lessons renderer, coordination in context()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## Unreleased
 
+- Wave 3b parity: `memory(action="decisions")` requests the typed
+  `decisions.v1` envelope (query, category, sort, status, since, offset) and
+  renders `[DECISIONS]` / `[DECISION]` lines with status, freshness, category,
+  and id, plus `[PARTIAL]` lines for every degraded source (including servers
+  that still return the legacy array). New `memory(action="create_decision")`
+  and `memory(action="decision_action")`; `session(action="capture",
+  event_type="decision")` routes to the typed create when rationale,
+  alternatives, scope, or confidence are present; `supersede_node` accepts
+  lookup text and returns a `[CANDIDATES]` list when ambiguous;
+  `decision_trace` renders `[DECISION_TRACE]` with the server answer.
+- Lessons: `capture_lesson`, `get_lessons`, `update_lesson`, `delete_lesson`,
+  and the new `supersede_lesson` go to `/lessons` first and fall back to the
+  events path only on 404 (stated with a `[PARTIAL]` line). `context()` and
+  `session(action="ground")` render `[LESSONS_WARNING]` through one renderer
+  (stored severity, relevance shown separately). Suggested-rule actions
+  render typed `[SUGGESTED_RULES]` lines with `source_lesson_ids` and the
+  native guidance snippet.
+- Coordination: `context()` fetches the coordination inbox (skipped on the
+  fast route) and `context()`/`init()` check in when a session id is
+  present; `[COORDINATION]` lines prefix other-project notices with
+  `[other project]`, add a `… N more` trailer, and are never auto-acked;
+  `share` validates `kind` client-side.
+- Hygiene: `[RULES_NOTICE]` now names the real refresh path
+  (`contextstream-mcp update`, previewed by `help(action="editor_rules")`)
+  instead of a phantom `generate_rules()` tool; the phantom `graph_decisions`
+  entry left the light toolset; `memory_decisions` is reachable in
+  consolidated mode; grounding hits with `superseded_by` are marked
+  `stale=true, stale_reason="superseded"`; `HarnessId::ContextCode`
+  (`contextcode`, `csc`, …) gets capability-aware teaching.
+
 - Added the `feed` tool for ContextStream Context Feeds (list, ensure, get,
   update, archive, items, post, follow, unfollow, read, share, unshare,
   feedback, curate, runs, sources, ground) with a `feeds` bundle, typed

--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -2910,7 +2910,7 @@ impl ContextStreamClient {
         );
     }
 
-    fn invalidate_memory_read_caches(&self) {
+    pub(crate) fn invalidate_memory_read_caches(&self) {
         self.invalidate_custom_cache_prefix(MEMORY_SEARCH_CACHE_PREFIX);
         self.invalidate_custom_cache_prefix(SESSION_RECALL_CACHE_PREFIX);
     }
@@ -11389,11 +11389,9 @@ impl ContextStreamClient {
         if let Some(c) = params.min_confidence {
             query_params.push(format!("min_confidence={}", c));
         }
-        let path = if query_params.is_empty() {
-            "/suggested-rules".to_string()
-        } else {
-            format!("/suggested-rules?{}", query_params.join("&"))
-        };
+        // Typed envelope: `source_lesson_ids` per rule plus `native_guidance`.
+        query_params.push("format=envelope".to_string());
+        let path = format!("/suggested-rules?{}", query_params.join("&"));
 
         match self.get::<serde_json::Value>(&path).await {
             Ok(result) => Ok(result),
@@ -18914,7 +18912,7 @@ fn parse_rate_limit_headers(headers: &reqwest::header::HeaderMap) -> Option<Rate
 /// The API interprets explicit `null` differently from an absent field —
 /// `null` can mean "explicitly unset" while absent falls back to headers/defaults.
 /// TypeScript omits `undefined` values from JSON.stringify; this matches that behavior.
-fn strip_nulls(value: serde_json::Value) -> serde_json::Value {
+pub(crate) fn strip_nulls(value: serde_json::Value) -> serde_json::Value {
     match value {
         serde_json::Value::Object(map) => {
             serde_json::Value::Object(map.into_iter().filter(|(_, v)| !v.is_null()).collect())
@@ -18944,7 +18942,7 @@ fn project_id_with_default(
     })
 }
 
-fn scope_ids_with_defaults(
+pub(crate) fn scope_ids_with_defaults(
     workspace_id: Option<Uuid>,
     project_id: Option<Uuid>,
     config: &Config,

--- a/crates/mcp-client/src/lib.rs
+++ b/crates/mcp-client/src/lib.rs
@@ -20,6 +20,7 @@ pub mod harness_readiness;
 pub mod harness_remote;
 pub mod ingest_guard;
 pub mod json;
+pub mod parity;
 pub mod retry;
 pub mod ticket;
 
@@ -188,6 +189,10 @@ pub use ingest_guard::{
     IngestRootRejection, IngestRootRejectionReason, ALLOW_BROAD_INGEST_ENV, SENSITIVE_DIR_NAMES,
 };
 pub use mcp_types::agentic::{ComplianceEventRecorded, ComplianceEventRequest};
+pub use parity::{
+    normalize_decisions_envelope, CreateDecisionParams, CreateLessonParams, DecisionActionParams,
+    ListDecisionsParams, ListLessonsParams, UpdateLessonParams, DECISION_ACTIONS,
+};
 pub use ticket::{
     append_ticket_extras, canonical_linked_item_kind, enrich_ticket_result_from_request,
     format_linked_summary, format_ticket_assignee_summary, format_ticket_linked_summary,

--- a/crates/mcp-client/src/parity.rs
+++ b/crates/mcp-client/src/parity.rs
@@ -1,0 +1,463 @@
+//! Typed decision, lesson, and suggested-rule endpoints (Wave 3 parity).
+//!
+//! Every method here targets the typed hosted contract first:
+//!
+//! * `GET /memory/decisions?format=envelope` → `decisions.v1` envelope
+//! * `POST /memory/decisions`, `POST /memory/decisions/:id/actions`,
+//!   `GET /memory/decisions/:id/trace`
+//! * `GET|POST /lessons`, `GET|PATCH|DELETE /lessons/:id`,
+//!   `POST /lessons/:id/supersede`, `GET /lessons/warnings`
+//!
+//! The client never invents fields. When a server still answers with the
+//! legacy decision array the envelope is synthesised with an explicit
+//! `degraded` entry so tools can say `[PARTIAL]`; a `404` on `/lessons` is
+//! surfaced unchanged so callers can fall back to the events-based path and
+//! state that in their tool text.
+
+use crate::client::{scope_ids_with_defaults, strip_nulls, ContextStreamClient};
+use mcp_types::Result;
+use serde::Serialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+/// Query parameters for the typed decisions listing.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ListDecisionsParams {
+    pub workspace_id: Option<Uuid>,
+    pub project_id: Option<Uuid>,
+    pub query: Option<String>,
+    pub category: Option<String>,
+    /// `recency` | `relevance`
+    pub sort: Option<String>,
+    /// `active` | `superseded` | `disputed` | `verified` | `all`
+    pub status: Option<String>,
+    /// ISO-8601 lower bound.
+    pub since: Option<String>,
+    pub offset: Option<i64>,
+    pub limit: Option<i64>,
+    pub source: Option<String>,
+}
+
+/// Body for `POST /memory/decisions`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct CreateDecisionParams {
+    pub workspace_id: Option<Uuid>,
+    pub project_id: Option<Uuid>,
+    pub title: String,
+    pub content: String,
+    pub rationale: Option<String>,
+    /// `[{"option": "...", "rejected_reason": "..."}]`
+    pub alternatives: Option<Vec<Value>>,
+    pub scope: Option<String>,
+    pub confidence: Option<f64>,
+    pub supersedes: Option<Uuid>,
+    pub category: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub session_id: Option<String>,
+}
+
+/// Body for `POST /memory/decisions/:id/actions`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct DecisionActionParams {
+    /// `supersede` | `dispute` | `verify` | `invalidate` | `choose_successor`
+    pub action: String,
+    pub successor_id: Option<Uuid>,
+    pub reason: Option<String>,
+    pub title: Option<String>,
+}
+
+/// Valid `action` values for [`DecisionActionParams`].
+pub const DECISION_ACTIONS: &[&str] = &[
+    "supersede",
+    "dispute",
+    "verify",
+    "invalidate",
+    "choose_successor",
+];
+
+/// Query parameters for `GET /lessons`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ListLessonsParams {
+    pub workspace_id: Option<Uuid>,
+    pub project_id: Option<Uuid>,
+    pub query: Option<String>,
+    pub severity: Option<Vec<String>>,
+    pub min_severity: Option<String>,
+    pub category: Option<String>,
+    pub keywords: Option<Vec<String>>,
+    pub scope: Option<String>,
+    pub include_superseded: Option<bool>,
+    pub since: Option<String>,
+    pub sort: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+/// Body for `POST /lessons`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct CreateLessonParams {
+    pub workspace_id: Option<Uuid>,
+    pub project_id: Option<Uuid>,
+    pub title: String,
+    pub trigger: String,
+    pub impact: String,
+    pub prevention: String,
+    pub severity: Option<String>,
+    pub category: Option<String>,
+    pub keywords: Option<Vec<String>>,
+}
+
+/// Body for `PATCH /lessons/:id`. Every field is optional.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateLessonParams {
+    pub title: Option<String>,
+    pub trigger: Option<String>,
+    pub impact: Option<String>,
+    pub prevention: Option<String>,
+    pub severity: Option<String>,
+    pub category: Option<String>,
+    pub keywords: Option<Vec<String>>,
+}
+
+impl UpdateLessonParams {
+    pub fn is_empty(&self) -> bool {
+        self.title.is_none()
+            && self.trigger.is_none()
+            && self.impact.is_none()
+            && self.prevention.is_none()
+            && self.severity.is_none()
+            && self.category.is_none()
+            && self.keywords.is_none()
+    }
+}
+
+fn push_param(params: &mut Vec<String>, key: &str, value: Option<&str>) {
+    if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
+        params.push(format!("{key}={}", urlencoding::encode(value)));
+    }
+}
+
+/// Wrap a legacy decision array into the `decisions.v1` envelope shape so
+/// every consumer sees one contract. The synthesised envelope carries an
+/// explicit `degraded` entry and `legacy_array: true`; it never fabricates
+/// `status` / `freshness` / `source` on the items.
+pub fn normalize_decisions_envelope(raw: Value, sort: Option<&str>) -> Value {
+    match raw {
+        Value::Array(items) => {
+            let total = items.len();
+            serde_json::json!({
+                "items": items,
+                "total": total,
+                "next_offset": Value::Null,
+                "sort": sort.unwrap_or("relevance"),
+                "scope": Value::Null,
+                "degraded": [{
+                    "source": "decisions_envelope",
+                    "detail": "server returned the legacy decision array; status, freshness, and source fields are unavailable"
+                }],
+                "legacy_array": true,
+            })
+        }
+        Value::Object(mut object) => {
+            if !object.contains_key("items") {
+                let items = object
+                    .remove("results")
+                    .or_else(|| object.remove("decisions"))
+                    .unwrap_or_else(|| Value::Array(Vec::new()));
+                object.insert("items".to_string(), items);
+            }
+            if !object.contains_key("degraded") {
+                object.insert("degraded".to_string(), Value::Array(Vec::new()));
+            }
+            if !object.contains_key("schema_version") {
+                object.insert("legacy_array".to_string(), Value::Bool(true));
+                if let Some(Value::Array(degraded)) = object.get_mut("degraded") {
+                    degraded.push(serde_json::json!({
+                        "source": "decisions_envelope",
+                        "detail": "server response carried no decisions.v1 schema_version; typed fields may be missing"
+                    }));
+                }
+            }
+            Value::Object(object)
+        }
+        other => serde_json::json!({
+            "items": [],
+            "total": 0,
+            "degraded": [{
+                "source": "decisions_envelope",
+                "detail": format!("unexpected decisions payload shape: {}", other)
+            }],
+            "legacy_array": true,
+        }),
+    }
+}
+
+impl ContextStreamClient {
+    /// `GET /memory/decisions?…&format=envelope`.
+    ///
+    /// Returns the `decisions.v1` envelope. Servers that still answer with
+    /// the legacy array are normalised through
+    /// [`normalize_decisions_envelope`] (with a `degraded` entry) so tools
+    /// can render `[PARTIAL]` instead of guessing.
+    pub async fn list_decisions_envelope(&self, params: ListDecisionsParams) -> Result<Value> {
+        let config = self.config().await;
+        let (ws_id, proj_id) =
+            scope_ids_with_defaults(params.workspace_id, params.project_id, &config);
+        let ws_id = ws_id.ok_or_else(|| {
+            mcp_types::Error::Validation("workspace_id is required for decisions".to_string())
+        })?;
+
+        let mut query = vec![format!("workspace_id={ws_id}")];
+        if let Some(id) = proj_id {
+            query.push(format!("project_id={id}"));
+        }
+        push_param(&mut query, "query", params.query.as_deref());
+        push_param(&mut query, "category", params.category.as_deref());
+        push_param(&mut query, "sort", params.sort.as_deref());
+        push_param(&mut query, "status", params.status.as_deref());
+        push_param(&mut query, "since", params.since.as_deref());
+        push_param(&mut query, "source", params.source.as_deref());
+        if let Some(offset) = params.offset {
+            query.push(format!("offset={offset}"));
+        }
+        if let Some(limit) = params.limit {
+            query.push(format!("limit={limit}"));
+        }
+        query.push("format=envelope".to_string());
+
+        let raw: Value = self
+            .get(&format!("/memory/decisions?{}", query.join("&")))
+            .await?;
+        Ok(normalize_decisions_envelope(raw, params.sort.as_deref()))
+    }
+
+    /// `POST /memory/decisions` — typed decision create.
+    pub async fn create_decision(&self, params: CreateDecisionParams) -> Result<Value> {
+        let config = self.config().await;
+        let (ws_id, proj_id) =
+            scope_ids_with_defaults(params.workspace_id, params.project_id, &config);
+        let ws_id = ws_id.ok_or_else(|| {
+            mcp_types::Error::Validation(
+                "workspace_id is required to create a decision. Run init first.".to_string(),
+            )
+        })?;
+        let body = strip_nulls(serde_json::json!({
+            "workspace_id": ws_id,
+            "project_id": proj_id,
+            "title": params.title,
+            "content": params.content,
+            "rationale": params.rationale,
+            "alternatives": params.alternatives,
+            "scope": params.scope,
+            "confidence": params.confidence,
+            "supersedes": params.supersedes,
+            "category": params.category,
+            "tags": params.tags,
+            "session_id": params.session_id,
+        }));
+        let result = self.post("/memory/decisions", body).await?;
+        self.invalidate_memory_read_caches();
+        Ok(result)
+    }
+
+    /// `POST /memory/decisions/:id/actions`.
+    pub async fn decision_action(
+        &self,
+        decision_id: Uuid,
+        params: DecisionActionParams,
+    ) -> Result<Value> {
+        let body = strip_nulls(serde_json::json!({
+            "action": params.action,
+            "successor_id": params.successor_id,
+            "reason": params.reason,
+            "title": params.title,
+        }));
+        let result = self
+            .post(&format!("/memory/decisions/{decision_id}/actions"), body)
+            .await?;
+        self.invalidate_memory_read_caches();
+        Ok(result)
+    }
+
+    /// `GET /memory/decisions/:id/trace`.
+    pub async fn get_decision_trace(&self, decision_id: Uuid) -> Result<Value> {
+        self.get(&format!("/memory/decisions/{decision_id}/trace"))
+            .await
+    }
+
+    /// Events-era supersede link (`POST /memory/nodes/:id/supersede`) used
+    /// as the fallback for `decision_action(action="supersede")` when the
+    /// typed decisions endpoint is absent.
+    pub async fn link_node_superseded_by(
+        &self,
+        node_id: Uuid,
+        successor_id: Uuid,
+    ) -> Result<Value> {
+        let result = self
+            .post(
+                &format!("/memory/nodes/{node_id}/supersede"),
+                serde_json::json!({ "superseded_by": successor_id }),
+            )
+            .await?;
+        self.invalidate_memory_read_caches();
+        Ok(result)
+    }
+
+    /// `GET /lessons?…&format=envelope` → `lessons.v1` envelope.
+    pub async fn list_lessons(&self, params: ListLessonsParams) -> Result<Value> {
+        let config = self.config().await;
+        let (ws_id, proj_id) =
+            scope_ids_with_defaults(params.workspace_id, params.project_id, &config);
+        let mut query = Vec::new();
+        if let Some(id) = ws_id {
+            query.push(format!("workspace_id={id}"));
+        }
+        if let Some(id) = proj_id {
+            query.push(format!("project_id={id}"));
+        }
+        push_param(&mut query, "query", params.query.as_deref());
+        for severity in params.severity.iter().flatten() {
+            push_param(&mut query, "severity[]", Some(severity));
+        }
+        push_param(&mut query, "min_severity", params.min_severity.as_deref());
+        push_param(&mut query, "category", params.category.as_deref());
+        for keyword in params.keywords.iter().flatten() {
+            push_param(&mut query, "keywords[]", Some(keyword));
+        }
+        push_param(&mut query, "scope", params.scope.as_deref());
+        if let Some(include) = params.include_superseded {
+            query.push(format!("include_superseded={include}"));
+        }
+        push_param(&mut query, "since", params.since.as_deref());
+        push_param(&mut query, "sort", params.sort.as_deref());
+        if let Some(limit) = params.limit {
+            query.push(format!("limit={limit}"));
+        }
+        if let Some(offset) = params.offset {
+            query.push(format!("offset={offset}"));
+        }
+        query.push("format=envelope".to_string());
+        self.get(&format!("/lessons?{}", query.join("&"))).await
+    }
+
+    /// `GET /lessons/:id`.
+    pub async fn get_lesson(&self, lesson_id: Uuid) -> Result<Value> {
+        self.get(&format!("/lessons/{lesson_id}")).await
+    }
+
+    /// `POST /lessons`.
+    pub async fn create_lesson(&self, params: CreateLessonParams) -> Result<Value> {
+        let config = self.config().await;
+        let (ws_id, proj_id) =
+            scope_ids_with_defaults(params.workspace_id, params.project_id, &config);
+        let body = strip_nulls(serde_json::json!({
+            "workspace_id": ws_id,
+            "project_id": proj_id,
+            "title": params.title,
+            "trigger": params.trigger,
+            "impact": params.impact,
+            "prevention": params.prevention,
+            "severity": params.severity,
+            "category": params.category,
+            "keywords": params.keywords,
+        }));
+        let result = self.post("/lessons", body).await?;
+        self.invalidate_memory_read_caches();
+        Ok(result)
+    }
+
+    /// `PATCH /lessons/:id`.
+    pub async fn update_lesson(
+        &self,
+        lesson_id: Uuid,
+        params: UpdateLessonParams,
+    ) -> Result<Value> {
+        let body = strip_nulls(serde_json::to_value(&params).unwrap_or(Value::Null));
+        let result = self.patch(&format!("/lessons/{lesson_id}"), body).await?;
+        self.invalidate_memory_read_caches();
+        Ok(result)
+    }
+
+    /// `POST /lessons/:id/supersede` with either `{successor_id}` or the
+    /// replacement lesson fields.
+    pub async fn supersede_lesson(&self, lesson_id: Uuid, body: Value) -> Result<Value> {
+        let result = self
+            .post(
+                &format!("/lessons/{lesson_id}/supersede"),
+                strip_nulls(body),
+            )
+            .await?;
+        self.invalidate_memory_read_caches();
+        Ok(result)
+    }
+
+    /// `DELETE /lessons/:id`.
+    pub async fn delete_lesson(&self, lesson_id: Uuid) -> Result<Value> {
+        let result = self.delete(&format!("/lessons/{lesson_id}")).await?;
+        self.invalidate_memory_read_caches();
+        Ok(result)
+    }
+
+    /// `GET /lessons/warnings?user_message=` → `{items:[{lesson, relevance, reason}], rule, degraded}`.
+    pub async fn lessons_warnings(
+        &self,
+        workspace_id: Option<Uuid>,
+        project_id: Option<Uuid>,
+        user_message: &str,
+        limit: Option<i64>,
+    ) -> Result<Value> {
+        let config = self.config().await;
+        let (ws_id, proj_id) = scope_ids_with_defaults(workspace_id, project_id, &config);
+        let mut query = Vec::new();
+        push_param(&mut query, "user_message", Some(user_message));
+        if let Some(id) = ws_id {
+            query.push(format!("workspace_id={id}"));
+        }
+        if let Some(id) = proj_id {
+            query.push(format!("project_id={id}"));
+        }
+        if let Some(limit) = limit {
+            query.push(format!("limit={limit}"));
+        }
+        self.get(&format!("/lessons/warnings?{}", query.join("&")))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn legacy_array_is_wrapped_with_degraded_entry() {
+        let wrapped = normalize_decisions_envelope(json!([{"id": "a"}]), Some("recency"));
+        assert_eq!(wrapped["items"].as_array().map(Vec::len), Some(1));
+        assert_eq!(wrapped["total"], 1);
+        assert_eq!(wrapped["sort"], "recency");
+        assert_eq!(wrapped["legacy_array"], true);
+        assert_eq!(wrapped["degraded"][0]["source"], "decisions_envelope");
+        // No typed fields are invented on the item.
+        assert!(wrapped["items"][0].get("status").is_none());
+    }
+
+    #[test]
+    fn envelope_passes_through_untouched() {
+        let envelope = json!({
+            "items": [{"id": "a", "status": "active"}],
+            "total": 1,
+            "degraded": [],
+            "schema_version": "decisions.v1"
+        });
+        let normalized = normalize_decisions_envelope(envelope.clone(), None);
+        assert_eq!(normalized, envelope);
+    }
+
+    #[test]
+    fn object_without_schema_version_is_marked_legacy() {
+        let normalized = normalize_decisions_envelope(json!({"results": [{"id": "a"}]}), None);
+        assert_eq!(normalized["items"].as_array().map(Vec::len), Some(1));
+        assert_eq!(normalized["legacy_array"], true);
+        assert_eq!(normalized["degraded"].as_array().map(Vec::len), Some(1));
+    }
+}

--- a/crates/mcp-model-registry/src/lib.rs
+++ b/crates/mcp-model-registry/src/lib.rs
@@ -107,6 +107,7 @@ pub enum KnownEditor {
     ChatGPTGateway,
     OpenAIResponses,
     ContextStreamCli,
+    ContextCode,
     Other,
 }
 
@@ -127,6 +128,7 @@ impl KnownEditor {
             Self::ChatGPTGateway => Some(HarnessId::ChatGptGateway),
             Self::OpenAIResponses => Some(HarnessId::OpenAiResponses),
             Self::ContextStreamCli => Some(HarnessId::ContextStreamCli),
+            Self::ContextCode => Some(HarnessId::ContextCode),
             Self::Other => None,
         }
     }
@@ -153,6 +155,7 @@ impl From<HarnessId> for KnownEditor {
             HarnessId::ChatGptGateway => Self::ChatGPTGateway,
             HarnessId::OpenAiResponses => Self::OpenAIResponses,
             HarnessId::ContextStreamCli => Self::ContextStreamCli,
+            HarnessId::ContextCode => Self::ContextCode,
         }
     }
 }

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -2354,6 +2354,10 @@ mod tests {
         "memory_create_event",
         "memory_create_task",
         "memory_create_todo",
+        // Wave 3b: the typed decisions read alias joined the consolidated
+        // surface. It was already registered but unreachable in the default
+        // (consolidated) mode, so no client loses a tool by this addition.
+        "memory_decisions",
         "memory_delete_doc",
         "memory_update_doc",
         "memory_update_task",
@@ -2410,8 +2414,11 @@ mod tests {
             "30f657e3f262c2fde96ce544d7dc78e3446a51dce8eebe19c6f5051793ba62e9",
         ),
         (
+            // Advanced in Wave 4b: `kind` became a validated enum
+            // (decision|constraint|warning|insight|blocker|request|handoff|note)
+            // so an invalid kind fails client-side instead of round-tripping.
             "coordination",
-            "e943310bd255e0b99063e09c232fff3e6a00c537f4d0191eb2fc668f33f57934",
+            "54c1a6f6df03f8c9d4c78538d7e4d82e24d61219eac2469d4add36ca9305a5ea",
         ),
         (
             "entity",
@@ -2448,8 +2455,13 @@ mod tests {
             "00334ef5436ef083b374795f098791bb29e4fdffe7bf4bf252c92c05cf7ca13d",
         ),
         (
+            // Advanced in Wave 3b: additive typed-decision inputs (sort,
+            // status, since, offset, source, rationale, alternatives,
+            // confidence, supersedes, decision_id, decision_action,
+            // successor_id) plus the `create_decision` / `decision_action`
+            // enum values. Every earlier field and action still accepted.
             "memory",
-            "e2b4682203559a4240f4980ac2571a52edcbaaefee8adf575ba2510e2424b3f6",
+            "7375ce8d9fb71cdb92141dc119db3e765cca73118ec740a493487b73b55f850f",
         ),
         (
             "memory_complete_todo",
@@ -2470,6 +2482,12 @@ mod tests {
         (
             "memory_create_todo",
             "ecd98039e145cbc1dd0815eb506a8ad66216398e38b436c067ee556380cf18fa",
+        ),
+        (
+            // New row in Wave 3b: `memory_decisions` was registered but
+            // unreachable in consolidated mode; it now reaches the surface.
+            "memory_decisions",
+            "f06803e365519667ae3a0aadc7d99b5e66203eb7c1013cc2392f5529e7e2c377",
         ),
         (
             "memory_delete_doc",
@@ -2500,8 +2518,11 @@ mod tests {
             "2a4168ef3625b67f01478562408bdacb6400c66ee6a23d8cf6ecfb2df3dba336",
         ),
         (
+            // Advanced in Wave 3b: additive inputs (successor_id, rationale,
+            // alternatives, scope, confidence, supersedes) plus the
+            // `supersede_lesson` action value. Additive only.
             "session",
-            "eba8ac7837f0d9a82a13928ac4f893307a2c4cd579e82cbf53525eaa54a7dcda",
+            "88135dfe81003211efaba8987e9a29d80ba2666b46ce5625cad352c75beeef39",
         ),
         (
             "session_capture",
@@ -2646,7 +2667,12 @@ mod tests {
     #[test]
     fn surface_name_manifests_match_the_v0_5_62_compatibility_baseline() {
         let broad = contextstream_tools_list(&test_registry(Config::default()), None);
-        assert_eq!(listed_names(&broad), V0_5_62_BROAD_TOOL_NAMES);
+        let broad_names = listed_names(&broad);
+        if broad_names != V0_5_62_BROAD_TOOL_NAMES {
+            // Printed so a deliberate baseline update can be copied verbatim.
+            eprintln!("BROAD_TOOL_NAMES actual = {broad_names:#?}");
+        }
+        assert_eq!(broad_names, V0_5_62_BROAD_TOOL_NAMES);
 
         let router = contextstream_tools_list(
             &test_registry(Config {
@@ -2683,6 +2709,14 @@ mod tests {
             .iter()
             .map(|(name, hash)| (*name, (*hash).to_string()))
             .collect();
+        if actual != expected {
+            // Printed so a deliberate baseline update can be copied verbatim.
+            for (name, hash) in &actual {
+                if !expected.iter().any(|(n, h)| n == name && h == hash) {
+                    eprintln!("SCHEMA_CONTRACT changed: (\"{name}\", \"{hash}\"),");
+                }
+            }
+        }
         assert_eq!(actual, expected);
     }
 

--- a/crates/mcp-server/src/setup/editors.rs
+++ b/crates/mcp-server/src/setup/editors.rs
@@ -123,7 +123,8 @@ impl Editor {
             HarnessId::OpenCode => Some(Editor::OpenCode),
             HarnessId::ChatGptGateway
             | HarnessId::OpenAiResponses
-            | HarnessId::ContextStreamCli => None,
+            | HarnessId::ContextStreamCli
+            | HarnessId::ContextCode => None,
         }
     }
 
@@ -1043,6 +1044,7 @@ mod tests {
             HarnessId::ChatGptGateway,
             HarnessId::OpenAiResponses,
             HarnessId::ContextStreamCli,
+            HarnessId::ContextCode,
         ] {
             assert_eq!(Editor::from_harness_id(harness), None);
         }

--- a/crates/mcp-server/src/setup/rules.rs
+++ b/crates/mcp-server/src/setup/rules.rs
@@ -1410,7 +1410,7 @@ fn generate_bootstrap_rules(editor: &Editor, workspace_name: &str, workspace_id:
 
 **Indexing:** Keep the editor connected to hosted MCP. `project(action="index")` asks the hosted service to refresh the exact registered checkout through ContextStream's managed sync bridge; editor hooks and ContextStream Desktop are additional local-ingest paths. A `requires_sync_bridge` response means the bridge is offline, unregistered, or has no matching checkout — repair setup/bridge health and retry without switching the editor to a local MCP transport. `project(action="ingest_local", path="<folder>")` is an optional direct path only when this process can already read the folder. Check `project(action="index_status")` for checkout-aware freshness.
 
-**Notices:** [GROUNDING] → read ranked prior-work hits before code search and inspect freshness before relying on time-sensitive decisions/transcripts/plans | [GROUNDING_AVAILABLE] → hook reminder that unread grounding exists; inspect source age and refresh stale hits before planning or implementing | [PROJECT_ROUTING] → resolve ambiguous/missing project scope before project-scoped search, indexing, memory, session, skill, or capture writes | [MATCHED_SKILLS] → run surfaced skills before other work | [LESSONS_WARNING] → apply lessons immediately and keep them active for the turn | [COORDINATION] → read shared-awareness notices from other live agents before continuing; ack via `coordination(action="ack")`; do not treat as a handoff | [PREFERENCE] → follow user preferences | [RULES_NOTICE] → run `generate_rules()` | [VERSION_NOTICE/CRITICAL] → tell user about update
+**Notices:** [GROUNDING] → read ranked prior-work hits before code search and inspect freshness before relying on time-sensitive decisions/transcripts/plans | [GROUNDING_AVAILABLE] → hook reminder that unread grounding exists; inspect source age and refresh stale hits before planning or implementing | [PROJECT_ROUTING] → resolve ambiguous/missing project scope before project-scoped search, indexing, memory, session, skill, or capture writes | [MATCHED_SKILLS] → run surfaced skills before other work | [LESSONS_WARNING] → apply lessons immediately and keep them active for the turn | [COORDINATION] → read shared-awareness notices from other live agents before continuing; ack via `coordination(action="ack")`; do not treat as a handoff | [PREFERENCE] → follow user preferences | [RULES_NOTICE] → run `contextstream-mcp update` in a terminal to refresh installed rules (help(action="editor_rules") previews them) | [VERSION_NOTICE/CRITICAL] → tell user about update
 {end}
 "#,
         start = CONTEXTSTREAM_START,
@@ -1473,7 +1473,7 @@ fn generate_minimal_rules(editor: &Editor, workspace_name: &str, workspace_id: &
 - `[MATCHED_SKILLS]` → Run the surfaced skills before other work
 - `[LESSONS_WARNING]` → Apply the lessons shown immediately and keep them active for the current task
 - `[PREFERENCE]` → Follow user preferences exactly
-- `[RULES_NOTICE]` → Run `generate_rules()` to update rules
+- `[RULES_NOTICE]` → Run `contextstream-mcp update` in a terminal to refresh installed rules; `help(action="editor_rules")` previews the content
 - `[VERSION_NOTICE]` → Inform user about available updates
 
 ## System Reminders
@@ -1545,7 +1545,7 @@ fn generate_full_rules(editor: &Editor, workspace_name: &str, workspace_id: &str
 - `[MATCHED_SKILLS]` → Run the surfaced skills before other work
 - `[LESSONS_WARNING]` → Apply the lessons shown immediately and keep them active for the current task
 - `[PREFERENCE]` → Follow user preferences exactly
-- `[RULES_NOTICE]` → Run `generate_rules()` to update rules
+- `[RULES_NOTICE]` → Run `contextstream-mcp update` in a terminal to refresh installed rules; `help(action="editor_rules")` previews the content
 - `[VERSION_NOTICE]` → Inform user about available updates
 
 ## System Reminders

--- a/crates/mcp-server/tests/integration_tests.rs
+++ b/crates/mcp-server/tests/integration_tests.rs
@@ -177,6 +177,103 @@ fn create_test_registry() -> mcp_tools::ToolRegistry {
 }
 
 // ============================================================================
+// Notice conformance
+// ============================================================================
+
+mod notice_conformance_tests {
+    use super::*;
+
+    /// Every tool named in any `[NOTICE]` text must exist on the MCP surface.
+    /// Guards against phantom actions such as the former `generate_rules()`.
+    #[test]
+    fn every_tool_named_in_a_notice_is_registered() {
+        let config = mcp_types::config::Config {
+            api_url: "http://127.0.0.1:9".to_string(),
+            consolidated_mode: false,
+            toolset: mcp_types::config::Toolset::Complete,
+            ..Default::default()
+        };
+        let client = mcp_client::ContextStreamClient::new(config.clone());
+        let session = Arc::new(mcp_session::SessionManager::new(
+            client.clone(),
+            config.clone(),
+        ));
+        let mut registry = mcp_tools::ToolRegistry::new(&config);
+        let index_keeper = Arc::new(mcp_tools::domains::index_keeper::IndexKeeper::new(
+            client.clone(),
+            session.clone(),
+            mcp_types::atlas_layer::noop_layer(),
+            mcp_types::acceleration_layer::noop_acceleration_layer(),
+        ));
+        mcp_tools::domains::session::register_session_tools(
+            &mut registry,
+            client.clone(),
+            session.clone(),
+            index_keeper.clone(),
+        );
+        mcp_tools::domains::search::register_search_tools(
+            &mut registry,
+            client.clone(),
+            session.clone(),
+            index_keeper,
+        );
+        mcp_tools::domains::memory::register_memory_tools(
+            &mut registry,
+            client.clone(),
+            session.clone(),
+        );
+        mcp_tools::domains::graph::register_graph_tools(
+            &mut registry,
+            client.clone(),
+            session.clone(),
+        );
+        mcp_tools::domains::entity::register_entity_tools(
+            &mut registry,
+            client.clone(),
+            session.clone(),
+        );
+        mcp_tools::domains::capsule::register_capsule_tools(&mut registry, client.clone());
+        mcp_tools::domains::coordination::register_coordination_tools(
+            &mut registry,
+            client.clone(),
+        );
+        mcp_tools::domains::help::register_help_tools(&mut registry, client.clone());
+        let registered: std::collections::HashSet<String> =
+            registry.names().into_iter().map(str::to_string).collect();
+
+        let mut templates = mcp_tools::notices::notice_templates();
+        // Grounding hints reference tools too; render one hit of each kind.
+        let recall = serde_json::json!({"results": [
+            {"score": 0.9, "metadata": {"title": "Old target", "event_type": "decision", "occurred_at": "2000-01-01T00:00:00Z"}},
+            {"score": 0.9, "id": "11111111-1111-4111-8111-111111111111", "metadata": {"title": "Runbook", "original_type": "doc"}},
+            {"score": 0.9, "metadata": {"title": "Prior session", "original_type": "transcript", "transcript_id": "22222222-2222-4222-8222-222222222222"}}
+        ]});
+        let hits = mcp_tools::domains::grounding::parse_recall_results_normalized(recall);
+        templates.push(mcp_tools::domains::grounding::format_grounding_block(
+            &hits, true,
+        ));
+        templates.push(mcp_tools::domains::grounding::format_grounding_block(
+            &hits, false,
+        ));
+
+        let mut checked = 0;
+        for template in templates {
+            for tool in mcp_tools::notices::notice_tool_names(&template) {
+                checked += 1;
+                assert!(
+                    registered.contains(&tool),
+                    "notice names unregistered tool `{tool}` in: {template}"
+                );
+            }
+        }
+        assert!(
+            checked >= 6,
+            "expected notice tool references, checked {checked}"
+        );
+    }
+}
+
+// ============================================================================
 // Authentication Tests
 // ============================================================================
 

--- a/crates/mcp-tools/src/domains/coordination.rs
+++ b/crates/mcp-tools/src/domains/coordination.rs
@@ -18,6 +18,23 @@ const VALID_ACTIONS: &[&str] = &[
     "check_in", "inbox", "list", "get", "share", "ack", "dismiss", "settings",
 ];
 
+/// Coordination item kinds accepted by `POST /coordinations`. Validated
+/// client-side so a typo fails fast instead of round-tripping a 4xx.
+pub const VALID_KINDS: &[&str] = &[
+    "decision",
+    "constraint",
+    "warning",
+    "insight",
+    "blocker",
+    "request",
+    "handoff",
+    "note",
+];
+
+/// Default number of `[COORDINATION]` lines rendered by `context()` /
+/// `session(action="ground")` before the `… N more` trailer.
+pub const NOTICE_RENDER_LIMIT: usize = 5;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CoordinationInput {
     pub action: String,
@@ -138,11 +155,12 @@ impl ToolHandler for CoordinationTool {
                 let title = input
                     .title
                     .ok_or_else(|| Error::Validation("title is required for share".into()))?;
+                let kind = validate_kind(input.kind.as_deref())?;
                 let mut body = serde_json::json!({
                     "title": title,
                     "summary": input.summary,
                     "why_it_matters": input.why_it_matters,
-                    "kind": input.kind.unwrap_or_else(|| "knowledge".into()),
+                    "kind": kind,
                     "workspace_id": workspace_id,
                     "project_id": project_id,
                     "created_by": "agent",
@@ -250,9 +268,10 @@ impl ToolHandler for CoordinationTool {
                 "Why another workspace/project needs this.",
                 false,
             )
-            .string(
+            .string_enum(
                 "kind",
-                "decision | constraint | api_contract | risk | status | knowledge",
+                "Kind of shared item (defaults to note).",
+                VALID_KINDS,
                 false,
             )
             .array(
@@ -293,6 +312,95 @@ fn coordination_id(value: &Value) -> Option<&str> {
     payload.get("id").and_then(Value::as_str)
 }
 
+/// Validate a `kind` for `share`; `None` defaults to `note`.
+pub fn validate_kind(kind: Option<&str>) -> Result<String> {
+    let kind = kind.map(str::trim).filter(|value| !value.is_empty());
+    match kind {
+        None => Ok("note".to_string()),
+        Some(value) => {
+            let normalized = value.to_ascii_lowercase();
+            if VALID_KINDS.contains(&normalized.as_str()) {
+                Ok(normalized)
+            } else {
+                Err(Error::Validation(format!(
+                    "Invalid coordination kind '{value}'. Use one of: {}",
+                    VALID_KINDS.join(", ")
+                )))
+            }
+        }
+    }
+}
+
+fn notice_project_id(notice: &Value) -> Option<Uuid> {
+    ["from_project_id", "project_id", "source_project_id"]
+        .iter()
+        .find_map(|field| notice.get(*field).and_then(Value::as_str))
+        .and_then(|raw| Uuid::parse_str(raw).ok())
+}
+
+/// Render `[COORDINATION]` lines for an inbox payload.
+///
+/// * At most `limit` notices are rendered; the rest collapse into a
+///   `… N more` trailer (using `total_pending` when the server reports it).
+/// * Notices from another project are prefixed `[other project]`.
+/// * The lines only *describe* the manual ack call. Nothing here (or in any
+///   caller) acks a notice automatically.
+pub fn format_coordination_notices(
+    inbox: &Value,
+    current_project_id: Option<Uuid>,
+    limit: usize,
+) -> String {
+    let payload = inbox_payload(inbox);
+    let notices = inbox_notices(inbox);
+    if notices.is_empty() {
+        return String::new();
+    }
+    let limit = limit.max(1);
+    let mut text = String::new();
+    for notice in notices.iter().take(limit) {
+        let reason = notice
+            .get("reason")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| notice.get("title").and_then(Value::as_str))
+            .unwrap_or("shared context");
+        let id = notice.get("id").and_then(Value::as_str).unwrap_or_default();
+        let other_project = match (notice_project_id(notice), current_project_id) {
+            (Some(from), Some(current)) => from != current,
+            (Some(_), None) => false,
+            (None, _) => false,
+        };
+        text.push_str(&crate::notices::coordination_notice_line(
+            reason,
+            id,
+            other_project,
+            notice.get("urgency").and_then(Value::as_str),
+        ));
+        text.push('\n');
+    }
+    let shown = notices.len().min(limit);
+    let total_pending = payload
+        .get("total_pending")
+        .and_then(Value::as_u64)
+        .map(|value| value as usize);
+    let truncated = payload
+        .get("truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let remaining = match total_pending {
+        Some(total) if total > shown => total - shown,
+        _ if notices.len() > shown => notices.len() - shown,
+        _ if truncated => 1,
+        _ => 0,
+    };
+    if remaining > 0 {
+        text.push_str(&crate::notices::coordination_more_line(remaining));
+        text.push('\n');
+    }
+    text
+}
+
 fn format_inbox(result: &Value) -> String {
     let data = inbox_payload(result);
     let notices = inbox_notices(result);
@@ -305,15 +413,10 @@ fn format_inbox(result: &Value) -> String {
         "Coordination inbox: {} notice(s), {items} item(s).",
         notices.len()
     );
-    for notice in notices.iter().take(5) {
-        let reason = notice
-            .get("reason")
-            .and_then(Value::as_str)
-            .unwrap_or("shared context");
-        let id = notice.get("id").and_then(Value::as_str).unwrap_or_default();
-        text.push_str(&format!(
-            "\n[COORDINATION] {reason} — ack via coordination(action=\"ack\", notice_id=\"{id}\")"
-        ));
+    let rendered = format_coordination_notices(result, None, NOTICE_RENDER_LIMIT);
+    if !rendered.is_empty() {
+        text.push('\n');
+        text.push_str(rendered.trim_end());
     }
     text
 }
@@ -394,6 +497,61 @@ mod tests {
         });
         assert_eq!(inbox_notices(&inbox).len(), 1);
         assert!(format_inbox(&inbox).contains("notice_id=\"n2\""));
+    }
+
+    #[test]
+    fn other_project_notices_are_prefixed_and_never_auto_acked() {
+        let current = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let inbox = json!({
+            "notices": [
+                {"id": "n1", "reason": "Shared decision", "from_project_id": current.to_string()},
+                {"id": "n2", "reason": "Schema freeze", "from_project_id": other.to_string(), "urgency": "high"},
+                {"id": "n3", "reason": "No project on notice"}
+            ]
+        });
+        let text = format_coordination_notices(&inbox, Some(current), 5);
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(
+            lines[0],
+            "[COORDINATION] Shared decision — ack via coordination(action=\"ack\", notice_id=\"n1\")"
+        );
+        assert!(lines[1].starts_with("[COORDINATION] [other project] Schema freeze (urgency=high)"));
+        assert!(!lines[2].contains("[other project]"));
+        // Only the manual ack call is described; no line claims an ack happened.
+        assert!(!text.to_ascii_lowercase().contains("acked"));
+    }
+
+    #[test]
+    fn truncation_trailer_counts_remaining_notices() {
+        let notices: Vec<Value> = (0..7)
+            .map(|index| json!({"id": format!("n{index}"), "reason": format!("reason {index}")}))
+            .collect();
+        let inbox = json!({"notices": notices, "truncated": true, "total_pending": 12});
+        let text = format_coordination_notices(&inbox, None, 5);
+        assert_eq!(text.matches("[COORDINATION]").count(), 6);
+        assert!(text.contains("[COORDINATION] … 7 more"));
+
+        let inbox = json!({"notices": [{"id": "a", "reason": "r"}], "truncated": true});
+        let text = format_coordination_notices(&inbox, None, 5);
+        assert!(text.contains("… 1 more"));
+
+        let inbox = json!({"notices": [{"id": "a", "reason": "r"}]});
+        assert!(!format_coordination_notices(&inbox, None, 5).contains("more"));
+        assert!(format_coordination_notices(&json!({"notices": []}), None, 5).is_empty());
+    }
+
+    #[test]
+    fn share_kind_is_validated_client_side() {
+        assert_eq!(validate_kind(None).unwrap(), "note");
+        assert_eq!(validate_kind(Some("Decision")).unwrap(), "decision");
+        for kind in VALID_KINDS {
+            assert_eq!(validate_kind(Some(kind)).unwrap(), *kind);
+        }
+        let err = validate_kind(Some("knowledge")).unwrap_err().to_string();
+        assert!(err.contains("Invalid coordination kind"));
+        assert!(err.contains("handoff"));
     }
 
     #[test]

--- a/crates/mcp-tools/src/domains/grounding.rs
+++ b/crates/mcp-tools/src/domains/grounding.rs
@@ -26,8 +26,13 @@ pub struct GroundingHit {
     pub source_timestamp: Option<DateTime<Utc>>,
     /// Age in whole days at parse time when a source timestamp exists.
     pub age_days: Option<i64>,
-    /// Whether this hit is time-sensitive and older than the local freshness window.
+    /// Whether this hit is time-sensitive and older than the local freshness window,
+    /// or has been superseded by a newer item.
     pub stale: bool,
+    /// Why the hit is stale: `superseded` (a `superseded_by` link or
+    /// `status=superseded`), `historical_status`, or `aged`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale_reason: Option<String>,
     /// Whether this hit is a prior snapshot/status claim about unfinished or failed work.
     /// These are useful evidence, but must never be treated as current truth without refresh.
     pub historical_status_claim: bool,
@@ -99,6 +104,17 @@ fn original_type(item: &Value) -> Option<String> {
 
 fn event_type(item: &Value) -> Option<String> {
     metadata_str(item, "event_type").map(|s| s.to_ascii_lowercase())
+}
+
+/// A hit whose source carries a `superseded_by` link (or `status=superseded`)
+/// is stale regardless of age: a newer decision/lesson replaced it.
+fn is_superseded(item: &Value) -> bool {
+    if metadata_str(item, "superseded_by").is_some() {
+        return true;
+    }
+    metadata_str(item, "status")
+        .map(|status| status.eq_ignore_ascii_case("superseded"))
+        .unwrap_or(false)
 }
 
 fn metadata_time(item: &Value) -> Option<DateTime<Utc>> {
@@ -332,7 +348,17 @@ pub fn parse_recall_results(recall: &Value) -> Vec<GroundingHit> {
                 .zip(stale_after_days(&kind))
                 .map(|(age, limit)| age > limit)
                 .unwrap_or(false);
-            let stale = historical_status_claim || aged_stale;
+            let superseded = is_superseded(item);
+            let stale = historical_status_claim || aged_stale || superseded;
+            let stale_reason = if superseded {
+                Some("superseded".to_string())
+            } else if historical_status_claim {
+                Some("historical_status".to_string())
+            } else if aged_stale {
+                Some("aged".to_string())
+            } else {
+                None
+            };
             Some(GroundingHit {
                 kind,
                 title,
@@ -344,6 +370,7 @@ pub fn parse_recall_results(recall: &Value) -> Vec<GroundingHit> {
                 source_timestamp,
                 age_days,
                 stale,
+                stale_reason,
                 historical_status_claim,
             })
         })
@@ -384,6 +411,9 @@ fn format_hit_label(hit: &GroundingHit) -> String {
     }
     if hit.stale {
         append_label_part(&mut prefix, "stale-check");
+    }
+    if hit.stale_reason.as_deref() == Some("superseded") {
+        append_label_part(&mut prefix, "superseded");
     }
     if hit.historical_status_claim {
         append_label_part(&mut prefix, "historical-status");
@@ -547,6 +577,8 @@ pub fn format_grounding_block(hits: &[GroundingHit], compact: bool) -> String {
                 out.push_str(
                     " [historical status claim; verify newer work before treating as current]",
                 );
+            } else if hit.stale_reason.as_deref() == Some("superseded") {
+                out.push_str(" [superseded; follow the successor instead]");
             } else if hit.stale {
                 out.push_str(" [verify freshness before relying]");
             }
@@ -571,6 +603,8 @@ pub fn format_grounding_block(hits: &[GroundingHit], compact: bool) -> String {
             ));
             if hit.historical_status_claim {
                 out.push_str("   ! Historical status claim: prior no-output/unexecuted/unanswered evidence only. Verify newer work before treating it as current.\n");
+            } else if hit.stale_reason.as_deref() == Some("superseded") {
+                out.push_str("   ! Superseded: a newer item replaced this one. Use the successor, not this hit.\n");
             } else if hit.stale {
                 out.push_str("   ! Time-sensitive and stale: refresh this source before using it to plan or implement.\n");
             }
@@ -814,6 +848,43 @@ mod tests {
     }
 
     #[test]
+    fn superseded_decision_is_stale_with_reason_even_when_recent() {
+        let today = Utc::now().format("%Y-%m-%dT00:00:00Z").to_string();
+        let recall = json!({
+            "results": [{
+                "score": 0.9,
+                "metadata": {
+                    "title": "Use Postgres for the ledger",
+                    "event_type": "decision",
+                    "occurred_at": today,
+                    "superseded_by": "11111111-1111-4111-8111-111111111111"
+                }
+            }, {
+                "score": 0.8,
+                "id": "22222222-2222-4222-8222-222222222222",
+                "status": "superseded",
+                "metadata": {
+                    "title": "Use Redis for the ledger",
+                    "event_type": "decision",
+                    "occurred_at": today
+                }
+            }]
+        });
+        let hits = parse_recall_results_normalized(recall);
+        assert_eq!(hits.len(), 2);
+        for hit in &hits {
+            assert!(hit.stale, "{hit:?}");
+            assert_eq!(hit.stale_reason.as_deref(), Some("superseded"));
+        }
+        let compact = format_grounding_block(&hits, true);
+        assert!(compact.contains("superseded"));
+        assert!(compact.contains("[superseded; follow the successor instead]"));
+        let serialized = serde_json::to_value(&hits[0]).unwrap();
+        assert_eq!(serialized["stale"], true);
+        assert_eq!(serialized["stale_reason"], "superseded");
+    }
+
+    #[test]
     fn durable_doc_with_old_date_is_not_marked_stale() {
         let recall = json!({
             "results": [{
@@ -854,6 +925,7 @@ mod tests {
             source_timestamp: None,
             age_days: None,
             stale: false,
+            stale_reason: None,
             historical_status_claim: false,
             search_keywords: "Fix auth".to_string(),
         }];
@@ -900,6 +972,7 @@ mod tests {
             source_timestamp: None,
             age_days: None,
             stale: false,
+            stale_reason: None,
             historical_status_claim: false,
             search_keywords: "Prod DB migration runbook".to_string(),
         }];

--- a/crates/mcp-tools/src/domains/memory.rs
+++ b/crates/mcp-tools/src/domains/memory.rs
@@ -28,6 +28,7 @@ use crate::domains::scope::{
 use crate::domains::session::{deserialize_string_or_vec, is_not_found_error};
 use crate::registry::ToolHandler;
 use crate::schema::SchemaBuilder;
+use mcp_client::SessionCaptureParams;
 
 /// Per-process warm cache for `memory(action="search")`. The short TTL
 /// preserves freshness; per-caller and per-entry bounds keep a shared gateway
@@ -965,6 +966,52 @@ fn collect_bulk_delete_matches(
         .into_iter()
         .filter(|m| m.exact)
         .collect()
+}
+
+enum LookupResolution<'a> {
+    None,
+    Single(&'a LookupMatch),
+    Ambiguous,
+}
+
+/// One clear winner (exact id/title, or a score gap above the ambiguity
+/// window) resolves; several close matches are ambiguous.
+fn classify_lookup_resolution(ranked: &[LookupMatch]) -> LookupResolution<'_> {
+    let Some(best) = ranked.first() else {
+        return LookupResolution::None;
+    };
+    let second_score = ranked.get(1).map(|item| item.score).unwrap_or_default();
+    if !best.exact && second_score > 0 && best.score <= second_score + 200 {
+        LookupResolution::Ambiguous
+    } else {
+        LookupResolution::Single(best)
+    }
+}
+
+/// `[CANDIDATES]` result for an ambiguous `supersede_node` lookup. Nothing
+/// is superseded; the agent retries with one of the listed ids.
+fn supersede_candidates_result(lookup: &str, matches: &[LookupMatch]) -> ToolResult {
+    let mut text = format!(
+        "[CANDIDATES] Multiple nodes match \"{lookup}\"; nothing was superseded. Retry supersede_node with node_id set to one of:\n"
+    );
+    let candidates: Vec<Value> = matches
+        .iter()
+        .take(5)
+        .enumerate()
+        .map(|(index, item)| {
+            text.push_str(&format!(
+                "{}. **{}** (id: {})\n",
+                index + 1,
+                item.title,
+                item.id
+            ));
+            serde_json::json!({"id": item.id, "title": item.title, "score": item.score})
+        })
+        .collect();
+    ToolResult::with_structured(
+        text.trim_end().to_string(),
+        serde_json::json!({"resolved": false, "lookup": lookup, "candidates": candidates}),
+    )
 }
 
 fn format_lookup_ambiguity(entity_name: &str, lookup: &str, matches: &[LookupMatch]) -> String {
@@ -2164,6 +2211,672 @@ pub struct MemoryDecisionsInput {
     /// TypeScript uses `category` for filtering decisions; accept both.
     pub category: Option<String>,
     pub limit: Option<i64>,
+    /// `recency` | `relevance` (server default: relevance).
+    #[serde(default)]
+    pub sort: Option<String>,
+    /// `active` | `superseded` | `disputed` | `verified` | `all` (server default: active).
+    #[serde(default)]
+    pub status: Option<String>,
+    /// ISO-8601 lower bound on the decision timestamp.
+    #[serde(default)]
+    pub since: Option<String>,
+    #[serde(default)]
+    pub offset: Option<i64>,
+    #[serde(default)]
+    pub source: Option<String>,
+}
+
+/// Valid `sort` values for the typed decisions listing.
+pub const DECISION_SORTS: &[&str] = &["recency", "relevance"];
+/// Valid `status` filters for the typed decisions listing.
+pub const DECISION_STATUSES: &[&str] = &["active", "superseded", "disputed", "verified", "all"];
+
+fn normalize_decision_sort(raw: Option<&str>) -> Result<Option<String>> {
+    match raw.map(str::trim).filter(|value| !value.is_empty()) {
+        None => Ok(None),
+        Some(value) => {
+            let lower = value.to_ascii_lowercase();
+            if DECISION_SORTS.contains(&lower.as_str()) {
+                Ok(Some(lower))
+            } else {
+                Err(Error::Validation(format!(
+                    "Invalid sort '{value}'. Use one of: {}",
+                    DECISION_SORTS.join(", ")
+                )))
+            }
+        }
+    }
+}
+
+fn normalize_decision_status(raw: Option<&str>) -> Result<Option<String>> {
+    match raw.map(str::trim).filter(|value| !value.is_empty()) {
+        None => Ok(None),
+        Some(value) => {
+            let lower = value.to_ascii_lowercase();
+            if DECISION_STATUSES.contains(&lower.as_str()) {
+                Ok(Some(lower))
+            } else {
+                Err(Error::Validation(format!(
+                    "Invalid status '{value}'. Use one of: {}",
+                    DECISION_STATUSES.join(", ")
+                )))
+            }
+        }
+    }
+}
+
+fn decision_str<'a>(node: &'a Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter().find_map(|key| {
+        node.get(*key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                node.get("metadata")
+                    .and_then(|meta| meta.get(*key))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+            })
+    })
+}
+
+/// Render one `[PARTIAL]` line per `degraded` entry of a typed envelope.
+pub(crate) fn render_degraded_lines(envelope: &Value) -> String {
+    let mut text = String::new();
+    if let Some(entries) = envelope.get("degraded").and_then(Value::as_array) {
+        for entry in entries {
+            let source = entry
+                .get("source")
+                .and_then(Value::as_str)
+                .unwrap_or("server");
+            let detail = entry
+                .get("detail")
+                .and_then(Value::as_str)
+                .or_else(|| entry.get("reason").and_then(Value::as_str))
+                .unwrap_or("degraded");
+            text.push_str(&format!("[PARTIAL] {source}: {detail}\n"));
+        }
+    }
+    text
+}
+
+/// Render the `decisions.v1` envelope as typed `[DECISION]` lines.
+///
+/// Missing typed fields render as `unknown` / `none`; nothing is inferred.
+pub(crate) fn render_decisions_envelope(
+    envelope: &Value,
+    requested_sort: Option<&str>,
+    requested_status: Option<&str>,
+) -> String {
+    let items = envelope
+        .get("items")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let total = envelope
+        .get("total")
+        .and_then(Value::as_u64)
+        .map(|value| value as usize)
+        .unwrap_or(items.len());
+    let sort = envelope
+        .get("sort")
+        .and_then(Value::as_str)
+        .or(requested_sort)
+        .unwrap_or("relevance");
+    let status_filter = requested_status.unwrap_or("active");
+    let mut text = String::new();
+
+    if items.is_empty() {
+        text.push_str(&format!(
+            "No decisions recorded yet (status={status_filter}).\n"
+        ));
+    } else {
+        text.push_str(&format!(
+            "[DECISIONS] {} of {} decision(s) (sort={sort}, status={status_filter}):\n\n",
+            items.len(),
+            total
+        ));
+        for (index, node) in items.iter().enumerate() {
+            let title = extract_display_title(node);
+            let status = decision_str(node, &["status"]).unwrap_or("unknown");
+            let freshness = decision_str(node, &["freshness"]).unwrap_or("unknown");
+            let category = decision_str(node, &["category"]).unwrap_or("none");
+            let id = decision_str(node, &["id", "node_id", "decision_id"]).unwrap_or("unknown");
+            text.push_str(&format!(
+                "{}. [DECISION] {title} — status={status} freshness={freshness} category={category} id={id}\n",
+                index + 1
+            ));
+            if let Some(content) = node
+                .get("content")
+                .or_else(|| node.get("details"))
+                .or_else(|| node.get("description"))
+                .and_then(Value::as_str)
+            {
+                let preview: String = content.chars().take(200).collect();
+                text.push_str(&format!("   {}\n", preview.replace('\n', " ")));
+            }
+            if let Some(rationale) = node
+                .get("structured")
+                .and_then(|value| value.get("rationale"))
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+            {
+                let preview: String = rationale.chars().take(160).collect();
+                text.push_str(&format!("   rationale: {}\n", preview.replace('\n', " ")));
+            }
+            let mut links = Vec::new();
+            if let Some(value) = decision_str(node, &["superseded_by"]) {
+                links.push(format!("superseded_by={value}"));
+            }
+            if let Some(value) = decision_str(node, &["supersedes"]) {
+                links.push(format!("supersedes={value}"));
+            }
+            if let Some(value) = decision_str(node, &["source"]) {
+                links.push(format!("source={value}"));
+            }
+            if let Some(score) = node.get("rank_score").and_then(Value::as_f64) {
+                links.push(format!("rank_score={score:.2}"));
+            }
+            if !links.is_empty() {
+                text.push_str(&format!("   {}\n", links.join(" ")));
+            }
+            let created_at = node
+                .get("created_at")
+                .or_else(|| node.get("createdAt"))
+                .or_else(|| node.get("timestamp"))
+                .or_else(|| node.get("date"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            text.push_str(&format!("   Created: {created_at}\n\n"));
+        }
+        if let Some(next_offset) = envelope.get("next_offset").and_then(Value::as_u64) {
+            text.push_str(&format!(
+                "Next offset: {next_offset} (pass offset={next_offset} to continue).\n"
+            ));
+        }
+    }
+    text.push_str(&render_degraded_lines(envelope));
+    text
+}
+
+// ============================================================================
+// Typed decision create / actions (shared by memory() and session(capture))
+// ============================================================================
+
+/// Input for `memory(action="create_decision")` and the structured route of
+/// `session(action="capture", event_type="decision")`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CreateDecisionInput {
+    pub workspace_id: Option<String>,
+    pub project_id: Option<String>,
+    pub title: String,
+    pub content: Option<String>,
+    pub rationale: Option<String>,
+    /// Strings or `{option, rejected_reason}` objects.
+    pub alternatives: Option<Vec<Value>>,
+    pub scope: Option<String>,
+    pub confidence: Option<f64>,
+    /// Decision id or lookup text of the decision this one replaces.
+    pub supersedes: Option<String>,
+    pub category: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub session_id: Option<String>,
+}
+
+/// Input for `memory(action="decision_action")`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DecisionActionInput {
+    pub workspace_id: Option<String>,
+    pub project_id: Option<String>,
+    /// Decision id or lookup text.
+    pub decision_id: String,
+    /// `supersede` | `dispute` | `verify` | `invalidate` | `choose_successor`
+    pub decision_action: String,
+    /// Successor decision id or lookup text (supersede / choose_successor).
+    pub successor_id: Option<String>,
+    pub reason: Option<String>,
+    /// Title for a successor created inline by the server.
+    pub title: Option<String>,
+}
+
+/// True when any typed decision field is present, which routes a plain
+/// `capture(event_type="decision")` to the typed create endpoint.
+pub fn has_structured_decision_fields(
+    rationale: Option<&str>,
+    alternatives: Option<&[Value]>,
+    scope: Option<&str>,
+    confidence: Option<f64>,
+) -> bool {
+    rationale
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+        || alternatives.is_some_and(|value| !value.is_empty())
+        || scope.map(str::trim).is_some_and(|value| !value.is_empty())
+        || confidence.is_some()
+}
+
+fn normalize_alternatives(raw: &[Value]) -> Vec<Value> {
+    raw.iter()
+        .filter_map(|entry| match entry {
+            Value::String(option) => {
+                let option = option.trim();
+                (!option.is_empty()).then(|| serde_json::json!({ "option": option }))
+            }
+            Value::Object(_) => Some(entry.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn compose_decision_content(
+    content: &str,
+    rationale: Option<&str>,
+    alternatives: &[Value],
+    scope: Option<&str>,
+    confidence: Option<f64>,
+) -> String {
+    let mut text = content.trim().to_string();
+    if let Some(rationale) = rationale.map(str::trim).filter(|value| !value.is_empty()) {
+        text.push_str(&format!("\n\n### Rationale\n{rationale}"));
+    }
+    if !alternatives.is_empty() {
+        text.push_str("\n\n### Alternatives considered");
+        for alternative in alternatives {
+            let option = alternative
+                .get("option")
+                .and_then(Value::as_str)
+                .unwrap_or("(unnamed)");
+            match alternative.get("rejected_reason").and_then(Value::as_str) {
+                Some(reason) if !reason.trim().is_empty() => {
+                    text.push_str(&format!("\n- {option} — rejected: {reason}"))
+                }
+                _ => text.push_str(&format!("\n- {option}")),
+            }
+        }
+    }
+    if let Some(scope) = scope.map(str::trim).filter(|value| !value.is_empty()) {
+        text.push_str(&format!("\n\n**Scope:** {scope}"));
+    }
+    if let Some(confidence) = confidence {
+        text.push_str(&format!("\n**Confidence:** {confidence}"));
+    }
+    text
+}
+
+fn format_decision_candidates(lookup: &str, matches: &[LookupMatch]) -> String {
+    let mut text = format!(
+        "Multiple decisions match \"{}\". Retry with an explicit decision id:\n\n",
+        lookup
+    );
+    for (index, item) in matches.iter().take(5).enumerate() {
+        text.push_str(&format!(
+            "{}. **{}** (id: {})\n",
+            index + 1,
+            item.title,
+            item.id
+        ));
+    }
+    text
+}
+
+/// Resolve a decision id from a UUID or lookup text against the typed
+/// decisions listing (all statuses). A single high-confidence match wins;
+/// several close matches return the candidate list as a validation error.
+pub(crate) async fn resolve_decision_id(
+    client: &ContextStreamClient,
+    workspace_id: Option<Uuid>,
+    project_id: Option<Uuid>,
+    lookup: &str,
+) -> Result<(Uuid, Option<String>)> {
+    let lookup = lookup.trim();
+    if let Ok(id) = Uuid::parse_str(lookup) {
+        return Ok((id, None));
+    }
+    if lookup.is_empty() {
+        return Err(Error::Validation("decision_id is required".to_string()));
+    }
+    let envelope = client
+        .list_decisions_envelope(mcp_client::ListDecisionsParams {
+            workspace_id,
+            project_id,
+            query: Some(lookup.to_string()),
+            status: Some("all".to_string()),
+            limit: Some(25),
+            ..Default::default()
+        })
+        .await?;
+    let items = envelope
+        .get("items")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let ranked = rank_lookup_matches(&items, lookup, &["title", "summary", "name"], 8);
+    let best = ranked.first().ok_or_else(|| {
+        Error::Validation(format!(
+            "No decisions match \"{lookup}\". Use memory(action=\"decisions\", query=\"{lookup}\", status=\"all\") to inspect candidates."
+        ))
+    })?;
+    let second_score = ranked.get(1).map(|item| item.score).unwrap_or_default();
+    if !best.exact && second_score > 0 && best.score <= second_score + 200 {
+        return Err(Error::Validation(format_decision_candidates(
+            lookup, &ranked,
+        )));
+    }
+    let note = (!best.exact).then(|| {
+        format!(
+            "Resolved decision \"{}\" to **{}** (id: {}).",
+            lookup, best.title, best.id
+        )
+    });
+    Ok((best.id, note))
+}
+
+/// Create a typed decision (`POST /memory/decisions`). When the server
+/// answers 404 the decision is stored as a decision event through
+/// `/memory/events` with the structured fields kept in `provenance`, and the
+/// tool text says so with a `[PARTIAL]` line.
+pub async fn execute_create_decision(
+    client: &ContextStreamClient,
+    session: &mcp_session::SessionManager,
+    input: CreateDecisionInput,
+) -> Result<ToolResult> {
+    let title = input.title.trim().to_string();
+    if title.is_empty() {
+        return Err(Error::Validation("title is required".to_string()));
+    }
+    let content = input
+        .content
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            input
+                .rationale
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
+        .ok_or_else(|| Error::Validation("content (or rationale) is required".to_string()))?
+        .to_string();
+
+    let scope = resolve_write_scope(
+        client,
+        session,
+        input.workspace_id.as_deref(),
+        input.project_id.as_deref(),
+    )
+    .await?;
+
+    let alternatives = input
+        .alternatives
+        .as_deref()
+        .map(normalize_alternatives)
+        .filter(|list| !list.is_empty());
+    let supersedes = match input
+        .supersedes
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(lookup) => Some(
+            resolve_decision_id(client, scope.workspace_id, scope.project_id, lookup)
+                .await?
+                .0,
+        ),
+        None => None,
+    };
+    let decision_scope = input
+        .scope
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let params = mcp_client::CreateDecisionParams {
+        workspace_id: scope.workspace_id,
+        project_id: scope.project_id,
+        title: title.clone(),
+        content: content.clone(),
+        rationale: input.rationale.clone(),
+        alternatives: alternatives.clone(),
+        scope: decision_scope.clone(),
+        confidence: input.confidence,
+        supersedes,
+        category: input.category.clone(),
+        tags: input.tags.clone(),
+        session_id: input.session_id.clone(),
+    };
+
+    match client.create_decision(params).await {
+        Ok(mut result) => {
+            let id = result
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+            let mut extras = Vec::new();
+            if let Some(node_id) = result.get("node_id").and_then(Value::as_str) {
+                extras.push(format!("node_id: {node_id}"));
+            }
+            if let Some(event_id) = result.get("event_id").and_then(Value::as_str) {
+                extras.push(format!("event_id: {event_id}"));
+            }
+            let deduplicated = result
+                .get("deduplicated")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let mut text = format!("Decision recorded: {title} (id: {id}");
+            if !extras.is_empty() {
+                text.push_str(&format!(", {}", extras.join(", ")));
+            }
+            text.push(')');
+            if deduplicated {
+                text.push_str(" — deduplicated against an existing decision");
+            }
+            text.push_str(".\nProgress: completed.");
+            if let Some(obj) = result.as_object_mut() {
+                obj.insert(
+                    "operation_status".to_string(),
+                    serde_json::json!({"operation": "create_decision", "state": "completed"}),
+                );
+            }
+            let mut output = ToolResult::with_structured(text, result);
+            if let Some(note) = scope.note {
+                output = output.with_prefix(format!("{note}\n"));
+            }
+            Ok(output)
+        }
+        Err(err) if is_not_found_error(&err) => {
+            let alternatives_list = alternatives.clone().unwrap_or_default();
+            let composed = compose_decision_content(
+                &content,
+                input.rationale.as_deref(),
+                &alternatives_list,
+                decision_scope.as_deref(),
+                input.confidence,
+            );
+            let structured = serde_json::json!({
+                "rationale": input.rationale,
+                "alternatives": alternatives,
+                "scope": decision_scope,
+                "confidence": input.confidence,
+                "supersedes": supersedes,
+                "category": input.category,
+            });
+            let capture = client
+                .session_capture(SessionCaptureParams {
+                    workspace_id: scope.workspace_id,
+                    project_id: scope.project_id,
+                    event_type: Some("decision".to_string()),
+                    title: title.clone(),
+                    content: composed,
+                    tags: input.tags.clone(),
+                    session_id: input.session_id.clone(),
+                    provenance: Some(serde_json::json!({
+                        "source": "create_decision_fallback",
+                        "structured": structured,
+                    })),
+                    ..Default::default()
+                })
+                .await?;
+            let event_id = capture
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+            let text = format!(
+                "Decision recorded as a memory event: {title} (ID: {event_id}).\n[PARTIAL] typed decision endpoint unavailable (404 on POST /memory/decisions); stored via /memory/events with the structured fields in provenance.\nProgress: completed."
+            );
+            let structured = serde_json::json!({
+                "id": event_id,
+                "event_id": event_id,
+                "node_id": Value::Null,
+                "deduplicated": false,
+                "fallback": "memory_events",
+                "degraded": [{
+                    "source": "decisions_create",
+                    "detail": "POST /memory/decisions returned 404; decision stored as a memory event"
+                }],
+                "raw": capture,
+                "operation_status": {"operation": "create_decision", "state": "completed"},
+            });
+            let mut output = ToolResult::with_structured(text, structured);
+            if let Some(note) = scope.note {
+                output = output.with_prefix(format!("{note}\n"));
+            }
+            Ok(output)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Apply a lifecycle action to a decision (`POST /memory/decisions/:id/actions`).
+///
+/// Only `supersede` with a successor has an events-era fallback
+/// (`/memory/nodes/:id/supersede`); every other action fails honestly when
+/// the typed endpoint is absent.
+pub async fn execute_decision_action(
+    client: &ContextStreamClient,
+    session: &mcp_session::SessionManager,
+    input: DecisionActionInput,
+) -> Result<ToolResult> {
+    let action = input.decision_action.trim().to_ascii_lowercase();
+    if !mcp_client::DECISION_ACTIONS.contains(&action.as_str()) {
+        return Err(Error::Validation(format!(
+            "Invalid decision_action '{}'. Use one of: {}",
+            input.decision_action,
+            mcp_client::DECISION_ACTIONS.join(", ")
+        )));
+    }
+    let scope = resolve_read_scope(
+        client,
+        session,
+        input.workspace_id.as_deref(),
+        input.project_id.as_deref(),
+    )
+    .await?;
+    let (decision_id, resolution_note) = resolve_decision_id(
+        client,
+        scope.workspace_id,
+        scope.project_id,
+        &input.decision_id,
+    )
+    .await?;
+    let successor = match input
+        .successor_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(lookup) => Some(
+            resolve_decision_id(client, scope.workspace_id, scope.project_id, lookup)
+                .await?
+                .0,
+        ),
+        None => None,
+    };
+    if matches!(action.as_str(), "supersede" | "choose_successor")
+        && successor.is_none()
+        && input
+            .title
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(str::is_empty)
+    {
+        return Err(Error::Validation(format!(
+            "successor_id (or title for a new successor) is required for decision_action=\"{action}\""
+        )));
+    }
+
+    let mut text = String::new();
+    if let Some(note) = resolution_note {
+        text.push_str(&note);
+        text.push('\n');
+    }
+    let params = mcp_client::DecisionActionParams {
+        action: action.clone(),
+        successor_id: successor,
+        reason: input.reason.clone(),
+        title: input.title.clone(),
+    };
+    match client.decision_action(decision_id, params).await {
+        Ok(result) => {
+            let applied = result
+                .get("applied")
+                .and_then(Value::as_bool)
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            let decision = result.get("decision").cloned().unwrap_or(Value::Null);
+            let title = if decision.is_object() {
+                extract_display_title(&decision)
+            } else {
+                decision_id.to_string()
+            };
+            let status = decision_str(&decision, &["status"]).unwrap_or("unknown");
+            text.push_str(&format!(
+                "[DECISION_ACTION] {action} applied={applied} — {title} (id={decision_id}) status={status}\n"
+            ));
+            if let Some(successor) = successor {
+                text.push_str(&format!("   successor={successor}\n"));
+            }
+            text.push_str(&render_degraded_lines(&result));
+            let mut output = ToolResult::with_structured(text.trim_end().to_string(), result);
+            if let Some(note) = scope.note {
+                output = output.with_prefix(format!("{note}\n"));
+            }
+            Ok(output)
+        }
+        Err(err) if is_not_found_error(&err) => {
+            if action == "supersede" {
+                if let Some(successor) = successor {
+                    let linked = client
+                        .link_node_superseded_by(decision_id, successor)
+                        .await?;
+                    text.push_str(&format!(
+                        "[DECISION_ACTION] supersede applied via /memory/nodes/{decision_id}/supersede — {decision_id} → {successor}\n[PARTIAL] typed decision actions unavailable (404 on POST /memory/decisions/{decision_id}/actions); only the supersede link was written, status/freshness were not updated."
+                    ));
+                    let structured = serde_json::json!({
+                        "applied": true,
+                        "action": action,
+                        "decision_id": decision_id,
+                        "successor_id": successor,
+                        "fallback": "memory_nodes_supersede",
+                        "degraded": [{
+                            "source": "decision_actions",
+                            "detail": "POST /memory/decisions/:id/actions returned 404; used /memory/nodes/:id/supersede"
+                        }],
+                        "raw": linked,
+                    });
+                    return Ok(ToolResult::with_structured(text, structured));
+                }
+            }
+            Err(Error::Validation(format!(
+                "decision_action \"{action}\" needs the typed decisions endpoint (POST /memory/decisions/{decision_id}/actions), which this server does not expose (404). No fallback exists for this action; nothing was changed."
+            )))
+        }
+        Err(err) => Err(err),
+    }
 }
 
 /// Memory decisions tool handler.
@@ -2243,49 +2956,62 @@ impl ToolHandler for MemoryDecisionsTool {
             return Ok(ToolResult::with_structured(text, structured));
         }
 
-        // P0 #4 — DecisionsHot warm cache. 60 s TTL. Cache key folds
-        // (workspace, project, query) only — category + limit are
-        // common-case unset; if specified they're rare enough that
-        // a collision is acceptable. If we observe collisions in
-        // metrics we'll widen the key.
+        let sort = normalize_decision_sort(input.sort.as_deref())?;
+        let status = normalize_decision_status(input.status.as_deref())?;
+        let offset = input.offset.filter(|value| *value > 0);
+        let limit = input.limit.or(Some(50));
+        // The DecisionsHot warm cache folds (workspace, project, query) only;
+        // any typed filter bypasses it so a filtered call never serves a
+        // differently-filtered payload.
+        let cacheable = input.category.is_none()
+            && input.since.is_none()
+            && input.source.is_none()
+            && offset.is_none()
+            && sort.is_none()
+            && status.is_none();
+
         let query_clone = input.query.clone();
         let user_scope_token = super::atlas_warm_cache::current_user_scope_token();
-        let cached_response = if let Some(ws) = scope.workspace_id {
-            let scope_obj = mcp_types::atlas_layer::AtlasFederationScope {
-                workspace_id: ws,
-                project_id: scope.project_id,
-                scope_hash: super::atlas_warm_cache::scope_hash_for_decisions_hot(
-                    ws,
-                    user_scope_token.as_deref(),
-                    scope.project_id,
-                    query_clone.as_deref(),
-                ),
-                user_scope: user_scope_token.clone(),
-            };
-            super::atlas_warm_cache::try_lookup(
-                &self.atlas_layer,
-                mcp_types::atlas_layer::AtlasWarmCacheKind::DecisionsHot,
-                scope_obj,
-                150, // primary baseline ms
-            )
-            .await
-        } else {
-            None
-        };
-        let response = if let Some(bundle) = cached_response {
-            bundle.payload
-        } else {
-            let r = self
-                .client
-                .list_memory_decisions(
-                    scope.workspace_id,
-                    scope.project_id,
-                    input.query,
-                    input.category,
-                    input.limit.or(Some(50)),
+        let cached_response = match (cacheable, scope.workspace_id) {
+            (true, Some(ws)) => {
+                let scope_obj = mcp_types::atlas_layer::AtlasFederationScope {
+                    workspace_id: ws,
+                    project_id: scope.project_id,
+                    scope_hash: super::atlas_warm_cache::scope_hash_for_decisions_hot(
+                        ws,
+                        user_scope_token.as_deref(),
+                        scope.project_id,
+                        query_clone.as_deref(),
+                    ),
+                    user_scope: user_scope_token.clone(),
+                };
+                super::atlas_warm_cache::try_lookup(
+                    &self.atlas_layer,
+                    mcp_types::atlas_layer::AtlasWarmCacheKind::DecisionsHot,
+                    scope_obj,
+                    150, // primary baseline ms
                 )
-                .await?;
-            if let Some(ws) = scope.workspace_id {
+                .await
+            }
+            _ => None,
+        };
+        let envelope = if let Some(bundle) = cached_response {
+            mcp_client::normalize_decisions_envelope(bundle.payload, sort.as_deref())
+        } else {
+            let params = mcp_client::ListDecisionsParams {
+                workspace_id: scope.workspace_id,
+                project_id: scope.project_id,
+                query: input.query.clone(),
+                category: input.category.clone(),
+                sort: sort.clone(),
+                status: status.clone(),
+                since: input.since.clone(),
+                offset,
+                limit,
+                source: input.source.clone(),
+            };
+            let envelope = self.client.list_decisions_envelope(params).await?;
+            if let (true, Some(ws)) = (cacheable, scope.workspace_id) {
                 let scope_obj = mcp_types::atlas_layer::AtlasFederationScope {
                     workspace_id: ws,
                     project_id: scope.project_id,
@@ -2301,57 +3027,14 @@ impl ToolHandler for MemoryDecisionsTool {
                     self.atlas_layer.clone(),
                     mcp_types::atlas_layer::AtlasWarmCacheKind::DecisionsHot,
                     scope_obj,
-                    r.clone(),
+                    envelope.clone(),
                 );
             }
-            r
+            envelope
         };
 
-        let mut text = String::new();
-
-        let results = response
-            .get("results")
-            .and_then(|v| v.as_array())
-            .cloned()
-            .unwrap_or_default();
-
-        if results.is_empty() {
-            text.push_str("No decisions recorded yet.");
-        } else {
-            // Log first result shape for debugging field name mismatches
-            if let Some(first) = results.first() {
-                tracing::debug!("decisions result shape: {:?}", first);
-            }
-
-            text.push_str(&format!("Found {} decisions:\n\n", results.len()));
-
-            for (i, node) in results.iter().enumerate() {
-                let title = extract_display_title(node);
-
-                text.push_str(&format!("{}. **{}**\n", i + 1, title));
-
-                if let Some(content) = node
-                    .get("content")
-                    .or_else(|| node.get("details"))
-                    .or_else(|| node.get("description"))
-                    .and_then(|v| v.as_str())
-                {
-                    let preview: String = content.chars().take(200).collect();
-                    text.push_str(&format!("   {}\n", preview.replace('\n', " ")));
-                }
-
-                let created_at = node
-                    .get("created_at")
-                    .or_else(|| node.get("createdAt"))
-                    .or_else(|| node.get("timestamp"))
-                    .or_else(|| node.get("date"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown");
-                text.push_str(&format!("   Created: {}\n\n", created_at));
-            }
-        }
-
-        let mut output = ToolResult::with_structured(text, response);
+        let text = render_decisions_envelope(&envelope, sort.as_deref(), status.as_deref());
+        let mut output = ToolResult::with_structured(text, envelope);
         if let Some(note) = scope.note.as_deref() {
             output = output.with_prefix(format!("{}\n", note));
         }
@@ -2373,10 +3056,20 @@ impl ToolHandler for MemoryDecisionsTool {
 
     fn input_schema(&self) -> Value {
         SchemaBuilder::new()
-            .description("List decisions")
+            .description("List decisions (typed decisions.v1 envelope)")
             .uuid("workspace_id", "Workspace ID", false)
             .uuid("project_id", "Project ID", false)
             .string("query", "Optional search query to filter decisions", false)
+            .string("category", "Optional category filter", false)
+            .string_enum("sort", "recency or relevance", DECISION_SORTS, false)
+            .string_enum(
+                "status",
+                "active (default), superseded, disputed, verified, or all",
+                DECISION_STATUSES,
+                false,
+            )
+            .string("since", "ISO-8601 lower bound on decision time", false)
+            .integer("offset", "Pagination offset", false)
             .integer("limit", "Maximum results", false)
             .build()
     }
@@ -2536,6 +3229,33 @@ pub struct MemoryInput {
     // Node supersede fields
     pub new_content: Option<String>,
     pub reason: Option<String>,
+    // Decision fields (decisions / create_decision / decision_action)
+    #[serde(default)]
+    pub category: Option<String>,
+    #[serde(default)]
+    pub sort: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub since: Option<String>,
+    #[serde(default)]
+    pub offset: Option<i64>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub rationale: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub alternatives: Option<Vec<Value>>,
+    #[serde(default)]
+    pub confidence: Option<f64>,
+    #[serde(default)]
+    pub supersedes: Option<String>,
+    #[serde(default)]
+    pub decision_id: Option<String>,
+    #[serde(default)]
+    pub decision_action: Option<String>,
+    #[serde(default)]
+    pub successor_id: Option<String>,
     // Task fields
     pub task_id: Option<String>,
     pub description: Option<String>,
@@ -3101,28 +3821,123 @@ impl ToolHandler for MemoryTool {
                 let node_id = input
                     .node_id
                     .ok_or_else(|| Error::Validation("node_id is required".to_string()))?;
-                let id = Uuid::parse_str(&node_id)
-                    .map_err(|_| Error::Validation("Invalid node_id UUID".to_string()))?;
                 let new_content = input
                     .new_content
                     .ok_or_else(|| Error::Validation("new_content is required".to_string()))?;
+                let node_lookup = node_id.trim().to_string();
+                let (id, resolution_note) = match Uuid::parse_str(&node_lookup) {
+                    Ok(id) => (id, None),
+                    Err(_) => {
+                        let listing = self
+                            .client
+                            .list_memory_nodes(
+                                workspace_id,
+                                project_id,
+                                input.node_type.clone(),
+                                Some(100),
+                            )
+                            .await?;
+                        let items = extract_collection_array(&listing)
+                            .cloned()
+                            .unwrap_or_default();
+                        let ranked = rank_lookup_matches(
+                            &items,
+                            &node_lookup,
+                            &["title", "summary", "name"],
+                            8,
+                        );
+                        match classify_lookup_resolution(&ranked) {
+                            LookupResolution::None => {
+                                return Err(Error::Validation(format!(
+                                    "No nodes match \"{node_lookup}\". Use memory(action=\"list_nodes\") or memory(action=\"search\", query=\"{node_lookup}\") to find the node id."
+                                )));
+                            }
+                            LookupResolution::Single(best) => {
+                                let note = (!best.exact).then(|| {
+                                    format!(
+                                        "Resolved node \"{}\" to **{}** (id: {}).",
+                                        node_lookup, best.title, best.id
+                                    )
+                                });
+                                (best.id, note)
+                            }
+                            LookupResolution::Ambiguous => {
+                                return Ok(supersede_candidates_result(&node_lookup, &ranked));
+                            }
+                        }
+                    }
+                };
                 let params = SupersedeMemoryNodeParams {
                     new_content,
                     reason: input.reason,
                 };
                 let result = self.client.supersede_memory_node(id, params).await?;
-                Ok(ToolResult::with_structured(
-                    "Node superseded successfully.".to_string(),
-                    result,
-                ))
+                let mut text = String::new();
+                if let Some(note) = resolution_note {
+                    text.push_str(&note);
+                    text.push('\n');
+                }
+                let new_id = result
+                    .get("new_node_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown");
+                text.push_str(&format!("Node superseded: {id} → {new_id}."));
+                Ok(ToolResult::with_structured(text, result))
+            }
+            "create_decision" => {
+                let title = input
+                    .title
+                    .ok_or_else(|| Error::Validation("title is required".to_string()))?;
+                let decision_input = CreateDecisionInput {
+                    workspace_id: input.workspace_id,
+                    project_id: input.project_id,
+                    title,
+                    content: input.content,
+                    rationale: input.rationale,
+                    alternatives: input.alternatives,
+                    scope: input.scope,
+                    confidence: input.confidence,
+                    supersedes: input.supersedes,
+                    category: input.category,
+                    tags: input.tags,
+                    session_id: input.session_id,
+                };
+                execute_create_decision(&self.client, self.session.as_ref(), decision_input).await
+            }
+            "decision_action" => {
+                let decision_id = input
+                    .decision_id
+                    .or(input.node_id)
+                    .ok_or_else(|| Error::Validation("decision_id is required".to_string()))?;
+                let decision_action = input.decision_action.ok_or_else(|| {
+                    Error::Validation(format!(
+                        "decision_action is required (one of: {})",
+                        mcp_client::DECISION_ACTIONS.join(", ")
+                    ))
+                })?;
+                let action_input = DecisionActionInput {
+                    workspace_id: input.workspace_id,
+                    project_id: input.project_id,
+                    decision_id,
+                    decision_action,
+                    successor_id: input.successor_id,
+                    reason: input.reason,
+                    title: input.title,
+                };
+                execute_decision_action(&self.client, self.session.as_ref(), action_input).await
             }
             "decisions" => {
                 let decisions_input = MemoryDecisionsInput {
                     workspace_id: input.workspace_id,
                     project_id: input.project_id,
                     query: input.query,
-                    category: None, // category accepted on standalone tool
+                    category: input.category,
                     limit: input.limit,
+                    sort: input.sort,
+                    status: input.status,
+                    since: input.since,
+                    offset: input.offset,
+                    source: input.source,
                 };
                 let tool =
                     MemoryDecisionsTool::with_session_and_atlas(
@@ -5314,7 +6129,7 @@ impl ToolHandler for MemoryTool {
             }
 
             _ => Err(Error::Validation(format!(
-                "Unknown action: {}. Available actions: search, create_node, get_node, update_node, delete_node, list_nodes, supersede_node, decisions, timeline, summary, create_event, get_event, update_event, delete_event, distill_event, list_events, import_batch, create_task, get_task, update_task, delete_task, list_tasks, reorder_tasks, create_todo, get_todo, update_todo, delete_todo, complete_todo, list_todos, create_diagram, get_diagram, update_diagram, delete_diagram, list_diagrams, create_doc, get_doc, update_doc, delete_doc, list_docs, create_roadmap, list_transcripts, get_transcript, search_transcripts, search_archive, delete_transcript, team_tasks, team_todos, team_diagrams, team_docs, team_discussions, team_transcript_topics.",
+                "Unknown action: {}. Available actions: search, create_node, get_node, update_node, delete_node, list_nodes, supersede_node, decisions, create_decision, decision_action, timeline, summary, create_event, get_event, update_event, delete_event, distill_event, list_events, import_batch, create_task, get_task, update_task, delete_task, list_tasks, reorder_tasks, create_todo, get_todo, update_todo, delete_todo, complete_todo, list_todos, create_diagram, get_diagram, update_diagram, delete_diagram, list_diagrams, create_doc, get_doc, update_doc, delete_doc, list_docs, create_roadmap, list_transcripts, get_transcript, search_transcripts, search_archive, delete_transcript, team_tasks, team_todos, team_diagrams, team_docs, team_discussions, team_transcript_topics.",
                 input.action
             ))),
         }
@@ -5325,7 +6140,7 @@ impl ToolHandler for MemoryTool {
         METADATA.get_or_init(|| ToolMetadata {
             name: "memory".to_string(),
             title: "Memory Operations".to_string(),
-            description: "Persistent memory storage — docs, runbooks, specs, ADRs, RFCs, decisions, lessons, preferences, tasks, todos, knowledge nodes, transcripts. NOT for codebase/file search.\n\n⚠️ FINDING A DOC, RUNBOOK, SPEC, OR ARCHITECTURE NOTE? USE THIS TOOL — NOT `find`, `ls`, `grep`, or filesystem searches. ContextStream docs/runbooks/specs/decisions/lessons live ONLY in this tool's storage (Postgres + indexes), NEVER on disk under ~/.claude, /tmp, or the project tree. If the user mentions 'the doc on X', 'our runbook for Y', 'the design spec', 'the ADR/RFC', 'a postmortem', 'the architecture note', 'why we decided Z' — go through:\n  · memory(action=\"search\", query=\"…\") — hybrid across docs + nodes (try this first when unsure)\n  · memory(action=\"list_docs\", query=\"…\") then memory(action=\"get_doc\", doc_id=\"<id-or-title>\")\n  · memory(action=\"decisions\", query=\"…\") for past architectural decisions\n  · session(action=\"recall\", query=\"…\") if it might be in past-session transcripts\nFalling back to filesystem tools to find a ContextStream doc is wrong — the doc is not on disk.\n\nCodebase / source / files? Use the `search` tool, not memory.\n\nPlans? Use session(action=\"capture_plan\") instead of memory(action=\"create_event\", event_type=\"plan\"). Plan tasks should be created with plan_id, plan_step_id, priority/status, and detailed descriptions.\n\nDISTINCT FROM (don't use memory for these):\n· entity(kind=ticket|handoff|incident|release|experiment|goal|key_result|sprint|review|risk|backlog_view) — structured taxonomy entities with their own status timelines and per-kind fields. When the user says 'create a ticket', 'file a bug', 'create a handoff', 'log an incident', 'track this release' — that's `entity`, not memory(create_task).\n· session(action=capture_lesson|capture|recall|capture_plan) — lessons / decisions / snapshots / plans tied to the current session.\n· capsule(...) — portable context bundles for cross-agent handoffs.\n\nThis tool's `create_task` is a lightweight project-tracking todo with priority/status — NOT a 'ticket'. This tool's `create_task` should include plan_id and plan_step_id when the task belongs to a plan. This tool's `create_doc(doc_type=runbook)` is a versioned markdown doc — NOT a 'handoff'.\n\nNode actions: create_node, get_node, update_node, delete_node, list_nodes, supersede_node. Query actions: search (searches memory nodes and relevant docs together, not code), decisions, timeline, summary. Event actions: create_event, get_event, update_event, delete_event, list_events, distill_event, import_batch. Task actions: create_task, get_task, update_task, delete_task, list_tasks, reorder_tasks. Todo actions: create_todo, list_todos, get_todo, update_todo, delete_todo, complete_todo. Diagram actions: create_diagram, list_diagrams, get_diagram, update_diagram, delete_diagram (diagram_type values: flowchart, sequence, class, er, gantt, mindmap, pie, other — use sequence for API/request flows and er for data models). Doc actions: create_doc, list_docs, get_doc, update_doc, delete_doc, create_roadmap (doc_type values: roadmap, spec, runbook, adr, rfc, postmortem, retro, release_notes, playbook, prd, user_story, persona, interview, design_spec, critique, glossary, oncall_schedule, slo, q_and_a, changelog, style_guide, general — `get_doc` accepts ID or natural-language title query). Transcript actions: list_transcripts, get_transcript, search_transcripts, search_archive, delete_transcript. `search_archive` queries the cold storage tier for transcripts past the hot-retention window (remote/hosted deployments only). Team actions: team_tasks, team_todos, team_diagrams, team_docs.".to_string(),
+            description: "Persistent memory storage — docs, runbooks, specs, ADRs, RFCs, decisions, lessons, preferences, tasks, todos, knowledge nodes, transcripts. NOT for codebase/file search.\n\n⚠️ FINDING A DOC, RUNBOOK, SPEC, OR ARCHITECTURE NOTE? USE THIS TOOL — NOT `find`, `ls`, `grep`, or filesystem searches. ContextStream docs/runbooks/specs/decisions/lessons live ONLY in this tool's storage (Postgres + indexes), NEVER on disk under ~/.claude, /tmp, or the project tree. If the user mentions 'the doc on X', 'our runbook for Y', 'the design spec', 'the ADR/RFC', 'a postmortem', 'the architecture note', 'why we decided Z' — go through:\n  · memory(action=\"search\", query=\"…\") — hybrid across docs + nodes (try this first when unsure)\n  · memory(action=\"list_docs\", query=\"…\") then memory(action=\"get_doc\", doc_id=\"<id-or-title>\")\n  · memory(action=\"decisions\", query=\"…\") for past architectural decisions\n  · session(action=\"recall\", query=\"…\") if it might be in past-session transcripts\nFalling back to filesystem tools to find a ContextStream doc is wrong — the doc is not on disk.\n\nCodebase / source / files? Use the `search` tool, not memory.\n\nPlans? Use session(action=\"capture_plan\") instead of memory(action=\"create_event\", event_type=\"plan\"). Plan tasks should be created with plan_id, plan_step_id, priority/status, and detailed descriptions.\n\nDISTINCT FROM (don't use memory for these):\n· entity(kind=ticket|handoff|incident|release|experiment|goal|key_result|sprint|review|risk|backlog_view) — structured taxonomy entities with their own status timelines and per-kind fields. When the user says 'create a ticket', 'file a bug', 'create a handoff', 'log an incident', 'track this release' — that's `entity`, not memory(create_task).\n· session(action=capture_lesson|capture|recall|capture_plan) — lessons / decisions / snapshots / plans tied to the current session.\n· capsule(...) — portable context bundles for cross-agent handoffs.\n\nThis tool's `create_task` is a lightweight project-tracking todo with priority/status — NOT a 'ticket'. This tool's `create_task` should include plan_id and plan_step_id when the task belongs to a plan. This tool's `create_doc(doc_type=runbook)` is a versioned markdown doc — NOT a 'handoff'.\n\nNode actions: create_node, get_node, update_node, delete_node, list_nodes, supersede_node (node_id accepts an id or lookup text; ambiguous text returns a [CANDIDATES] list). Query actions: search (searches memory nodes and relevant docs together, not code), decisions (typed envelope: query, category, sort=recency|relevance, status=active|superseded|disputed|verified|all, since, offset, limit), timeline, summary. Decision actions: create_decision (title, content, rationale, alternatives, scope, confidence, supersedes, category, tags), decision_action (decision_id or lookup text + decision_action=supersede|dispute|verify|invalidate|choose_successor, successor_id, reason). Event actions: create_event, get_event, update_event, delete_event, list_events, distill_event, import_batch. Task actions: create_task, get_task, update_task, delete_task, list_tasks, reorder_tasks. Todo actions: create_todo, list_todos, get_todo, update_todo, delete_todo, complete_todo. Diagram actions: create_diagram, list_diagrams, get_diagram, update_diagram, delete_diagram (diagram_type values: flowchart, sequence, class, er, gantt, mindmap, pie, other — use sequence for API/request flows and er for data models). Doc actions: create_doc, list_docs, get_doc, update_doc, delete_doc, create_roadmap (doc_type values: roadmap, spec, runbook, adr, rfc, postmortem, retro, release_notes, playbook, prd, user_story, persona, interview, design_spec, critique, glossary, oncall_schedule, slo, q_and_a, changelog, style_guide, general — `get_doc` accepts ID or natural-language title query). Transcript actions: list_transcripts, get_transcript, search_transcripts, search_archive, delete_transcript. `search_archive` queries the cold storage tier for transcripts past the hot-retention window (remote/hosted deployments only). Team actions: team_tasks, team_todos, team_diagrams, team_docs.".to_string(),
             category: ToolCategory::Memory,
             annotations: ToolAnnotations::destructive(),
             is_pro: false,
@@ -5344,6 +6159,8 @@ impl ToolHandler for MemoryTool {
             "list_nodes",
             "supersede_node",
             "decisions",
+            "create_decision",
+            "decision_action",
             "timeline",
             "summary",
             // Event actions
@@ -5407,7 +6224,7 @@ impl ToolHandler for MemoryTool {
             )
             .string(
                 "scope",
-                "Todo scope for list_todos: all, personal, or team",
+                "Todo scope for list_todos (all, personal, team) or the decision scope for create_decision (free text)",
                 false,
             )
             .uuid(
@@ -5445,7 +6262,72 @@ impl ToolHandler for MemoryTool {
                 "New content (for supersede_node; also accepted as the body for update_node)",
                 false,
             )
-            .string("reason", "Reason (for supersede_node)", false)
+            .string("reason", "Reason (for supersede_node, decision_action)", false)
+            // Decision fields
+            .string(
+                "category",
+                "Decision category filter (decisions) or category to store (create_decision)",
+                false,
+            )
+            .string_enum(
+                "sort",
+                "Decision ordering (decisions): recency or relevance",
+                DECISION_SORTS,
+                false,
+            )
+            .string_enum(
+                "status",
+                "Decision status filter (decisions): active (default), superseded, disputed, verified, or all",
+                DECISION_STATUSES,
+                false,
+            )
+            .string(
+                "since",
+                "ISO-8601 lower bound on decision time (decisions)",
+                false,
+            )
+            .integer("offset", "Pagination offset (decisions)", false)
+            .string("source", "Decision source filter (decisions)", false)
+            .string(
+                "rationale",
+                "Why this decision was made (create_decision)",
+                false,
+            )
+            .property(
+                "alternatives",
+                serde_json::json!({
+                    "type": "array",
+                    "description": "Alternatives considered (create_decision): strings or {option, rejected_reason} objects",
+                    "items": {"anyOf": [{"type": "string"}, {"type": "object"}]}
+                }),
+                false,
+            )
+            .number(
+                "confidence",
+                "Confidence in the decision, 0.0-1.0 (create_decision)",
+                false,
+            )
+            .string(
+                "supersedes",
+                "Decision id or lookup text this decision replaces (create_decision)",
+                false,
+            )
+            .string(
+                "decision_id",
+                "Decision id or lookup text (decision_action)",
+                false,
+            )
+            .string_enum(
+                "decision_action",
+                "Lifecycle action to apply (decision_action)",
+                mcp_client::DECISION_ACTIONS,
+                false,
+            )
+            .string(
+                "successor_id",
+                "Successor decision id or lookup text (decision_action=supersede|choose_successor)",
+                false,
+            )
             // Event fields
             .string_enum(
                 "event_type",

--- a/crates/mcp-tools/src/domains/memory_tests.rs
+++ b/crates/mcp-tools/src/domains/memory_tests.rs
@@ -693,6 +693,19 @@ mod read_scope_resolution_tests {
             events: None,
             new_content: None,
             reason: None,
+            category: None,
+            sort: None,
+            status: None,
+            since: None,
+            offset: None,
+            source: None,
+            rationale: None,
+            alternatives: None,
+            confidence: None,
+            supersedes: None,
+            decision_id: None,
+            decision_action: None,
+            successor_id: None,
             task_id: None,
             description: None,
             priority: None,
@@ -1502,9 +1515,11 @@ mod schema_tests {
                 assert!(values.contains(&"search_archive")); // A7
                 assert!(values.contains(&"delete_transcript"));
 
-                // Verify total action count: 10+7+6+6+5+6+5+4 = 49
-                // (transcript actions grew from 4 to 5 with A7's search_archive)
-                assert_eq!(values.len(), 51, "Expected 51 memory actions");
+                // Verify total action count. Wave 3b added the typed
+                // `create_decision` and `decision_action` node actions.
+                assert!(values.contains(&"create_decision"));
+                assert!(values.contains(&"decision_action"));
+                assert_eq!(values.len(), 53, "Expected 53 memory actions");
             }
         }
 
@@ -2616,16 +2631,16 @@ mod registration_tests {
 
         assert_eq!(expected_tools.len(), 4);
 
-        // Unified memory tool supports 42 actions:
-        // - Node actions (8): search, create_node, get_node, update_node, delete_node, list_nodes, supersede_node, decisions
+        // Unified memory tool supports 44 actions:
+        // - Node actions (10): search, create_node, get_node, update_node, delete_node, list_nodes, supersede_node, decisions, create_decision, decision_action
         // - Event actions (7): create_event, get_event, update_event, delete_event, distill_event, list_events, import_batch
         // - Task actions (6): create_task, get_task, update_task, delete_task, list_tasks, reorder_tasks
         // - Todo actions (6): create_todo, list_todos, get_todo, update_todo, delete_todo, complete_todo
         // - Diagram actions (5): create_diagram, list_diagrams, get_diagram, update_diagram, delete_diagram
         // - Doc actions (6): create_doc, list_docs, get_doc, update_doc, delete_doc, create_roadmap
         // - Transcript actions (4): list_transcripts, get_transcript, search_transcripts, delete_transcript
-        let action_count = 8 + 7 + 6 + 6 + 5 + 6 + 4;
-        assert_eq!(action_count, 42);
+        let action_count = 10 + 7 + 6 + 6 + 5 + 6 + 4;
+        assert_eq!(action_count, 44);
     }
 
     #[test]

--- a/crates/mcp-tools/src/domains/mod.rs
+++ b/crates/mcp-tools/src/domains/mod.rs
@@ -29,6 +29,9 @@ pub mod vcs;
 pub mod workspace;
 pub mod workspace_drift;
 
+#[cfg(test)]
+mod parity_eval_tests;
+
 // Re-export all domain tools
 pub use atlas_jobs::*;
 pub use capsule::*;

--- a/crates/mcp-tools/src/domains/parity_eval_tests.rs
+++ b/crates/mcp-tools/src/domains/parity_eval_tests.rs
@@ -1,0 +1,1045 @@
+//! Wave 3b / 4b parity eval corpus.
+//!
+//! Each case names the prompt an agent would send, the tool + action that
+//! must answer it, and the exact text markers the tool must emit. The cases
+//! run against a routing mock of the hosted API so both the typed contract
+//! and the 404 fallbacks (`[PARTIAL]`) are exercised without network access.
+
+use super::memory::MemoryTool;
+use super::session::{
+    ContextTool, SessionCaptureLessonTool, SessionDecisionTraceTool, SessionGetLessonsTool,
+    SessionTool,
+};
+use crate::registry::ToolHandler;
+use crate::testing::TestFixtures;
+use mcp_client::ContextStreamClient;
+use mcp_session::SessionManager;
+use mcp_types::tool::{ContentItem, ToolResult};
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use uuid::Uuid;
+
+/// One eval case: what the agent asks, which tool/action answers, and the
+/// markers the rendered text must contain.
+struct EvalCase {
+    id: &'static str,
+    prompt: &'static str,
+    expected_tool: &'static str,
+    expected_action: &'static str,
+    expected_markers: &'static [&'static str],
+}
+
+const PARITY_EVAL_CORPUS: &[EvalCase] = &[
+    EvalCase {
+        id: "decisions-latest-5",
+        prompt: "show me the latest 5 decisions",
+        expected_tool: "memory",
+        expected_action: "decisions",
+        expected_markers: &["[DECISIONS] 2 of 2 decision(s) (sort=recency, status=active)", "[DECISION]", "status=active", "freshness=fresh"],
+    },
+    EvalCase {
+        id: "decisions-about-x",
+        prompt: "what did we decide about the ledger database",
+        expected_tool: "memory",
+        expected_action: "decisions",
+        expected_markers: &["[DECISION]", "status=unknown", "[PARTIAL] decisions_envelope:"],
+    },
+    EvalCase {
+        id: "decision-why-trace",
+        prompt: "why did we choose postgres for the ledger",
+        expected_tool: "session",
+        expected_action: "decision_trace",
+        expected_markers: &["[DECISION_TRACE] Postgres was chosen for transactional guarantees.", "status=verified"],
+    },
+    EvalCase {
+        id: "supersede-by-text",
+        prompt: "supersede the ledger database node with the new content",
+        expected_tool: "memory",
+        expected_action: "supersede_node",
+        expected_markers: &["Resolved node \"ledger database\"", "Node superseded:"],
+    },
+    EvalCase {
+        id: "capture-lesson",
+        prompt: "remember this lesson: always quote shell paths",
+        expected_tool: "session",
+        expected_action: "capture_lesson",
+        expected_markers: &["Lesson captured: Quote shell paths (ID: "],
+    },
+    EvalCase {
+        id: "high-severity-lessons",
+        prompt: "list high severity lessons",
+        expected_tool: "session",
+        expected_action: "get_lessons",
+        expected_markers: &["Found 1 of 1 lesson(s).", "[HIGH] Quote shell paths id=", "status=active"],
+    },
+    EvalCase {
+        id: "ground-lessons-warning",
+        prompt: "refactor the ledger service",
+        expected_tool: "session",
+        expected_action: "ground",
+        expected_markers: &["[LESSONS_WARNING] severity=high relevance=0.90 Quote shell paths", "[COORDINATION] Ledger schema freeze"],
+    },
+    EvalCase {
+        id: "context-coordination",
+        prompt: "continue the ledger refactor",
+        expected_tool: "context",
+        expected_action: "",
+        expected_markers: &["[COORDINATION] [other project] Schema freeze (urgency=high) — ack via coordination(action=\"ack\", notice_id=\"n-other\")", "[COORDINATION] Same-project note — ack via"],
+    },
+];
+
+fn case(id: &str) -> &'static EvalCase {
+    PARITY_EVAL_CORPUS
+        .iter()
+        .find(|case| case.id == id)
+        .unwrap_or_else(|| panic!("eval case {id} is not in the corpus"))
+}
+
+fn assert_case(id: &str, text: &str) {
+    let case = case(id);
+    for marker in case.expected_markers {
+        assert!(
+            text.contains(marker),
+            "case {id} ({}) expected marker {marker:?} in:\n{text}",
+            case.prompt
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Routing mock of the hosted API
+// ---------------------------------------------------------------------------
+
+struct Route {
+    method: &'static str,
+    path_contains: String,
+    status: u16,
+    body: String,
+}
+
+fn route(method: &'static str, path_contains: &str, status: u16, body: Value) -> Route {
+    Route {
+        method,
+        path_contains: path_contains.to_string(),
+        status,
+        body: body.to_string(),
+    }
+}
+
+struct MockApi {
+    base_url: String,
+    requests: Arc<Mutex<Vec<String>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for MockApi {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl MockApi {
+    async fn start(routes: Vec<Route>) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock api");
+        let base_url = format!("http://{}", listener.local_addr().expect("mock addr"));
+        let requests: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let log = requests.clone();
+        let routes = Arc::new(routes);
+        let task = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let routes = routes.clone();
+                let log = log.clone();
+                tokio::spawn(async move {
+                    let mut buffer = vec![0_u8; 64 * 1024];
+                    let count = socket.read(&mut buffer).await.unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buffer[..count]).to_string();
+                    let request_line = request.lines().next().unwrap_or_default().to_string();
+                    log.lock().unwrap().push(request_line.clone());
+                    let (status, body) = routes
+                        .iter()
+                        .find(|route| {
+                            request_line.starts_with(&format!("{} ", route.method))
+                                && request_line.contains(&route.path_contains)
+                        })
+                        .map(|route| (route.status, route.body.clone()))
+                        .unwrap_or((404, json!({"error": "not found"}).to_string()));
+                    let reason = match status {
+                        200 => "OK",
+                        201 => "Created",
+                        404 => "Not Found",
+                        _ => "OK",
+                    };
+                    let response = format!(
+                        "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.shutdown().await;
+                });
+            }
+        });
+        Self {
+            base_url,
+            requests,
+            task,
+        }
+    }
+
+    fn requests(&self) -> Vec<String> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    fn saw(&self, needle: &str) -> bool {
+        self.requests().iter().any(|line| line.contains(needle))
+    }
+
+    async fn wait_for(&self, needle: &str) -> bool {
+        for _ in 0..40 {
+            if self.saw(needle) {
+                return true;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        false
+    }
+}
+
+fn client_and_session(
+    base_url: &str,
+    workspace_id: Uuid,
+    project_id: Option<Uuid>,
+) -> (ContextStreamClient, Arc<SessionManager>) {
+    let mut config = TestFixtures::test_config();
+    config.api_url = base_url.to_string();
+    config.default_workspace_id = Some(workspace_id);
+    config.default_project_id = project_id;
+    let client = ContextStreamClient::new(config.clone());
+    let session = Arc::new(SessionManager::new(client.clone(), config));
+    (client, session)
+}
+
+fn text_of(result: &ToolResult) -> String {
+    result
+        .content
+        .iter()
+        .find_map(|item| match item {
+            ContentItem::Text { text } => Some(text.clone()),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+fn scope_routes(workspace_id: Uuid, project_id: Option<Uuid>) -> Vec<Route> {
+    let mut routes = vec![route(
+        "GET",
+        &format!("/api/v1/workspaces/{workspace_id}"),
+        200,
+        json!({"id": workspace_id, "name": "Parity", "slug": "parity"}),
+    )];
+    if let Some(project_id) = project_id {
+        routes.push(route(
+            "GET",
+            &format!("/api/v1/projects/{project_id}"),
+            200,
+            json!({"id": project_id, "workspace_id": workspace_id, "name": "ledger", "slug": "ledger"}),
+        ));
+    }
+    routes
+}
+
+const D1: &str = "11111111-1111-4111-8111-111111111111";
+const D2: &str = "22222222-2222-4222-8222-222222222222";
+
+// ---------------------------------------------------------------------------
+// Cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn corpus_ids_are_unique_and_name_real_tools() {
+    let mut ids = HashSet::new();
+    for case in PARITY_EVAL_CORPUS {
+        assert!(ids.insert(case.id), "duplicate eval case id {}", case.id);
+        assert!(
+            matches!(
+                case.expected_tool,
+                "memory" | "session" | "context" | "init"
+            ),
+            "unknown tool {}",
+            case.expected_tool
+        );
+        assert!(!case.expected_markers.is_empty());
+        // `context` is a plain tool; every other case names a real action.
+        assert_eq!(
+            case.expected_action.is_empty(),
+            case.expected_tool == "context",
+            "case {} action/tool mismatch",
+            case.id
+        );
+    }
+    assert_eq!(PARITY_EVAL_CORPUS.len(), 8);
+}
+
+#[tokio::test]
+async fn decisions_latest_5_requests_envelope_and_renders_typed_lines() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "GET",
+        "/api/v1/memory/decisions?",
+        200,
+        json!({
+            "items": [
+                {"id": D1, "title": "Use Postgres for the ledger", "status": "active", "freshness": "fresh",
+                 "category": "architecture", "created_at": "2026-09-01T10:00:00Z",
+                 "structured": {"rationale": "Transactional guarantees"}},
+                {"id": D2, "title": "Batch writes nightly", "status": "active", "freshness": "fresh",
+                 "category": "operations", "created_at": "2026-08-30T10:00:00Z"}
+            ],
+            "total": 2, "next_offset": null, "sort": "recency", "scope": {"workspace_id": ws},
+            "degraded": [], "schema_version": "decisions.v1"
+        }),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = MemoryTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let result = tool
+        .execute(json!({"action": "decisions", "sort": "recency", "limit": 5, "workspace_id": ws}))
+        .await
+        .expect("decisions");
+    let text = text_of(&result);
+    assert_case("decisions-latest-5", &text);
+    assert!(text.contains(&format!("1. [DECISION] Use Postgres for the ledger — status=active freshness=fresh category=architecture id={D1}")));
+    assert!(text.contains("rationale: Transactional guarantees"));
+    assert!(!text.contains("[PARTIAL]"));
+    let request = api
+        .requests()
+        .into_iter()
+        .find(|line| line.contains("/api/v1/memory/decisions?"))
+        .expect("decisions request");
+    for needle in ["sort=recency", "limit=5", "format=envelope"] {
+        assert!(request.contains(needle), "{request}");
+    }
+    let structured = result.structured_content.as_ref().expect("structured");
+    assert_eq!(structured["schema_version"], "decisions.v1");
+}
+
+#[tokio::test]
+async fn decisions_about_topic_falls_back_to_legacy_array_with_partial() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "GET",
+        "/api/v1/memory/decisions?",
+        200,
+        json!([{"id": D1, "summary": "Use Postgres for the ledger", "details": "chosen over Redis"}]),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = MemoryTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let result = tool
+        .execute(json!({"action": "decisions", "query": "ledger database", "status": "all", "workspace_id": ws}))
+        .await
+        .expect("decisions");
+    let text = text_of(&result);
+    assert_case("decisions-about-x", &text);
+    assert!(text.contains("freshness=unknown"));
+    assert!(api.saw("query=ledger%20database"));
+    assert!(api.saw("status=all"));
+    let err = tool
+        .execute(json!({"action": "decisions", "status": "bogus"}))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("Invalid status"));
+}
+
+#[tokio::test]
+async fn decision_trace_renders_answer_from_typed_trace() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "POST",
+        "/api/v1/memory/search/decisions/trace",
+        200,
+        json!({"decisions": [{"id": D1, "title": "Use Postgres for the ledger", "status": "verified", "created_at": "2026-09-01"}]}),
+    ));
+    routes.push(route(
+        "GET",
+        &format!("/api/v1/memory/decisions/{D1}/trace"),
+        200,
+        json!({"answer": "Postgres was chosen for transactional guarantees.", "markers": ["[DECISION_TRACE]"], "decision": {"id": D1}}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, _session) = client_and_session(&api.base_url, ws, None);
+    let tool = SessionDecisionTraceTool::new(client);
+    let result = tool
+        .execute(json!({"query": "why postgres for the ledger", "workspace_id": ws}))
+        .await
+        .expect("trace");
+    let text = text_of(&result);
+    assert_case("decision-why-trace", &text);
+    assert!(text.starts_with("[DECISION_TRACE] Postgres was chosen"));
+    assert!(text.contains(&format!(
+        "1. Use Postgres for the ledger — status=verified (2026-09-01) id={D1}"
+    )));
+    assert!(text.contains("memory(action=\"decision_action\""));
+    let structured = result.structured_content.as_ref().expect("structured");
+    assert_eq!(structured["markers"][0], "[DECISION_TRACE]");
+
+    // A UUID query goes straight to the typed trace.
+    let result = tool
+        .execute(json!({"query": D1, "workspace_id": ws}))
+        .await
+        .expect("trace by id");
+    assert!(text_of(&result).starts_with("[DECISION_TRACE] Postgres was chosen"));
+}
+
+#[tokio::test]
+async fn decision_trace_without_typed_endpoint_says_no_answer() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "POST",
+        "/api/v1/memory/search/decisions/trace",
+        200,
+        json!({"decisions": [{"id": D1, "title": "Use Postgres for the ledger"}]}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, _session) = client_and_session(&api.base_url, ws, None);
+    let text = text_of(
+        &SessionDecisionTraceTool::new(client)
+            .execute(json!({"query": "postgres ledger", "workspace_id": ws}))
+            .await
+            .expect("trace"),
+    );
+    assert!(text.starts_with("[DECISION_TRACE] No synthesized answer from the server"));
+    assert!(text.contains("status=unknown"));
+}
+
+#[tokio::test]
+async fn supersede_node_resolves_lookup_text_and_lists_candidates_when_ambiguous() {
+    let ws = Uuid::new_v4();
+    let node_id = Uuid::new_v4();
+    let new_id = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "GET",
+        &format!("/api/v1/memory/nodes/workspace/{ws}"),
+        200,
+        json!({"items": [
+            {"id": node_id, "title": "Ledger database choice", "node_type": "Decision"},
+            {"id": Uuid::new_v4(), "title": "Unrelated caching note", "node_type": "Note"}
+        ]}),
+    ));
+    routes.push(route(
+        "GET",
+        &format!("/api/v1/memory/nodes/{node_id}"),
+        200,
+        json!({"id": node_id, "workspace_id": ws, "node_type": "Decision", "summary": "Ledger database choice"}),
+    ));
+    routes.push(route(
+        "POST",
+        "/api/v1/memory/nodes",
+        200,
+        json!({"id": new_id}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = MemoryTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let result = tool
+        .execute(json!({"action": "supersede_node", "node_id": "ledger database", "new_content": "Use Postgres 16", "workspace_id": ws}))
+        .await
+        .expect("supersede");
+    let text = text_of(&result);
+    assert_case("supersede-by-text", &text);
+    assert!(text.contains(&format!("Node superseded: {node_id} → {new_id}.")));
+    assert!(api.saw(&format!("POST /api/v1/memory/nodes/{node_id}/supersede")));
+
+    // Ambiguous lookup: candidate list, nothing superseded.
+    let ambiguous = MockApi::start({
+        let mut routes = scope_routes(ws, None);
+        routes.push(route(
+            "GET",
+            &format!("/api/v1/memory/nodes/workspace/{ws}"),
+            200,
+            json!({"items": [
+                {"id": Uuid::new_v4(), "title": "Ledger database choice"},
+                {"id": Uuid::new_v4(), "title": "Ledger database rollout"}
+            ]}),
+        ));
+        routes
+    })
+    .await;
+    let (client, session) = client_and_session(&ambiguous.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = MemoryTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let result = tool
+        .execute(json!({"action": "supersede_node", "node_id": "ledger database", "new_content": "x", "workspace_id": ws}))
+        .await
+        .expect("candidates");
+    let text = text_of(&result);
+    assert!(text.starts_with(
+        "[CANDIDATES] Multiple nodes match \"ledger database\"; nothing was superseded."
+    ));
+    assert_eq!(
+        result.structured_content.as_ref().unwrap()["candidates"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+    assert!(!ambiguous.saw("/supersede"));
+}
+
+#[tokio::test]
+async fn capture_lesson_uses_typed_endpoint_then_events_on_404() {
+    let ws = Uuid::new_v4();
+    let lesson_id = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "POST",
+        "/api/v1/lessons",
+        201,
+        json!({"id": lesson_id, "title": "Quote shell paths"}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = SessionCaptureLessonTool::new(client, session);
+    let text = text_of(
+        &tool
+            .execute(json!({"title": "Quote shell paths", "trigger": "paths with spaces", "impact": "command failed",
+                           "prevention": "Always quote paths.", "severity": "high", "workspace_id": ws}))
+            .await
+            .expect("capture"),
+    );
+    assert_case("capture-lesson", &text);
+    assert!(text.contains(&lesson_id.to_string()));
+    assert!(!text.contains("[PARTIAL]"));
+    assert!(!api.saw("/api/v1/memory/events"));
+
+    let event_id = Uuid::new_v4();
+    let fallback = MockApi::start({
+        let mut routes = scope_routes(ws, None);
+        routes.push(route(
+            "POST",
+            "/api/v1/lessons",
+            404,
+            json!({"error": "not found"}),
+        ));
+        routes.push(route(
+            "POST",
+            "/api/v1/memory/events",
+            200,
+            json!({"id": event_id}),
+        ));
+        routes
+    })
+    .await;
+    let (client, session) = client_and_session(&fallback.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = SessionCaptureLessonTool::new(client, session);
+    let result = tool
+        .execute(json!({"title": "Quote shell paths (events)", "trigger": "paths with spaces", "impact": "command failed",
+                       "prevention": "Always quote paths.", "severity": "high", "workspace_id": ws}))
+        .await
+        .expect("fallback capture");
+    let text = text_of(&result);
+    assert!(text.contains(&format!(
+        "Lesson captured: Quote shell paths (events) (ID: {event_id})."
+    )));
+    assert!(text.contains("[PARTIAL] /lessons endpoint unavailable (404); stored the lesson as a memory event via /memory/events."));
+    assert_eq!(
+        result.structured_content.as_ref().unwrap()["fallback"],
+        "memory_events"
+    );
+    assert!(fallback.saw("POST /api/v1/lessons"));
+    assert!(fallback.saw("POST /api/v1/memory/events"));
+}
+
+#[tokio::test]
+async fn high_severity_lessons_use_typed_listing_with_min_severity() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "GET",
+        "/api/v1/lessons?",
+        200,
+        json!({"items": [{"id": D1, "title": "Quote shell paths", "severity": "high", "status": "active",
+                          "category": "workflow", "prevention": "Always quote paths."}],
+               "total": 1, "next_offset": null, "degraded": [], "schema_version": "lessons.v1"}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = SessionGetLessonsTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let result = tool
+        .execute(json!({"severity": "high", "workspace_id": ws}))
+        .await
+        .expect("lessons");
+    let text = text_of(&result);
+    assert_case("high-severity-lessons", &text);
+    assert!(text.contains("category=workflow"));
+    let request = api
+        .requests()
+        .into_iter()
+        .find(|line| line.contains("/api/v1/lessons?"))
+        .expect("lessons request");
+    assert!(request.contains("min_severity=high"), "{request}");
+    assert!(request.contains("format=envelope"), "{request}");
+    assert_eq!(
+        result.structured_content.as_ref().unwrap()["source"],
+        "lessons_api"
+    );
+}
+
+#[tokio::test]
+async fn get_lessons_falls_back_to_events_on_404_and_says_so() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "GET",
+        "/api/v1/lessons?",
+        404,
+        json!({"error": "not found"}),
+    ));
+    routes.push(route(
+        "GET",
+        &format!("/api/v1/memory/events/workspace/{ws}"),
+        200,
+        json!({"items": [{"id": D1, "type": "lesson", "event_type": "lesson",
+                          "title": "Quote shell paths",
+                          "metadata": {"original_type": "lesson", "severity": "high"},
+                          "content": "## Quote shell paths\n**Severity:** high\n### Prevention\nAlways quote paths."}]}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = SessionGetLessonsTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let result = tool
+        .execute(json!({"workspace_id": ws}))
+        .await
+        .expect("lessons");
+    let text = text_of(&result);
+    assert!(text.contains("[HIGH] Quote shell paths"));
+    assert!(text.contains(
+        "[PARTIAL] /lessons endpoint unavailable (404); listed lessons from memory events."
+    ));
+    assert_eq!(
+        result.structured_content.as_ref().unwrap()["source"],
+        "memory_events"
+    );
+}
+
+#[tokio::test]
+async fn ground_emits_lessons_warning_and_coordination_lines() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "GET",
+        "/api/v1/lessons/warnings?",
+        200,
+        json!({"items": [{"lesson": {"id": D1, "title": "Quote shell paths", "severity": "high", "prevention": "Always quote paths."},
+                          "relevance": 0.9, "reason": "matched shell"}],
+               "rule": "Apply before shell edits", "degraded": []}),
+    ));
+    routes.push(route(
+        "POST",
+        "/api/v1/session/recall",
+        200,
+        json!({"results": []}),
+    ));
+    routes.push(route("GET", "/api/v1/memory/decisions?", 200, json!([])));
+    routes.push(route(
+        "GET",
+        "/api/v1/coordination/inbox",
+        200,
+        json!({"notices": [{"id": "n1", "reason": "Ledger schema freeze"}], "items": []}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = SessionTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let result = tool
+        .execute(json!({"action": "ground", "user_message": "refactor the ledger service", "workspace_id": ws}))
+        .await
+        .expect("ground");
+    let text = text_of(&result);
+    assert_case("ground-lessons-warning", &text);
+    assert!(text.contains("Always quote paths."));
+    assert!(text.contains("notice_id=\"n1\""));
+    assert!(!api.saw("/ack"));
+    let request = api
+        .requests()
+        .into_iter()
+        .find(|line| line.contains("/api/v1/lessons/warnings?"))
+        .expect("warnings request");
+    assert!(
+        request.contains("user_message=refactor%20the%20ledger%20service"),
+        "{request}"
+    );
+    assert_eq!(
+        result.structured_content.as_ref().unwrap()["lessons"]["source"],
+        "lessons_warnings"
+    );
+}
+
+#[tokio::test]
+async fn ground_lessons_fall_back_to_events_on_404() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "GET",
+        "/api/v1/lessons/warnings?",
+        404,
+        json!({"error": "not found"}),
+    ));
+    routes.push(route(
+        "POST",
+        "/api/v1/memory/search",
+        200,
+        json!({"results": [{"id": D1, "type": "lesson", "title": "Quote shell paths", "score": 0.7,
+                             "content": "## Quote shell paths\n**Severity:** critical\n### Prevention\nAlways quote paths."}]}),
+    ));
+    routes.push(route(
+        "POST",
+        "/api/v1/session/recall",
+        200,
+        json!({"results": []}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = SessionTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let text = text_of(
+        &tool
+            .execute(json!({"action": "ground", "user_message": "shell edits", "workspace_id": ws}))
+            .await
+            .expect("ground"),
+    );
+    assert!(text.contains(
+        "[LESSONS_WARNING] severity=critical relevance=0.70 Quote shell paths: Always quote paths."
+    ));
+    assert!(text.contains("[PARTIAL] lessons_warnings: GET /lessons/warnings returned 404"));
+}
+
+#[tokio::test]
+async fn context_emits_coordination_lines_and_checks_in_without_acking() {
+    let ws = Uuid::new_v4();
+    let project = Uuid::new_v4();
+    let other = Uuid::new_v4();
+    let mut routes = scope_routes(ws, Some(project));
+    routes.push(route(
+        "POST",
+        "/api/v1/context/smart",
+        200,
+        json!({"context": "[CTX] W:Parity P:ledger", "summary": "ledger refactor"}),
+    ));
+    routes.push(route(
+        "GET",
+        "/api/v1/coordination/inbox",
+        200,
+        json!({"notices": [
+            {"id": "n-other", "reason": "Schema freeze", "from_project_id": other, "urgency": "high"},
+            {"id": "n-same", "reason": "Same-project note", "from_project_id": project}
+        ], "items": []}),
+    ));
+    routes.push(route(
+        "POST",
+        "/api/v1/coordination/check-in",
+        200,
+        json!({"ok": true}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, Some(project));
+    session
+        .initialize(Some(ws), Some(project), None, None)
+        .await;
+    let index_keeper = Arc::new(super::index_keeper::IndexKeeper::new(
+        client.clone(),
+        session.clone(),
+        mcp_types::atlas_layer::noop_layer(),
+        mcp_types::acceleration_layer::noop_acceleration_layer(),
+    ));
+    let tool = ContextTool::new(
+        client,
+        session,
+        index_keeper,
+        mcp_types::atlas_layer::noop_layer(),
+    );
+    let result = tool
+        .execute(
+            json!({"user_message": "continue the ledger refactor", "mode": "standard",
+                       "session_id": "parity-session", "workspace_id": ws, "project_id": project}),
+        )
+        .await
+        .expect("context");
+    let text = text_of(&result);
+    assert_case("context-coordination", &text);
+    assert!(!text.contains("[COORDINATION] [other project] Same-project note"));
+    assert!(api.wait_for("POST /api/v1/coordination/check-in").await);
+    assert!(!api.saw("/ack"));
+    assert!(!api.saw("/dismiss"));
+    let structured = result.structured_content.as_ref().expect("structured");
+    assert_eq!(
+        structured["coordination_inbox"]["notices"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn context_fast_route_skips_coordination_inbox() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "POST",
+        "/api/v1/context/hook",
+        200,
+        json!({"context": "[CTX] fast"}),
+    ));
+    routes.push(route(
+        "GET",
+        "/api/v1/coordination/inbox",
+        200,
+        json!({"notices": [{"id": "n1", "reason": "should not render"}]}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let index_keeper = Arc::new(super::index_keeper::IndexKeeper::new(
+        client.clone(),
+        session.clone(),
+        mcp_types::atlas_layer::noop_layer(),
+        mcp_types::acceleration_layer::noop_acceleration_layer(),
+    ));
+    let tool = ContextTool::new(
+        client,
+        session,
+        index_keeper,
+        mcp_types::atlas_layer::noop_layer(),
+    );
+    let result = tool
+        .execute(json!({"user_message": "quick lookup", "mode": "fast", "workspace_id": ws}))
+        .await
+        .expect("fast context");
+    assert!(!text_of(&result).contains("[COORDINATION]"));
+    assert!(!api.saw("/api/v1/coordination/inbox"));
+}
+
+#[tokio::test]
+async fn capture_decision_with_structured_fields_routes_to_typed_create() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "POST",
+        "/api/v1/memory/decisions",
+        201,
+        json!({"id": D1, "node_id": D2, "event_id": D1, "deduplicated": false}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = SessionTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let text = text_of(
+        &tool
+            .execute(json!({"action": "capture", "event_type": "decision", "title": "Use Postgres for the ledger",
+                           "content": "Postgres over Redis", "rationale": "transactions",
+                           "alternatives": ["Redis"], "confidence": 0.8, "workspace_id": ws}))
+            .await
+            .expect("capture decision"),
+    );
+    assert!(text.contains(&format!(
+        "Decision recorded: Use Postgres for the ledger (id: {D1}, node_id: {D2}, event_id: {D1})."
+    )));
+    assert!(api.saw("POST /api/v1/memory/decisions"));
+    assert!(!api.saw("POST /api/v1/memory/events"));
+
+    // Without the typed endpoint the decision is stored as an event and says so.
+    let fallback = MockApi::start({
+        let mut routes = scope_routes(ws, None);
+        routes.push(route(
+            "POST",
+            "/api/v1/memory/decisions",
+            404,
+            json!({"error": "not found"}),
+        ));
+        routes.push(route(
+            "POST",
+            "/api/v1/memory/events",
+            200,
+            json!({"id": D2}),
+        ));
+        routes
+    })
+    .await;
+    let (client, session) = client_and_session(&fallback.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = MemoryTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let result = tool
+        .execute(json!({"action": "create_decision", "title": "Use Postgres for the ledger", "rationale": "transactions", "workspace_id": ws}))
+        .await
+        .expect("fallback create");
+    let text = text_of(&result);
+    assert!(text.contains(&format!(
+        "Decision recorded as a memory event: Use Postgres for the ledger (ID: {D2})."
+    )));
+    assert!(text
+        .contains("[PARTIAL] typed decision endpoint unavailable (404 on POST /memory/decisions)"));
+    assert_eq!(
+        result.structured_content.as_ref().unwrap()["fallback"],
+        "memory_events"
+    );
+}
+
+#[tokio::test]
+async fn decision_action_resolves_lookup_text_and_reports_applied() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "GET",
+        "/api/v1/memory/decisions?",
+        200,
+        json!({"items": [{"id": D1, "title": "Use Postgres for the ledger", "status": "active"}],
+               "total": 1, "degraded": [], "schema_version": "decisions.v1"}),
+    ));
+    routes.push(route(
+        "POST",
+        &format!("/api/v1/memory/decisions/{D1}/actions"),
+        200,
+        json!({"applied": true, "decision": {"id": D1, "title": "Use Postgres for the ledger", "status": "verified"}, "degraded": []}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = MemoryTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let text = text_of(
+        &tool
+            .execute(json!({"action": "decision_action", "decision_id": "postgres ledger", "decision_action": "verify", "workspace_id": ws}))
+            .await
+            .expect("verify"),
+    );
+    assert!(text.contains(&format!("[DECISION_ACTION] verify applied=true — Use Postgres for the ledger (id={D1}) status=verified")));
+    let err = tool
+        .execute(
+            json!({"action": "decision_action", "decision_id": D1, "decision_action": "explode"}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("Invalid decision_action"));
+}
+
+#[tokio::test]
+async fn decision_action_without_typed_endpoint_is_honest() {
+    let ws = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "POST",
+        &format!("/api/v1/memory/decisions/{D1}/actions"),
+        404,
+        json!({"error": "not found"}),
+    ));
+    routes.push(route(
+        "POST",
+        &format!("/api/v1/memory/nodes/{D1}/supersede"),
+        200,
+        json!({"ok": true}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = MemoryTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let err = tool
+        .execute(json!({"action": "decision_action", "decision_id": D1, "decision_action": "verify", "workspace_id": ws}))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains(
+        "does not expose (404). No fallback exists for this action; nothing was changed."
+    ));
+    let text = text_of(
+        &tool
+            .execute(json!({"action": "decision_action", "decision_id": D1, "decision_action": "supersede", "successor_id": D2, "workspace_id": ws}))
+            .await
+            .expect("supersede fallback"),
+    );
+    assert!(text.contains(&format!(
+        "[DECISION_ACTION] supersede applied via /memory/nodes/{D1}/supersede — {D1} → {D2}"
+    )));
+    assert!(text.contains("[PARTIAL] typed decision actions unavailable"));
+    assert!(api.saw(&format!("POST /api/v1/memory/nodes/{D1}/supersede")));
+}
+
+#[tokio::test]
+async fn suggested_rules_render_typed_lines_with_sources_and_native_guidance() {
+    let ws = Uuid::new_v4();
+    let rule_id = Uuid::new_v4();
+    let mut routes = scope_routes(ws, None);
+    routes.push(route(
+        "GET",
+        "/api/v1/suggested-rules?",
+        200,
+        json!({"rules": [{"id": rule_id, "instruction": "Quote shell paths", "category": "workflow", "confidence": 0.92,
+                          "occurrence_count": 4, "source_lesson_ids": [D1, D2]}],
+               "native_guidance": {"heading": "Shell safety", "agents_md_snippet": "- Always quote shell paths"}}),
+    ));
+    routes.push(route(
+        "POST",
+        &format!("/api/v1/suggested-rules/{rule_id}/action"),
+        200,
+        json!({"success": true, "status": "accepted"}),
+    ));
+    routes.push(route(
+        "GET",
+        "/api/v1/suggested-rules/stats",
+        200,
+        json!({"total_suggested": 3, "accepted": 1, "rejected": 1, "pending": 1}),
+    ));
+    let api = MockApi::start(routes).await;
+    let (client, session) = client_and_session(&api.base_url, ws, None);
+    session.initialize(Some(ws), None, None, None).await;
+    let tool = SessionTool::new(client, session, mcp_types::atlas_layer::noop_layer());
+    let text = text_of(
+        &tool
+            .execute(json!({"action": "list_suggested_rules", "workspace_id": ws}))
+            .await
+            .expect("list"),
+    );
+    assert!(text.starts_with(crate::notices::SUGGESTED_RULES_HEADER));
+    assert!(text.contains(&format!("[SUGGESTED_RULES] [workflow] Quote shell paths (confidence: 92%, seen 4x) id={rule_id} source_lesson_ids={D1},{D2}")));
+    assert!(text.contains("[SUGGESTED_RULES] native_guidance heading=\"Shell safety\" — paste into the rules file:\n- Always quote shell paths"));
+    assert!(api.saw("format=envelope"));
+    let text = text_of(
+        &tool
+            .execute(json!({"action": "suggested_rule_action", "rule_id": rule_id, "rule_action": "accept"}))
+            .await
+            .expect("action"),
+    );
+    assert_eq!(
+        text,
+        format!("[SUGGESTED_RULES] action=accept rule_id={rule_id} success=true status=accepted")
+    );
+    let text = text_of(
+        &tool
+            .execute(json!({"action": "suggested_rules_stats", "workspace_id": ws}))
+            .await
+            .expect("stats"),
+    );
+    assert_eq!(
+        text,
+        "[SUGGESTED_RULES] stats total=3 accepted=1 rejected=1 pending=1"
+    );
+}

--- a/crates/mcp-tools/src/domains/session.rs
+++ b/crates/mcp-tools/src/domains/session.rs
@@ -3186,7 +3186,7 @@ impl ToolHandler for InitTool {
         }
 
         if is_post_compact {
-            let restore_session_id = init_session_id;
+            let restore_session_id = init_session_id.clone();
             let restore = self
                 .client
                 .session_restore_context(SessionRestoreContextParams {
@@ -3220,6 +3220,23 @@ impl ToolHandler for InitTool {
                     text.push_str(&message);
                     result["post_compact_restore_error"] = Value::String(error.to_string());
                 }
+            }
+        }
+
+        // Wave 4b: presence check-in for cross-agent coordination. Best-effort
+        // and spawned; init never waits on it.
+        if let Some(session_id) = init_session_id.clone() {
+            if resolved_workspace_id.is_some() {
+                spawn_coordination_check_in(
+                    &self.client,
+                    resolved_workspace_id,
+                    resolved_project_id,
+                    session_id,
+                    input
+                        .context_hint
+                        .as_deref()
+                        .and_then(coordination_task_summary),
+                );
             }
         }
 
@@ -4116,6 +4133,8 @@ fn estimated_context_tool_wire_tokens(text: &str, structured: &Value) -> usize {
 fn context_wire_text_priority(line: &str) -> Option<u8> {
     let upper = line.to_ascii_uppercase();
     if upper.contains("[LESSONS_WARNING]")
+        || upper.contains("[COORDINATION]")
+        || upper.contains("[PARTIAL]")
         || upper.contains("[PREFERENCE]")
         || upper.contains("[PREFS]")
         || upper.contains("[ACTION_REQUIRED]")
@@ -4966,6 +4985,164 @@ const BOILERPLATE_RULE_PATTERNS: &[&str] = &[
 const BOILERPLATE_OCCURRENCE_THRESHOLD: i32 = 1000;
 const MIN_ACTIONABLE_INSTRUCTION_LEN: usize = 20;
 
+fn suggested_rules_payload(result: &Value) -> &Value {
+    match result.get("data") {
+        Some(data) if data.is_object() => data,
+        _ => result,
+    }
+}
+
+fn suggested_rule_items(result: &Value) -> Vec<Value> {
+    let payload = suggested_rules_payload(result);
+    payload
+        .get("rules")
+        .or_else(|| payload.get("items"))
+        .or_else(|| payload.get("suggested_rules"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn suggested_rules_message(result: &Value) -> Option<&str> {
+    suggested_rules_payload(result)
+        .get("message")
+        .or_else(|| result.get("message"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+/// Typed `[SUGGESTED_RULES]` lines for `session(action="list_suggested_rules")`:
+/// one line per rule with its source lesson ids, then the server's native
+/// guidance snippet (an AGENTS.md-ready block) when present.
+pub(crate) fn render_suggested_rules_list(result: &Value) -> String {
+    let rules = suggested_rule_items(result);
+    let payload = suggested_rules_payload(result);
+    let mut text = String::new();
+    if rules.is_empty() {
+        match suggested_rules_message(result) {
+            Some(message) => text.push_str(&format!(
+                "[SUGGESTED_RULES] No pending rule suggestions.\n[PARTIAL] suggested rules: {message}"
+            )),
+            None => text.push_str("[SUGGESTED_RULES] No pending rule suggestions."),
+        }
+        let partial = crate::domains::memory::render_degraded_lines(result);
+        if !partial.is_empty() {
+            text.push('\n');
+            text.push_str(partial.trim_end());
+        }
+        return text;
+    }
+    text.push_str(crate::notices::SUGGESTED_RULES_HEADER);
+    text.push('\n');
+    for rule in rules.iter().take(10) {
+        let instruction = rule
+            .get("instruction")
+            .or_else(|| rule.get("rule"))
+            .and_then(Value::as_str)
+            .unwrap_or("(no instruction)");
+        let category = rule
+            .get("category")
+            .and_then(Value::as_str)
+            .unwrap_or("general");
+        let confidence = rule
+            .get("confidence")
+            .and_then(Value::as_f64)
+            .map(|value| format!("{:.0}%", value * 100.0))
+            .unwrap_or_else(|| "n/a".to_string());
+        let seen = rule
+            .get("occurrence_count")
+            .and_then(Value::as_i64)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "n/a".to_string());
+        let id = rule.get("id").and_then(Value::as_str).unwrap_or("unknown");
+        let sources = rule
+            .get("source_lesson_ids")
+            .and_then(Value::as_array)
+            .map(|ids| {
+                ids.iter()
+                    .filter_map(Value::as_str)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            })
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "none".to_string());
+        text.push_str(&format!(
+            "[SUGGESTED_RULES] [{category}] {instruction} (confidence: {confidence}, seen {seen}x) id={id} source_lesson_ids={sources}\n"
+        ));
+    }
+    if let Some(guidance) = payload
+        .get("native_guidance")
+        .filter(|value| value.is_object())
+    {
+        let heading = guidance
+            .get("heading")
+            .and_then(Value::as_str)
+            .unwrap_or("ContextStream rules");
+        if let Some(snippet) = guidance
+            .get("agents_md_snippet")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+        {
+            text.push_str(&format!(
+                "[SUGGESTED_RULES] native_guidance heading=\"{heading}\" — paste into the rules file:\n{}\n",
+                snippet.trim_end()
+            ));
+        }
+    }
+    text.push_str(&crate::domains::memory::render_degraded_lines(result));
+    text.trim_end().to_string()
+}
+
+/// Typed line for `session(action="suggested_rule_action")`.
+pub(crate) fn render_suggested_rule_action(rule_id: &Uuid, action: &str, result: &Value) -> String {
+    let payload = suggested_rules_payload(result);
+    let success = payload
+        .get("success")
+        .and_then(Value::as_bool)
+        .or_else(|| payload.get("applied").and_then(Value::as_bool));
+    let mut text = format!(
+        "[SUGGESTED_RULES] action={action} rule_id={rule_id} success={}",
+        success
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    );
+    if let Some(status) = payload.get("status").and_then(Value::as_str) {
+        text.push_str(&format!(" status={status}"));
+    }
+    if let Some(message) = suggested_rules_message(result) {
+        if success == Some(false) {
+            text.push_str(&format!("\n[PARTIAL] {message}"));
+        } else {
+            text.push_str(&format!(" — {message}"));
+        }
+    }
+    text
+}
+
+/// Typed line for `session(action="suggested_rules_stats")`.
+pub(crate) fn render_suggested_rules_stats(result: &Value) -> String {
+    let payload = suggested_rules_payload(result);
+    let count = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_i64)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "n/a".to_string())
+    };
+    let mut text = format!(
+        "[SUGGESTED_RULES] stats total={} accepted={} rejected={} pending={}",
+        count("total_suggested"),
+        count("accepted"),
+        count("rejected"),
+        count("pending")
+    );
+    if let Some(message) = suggested_rules_message(result) {
+        text.push_str(&format!("\n[PARTIAL] suggested rules: {message}"));
+    }
+    text
+}
+
 fn is_boilerplate_suggested_rule(rule: &mcp_types::api::SuggestedRule) -> bool {
     let category = rule.category.as_deref().unwrap_or("").to_ascii_lowercase();
     if category.is_empty() || category == "general" {
@@ -5500,51 +5677,245 @@ fn format_typed_snapshots(items: &[&SmartContextItem], compact: bool) -> String 
     text
 }
 
-/// Format lesson items (L kind) from typed items, leveraging relevance scoring.
-fn format_typed_lessons(items: &[&SmartContextItem], compact: bool) -> String {
-    if items.is_empty() {
+/// One lesson ready for `[LESSONS_WARNING]` rendering.
+///
+/// `severity` is the *stored* severity (never derived from relevance);
+/// `relevance` is the retrieval score and is shown separately.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct LessonWarningLine {
+    pub title: String,
+    pub guidance: String,
+    pub severity: Option<String>,
+    pub relevance: Option<f32>,
+    pub id: Option<String>,
+    pub superseded: bool,
+}
+
+/// Maximum lessons rendered per `[LESSONS_WARNING]` block.
+pub(crate) const LESSONS_WARNING_MAX: usize = 5;
+
+/// Parse a stored severity out of free-form lesson text
+/// (`**Severity:** high`, `severity: high`, `severity=high`).
+fn severity_from_text(text: &str) -> Option<String> {
+    let lower = text.to_ascii_lowercase();
+    let idx = lower.find("severity")?;
+    let rest = &lower[idx + "severity".len()..];
+    let rest = rest.trim_start_matches(['*', ':', '=', ' ']);
+    let token: String = rest
+        .chars()
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect();
+    match token.as_str() {
+        "low" | "medium" | "high" | "critical" => Some(token),
+        _ => None,
+    }
+}
+
+fn lesson_title_from_value(value: &str) -> String {
+    value
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(|line| line.trim_start_matches('#').trim().to_string())
+        .unwrap_or_else(|| "Untitled lesson".to_string())
+}
+
+fn lesson_guidance_from_value(value: &str) -> String {
+    if let Some(prevention) = extract_markdown_section(value, "Prevention") {
+        return prevention;
+    }
+    let title = lesson_title_from_value(value);
+    let rest: Vec<&str> = value
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .skip_while(|line| line.trim_start_matches('#').trim() == title)
+        .filter(|line| !line.to_ascii_lowercase().starts_with("**severity"))
+        .collect();
+    if rest.is_empty() {
+        value.trim().to_string()
+    } else {
+        rest.join(" ")
+    }
+}
+
+/// Typed `L` items from `/context/smart`.
+pub(crate) fn lesson_lines_from_typed(items: &[&SmartContextItem]) -> Vec<LessonWarningLine> {
+    items
+        .iter()
+        .map(|item| LessonWarningLine {
+            title: lesson_title_from_value(&item.value),
+            guidance: lesson_guidance_from_value(&item.value),
+            severity: severity_from_text(&item.value),
+            relevance: Some(item.score),
+            id: item.item_id.map(|id| id.to_string()),
+            superseded: false,
+        })
+        .collect()
+}
+
+/// Legacy flat `lessons` array from `/context/smart`.
+pub(crate) fn lesson_lines_from_api(lessons: &[mcp_types::api::Lesson]) -> Vec<LessonWarningLine> {
+    lessons
+        .iter()
+        .map(|lesson| LessonWarningLine {
+            title: lesson
+                .title
+                .clone()
+                .unwrap_or_else(|| "Untitled".to_string()),
+            guidance: lesson
+                .prevention
+                .clone()
+                .or_else(|| lesson.trigger.clone())
+                .unwrap_or_default(),
+            severity: lesson.severity.clone(),
+            relevance: None,
+            id: None,
+            superseded: false,
+        })
+        .collect()
+}
+
+/// Lesson JSON values from `/lessons`, `/lessons/warnings`, or the events
+/// listing. `/lessons/warnings` items are `{lesson, relevance, reason}`.
+pub(crate) fn lesson_lines_from_values(items: &[Value]) -> Vec<LessonWarningLine> {
+    items
+        .iter()
+        .map(|item| {
+            let (lesson, relevance) = match item.get("lesson") {
+                Some(inner) if inner.is_object() => (
+                    inner,
+                    item.get("relevance")
+                        .and_then(Value::as_f64)
+                        .map(|value| value as f32),
+                ),
+                _ => (
+                    item,
+                    item.get("relevance")
+                        .or_else(|| item.get("score"))
+                        .and_then(Value::as_f64)
+                        .map(|value| value as f32),
+                ),
+            };
+            let stored_severity = lesson
+                .get("severity")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| {
+                    lesson
+                        .get("metadata")
+                        .and_then(|meta| meta.get("severity"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .or_else(|| {
+                    lesson
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .and_then(severity_from_text)
+                });
+            LessonWarningLine {
+                title: extract_lesson_title(lesson),
+                guidance: extract_lesson_prevention(lesson)
+                    .or_else(|| {
+                        lesson
+                            .get("content")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    })
+                    .unwrap_or_default(),
+                severity: stored_severity,
+                relevance,
+                id: lesson.get("id").and_then(Value::as_str).map(str::to_string),
+                superseded: lesson
+                    .get("superseded_by")
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| !value.is_empty())
+                    || lesson
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .is_some_and(|status| status.eq_ignore_ascii_case("superseded")),
+            }
+        })
+        .collect()
+}
+
+fn lesson_line_body(line: &LessonWarningLine) -> String {
+    let guidance: String = line
+        .guidance
+        .chars()
+        .take(500)
+        .collect::<String>()
+        .replace('\n', " ");
+    let mut body = line.title.clone();
+    if !guidance.trim().is_empty() && guidance.trim() != line.title.trim() {
+        body.push_str(": ");
+        body.push_str(guidance.trim());
+    }
+    if let Some(id) = line.id.as_deref() {
+        body.push_str(&format!(" id={id}"));
+    }
+    if line.superseded {
+        body.push_str(" [superseded]");
+    }
+    body
+}
+
+/// The single `[LESSONS_WARNING]` renderer used by `context()` and
+/// `session(action="ground")`. Compact mode emits one marker line per lesson
+/// (so wire-budget trimming keeps each one); verbose mode emits a header and
+/// a numbered list. Severity is the stored value; relevance is shown
+/// separately and never converted into a severity.
+pub(crate) fn render_lessons_warning(lines: &[LessonWarningLine], compact: bool) -> String {
+    if lines.is_empty() {
         return String::new();
     }
+    let severity_label = |line: &LessonWarningLine| {
+        line.severity
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_ascii_lowercase)
+            .unwrap_or_else(|| "unspecified".to_string())
+    };
+    let relevance_label = |line: &LessonWarningLine| match line.relevance {
+        Some(score) => format!("{score:.2}"),
+        None => "n/a".to_string(),
+    };
     let mut text = String::new();
     if compact {
-        for item in items.iter().take(5) {
-            let severity = if item.score >= 0.8 {
-                "CRIT"
-            } else if item.score >= 0.5 {
-                "HIGH"
-            } else {
-                "note"
-            };
-            let preview: String = item.value.chars().take(500).collect();
+        for line in lines.iter().take(LESSONS_WARNING_MAX) {
             text.push_str(&format!(
-                "\n[LESSONS_WARNING] severity={} relevance={:.2} {}",
-                severity, item.score, preview
+                "\n[LESSONS_WARNING] severity={} relevance={} {}",
+                severity_label(line),
+                relevance_label(line),
+                lesson_line_body(line)
             ));
         }
     } else {
-        text.push_str(
-            "🚨 [LESSONS_WARNING] Apply these lessons before proceeding; keep them active for this task.\n",
-        );
-        for (i, item) in items.iter().take(5).enumerate() {
-            let severity = if item.score >= 0.8 {
-                "🚨"
-            } else if item.score >= 0.5 {
-                "⚠️"
-            } else {
-                "📝"
-            };
-            let preview: String = item.value.chars().take(500).collect();
+        text.push_str("🚨 ");
+        text.push_str(crate::notices::LESSONS_WARNING_HEADER);
+        text.push('\n');
+        for (index, line) in lines.iter().take(LESSONS_WARNING_MAX).enumerate() {
             text.push_str(&format!(
-                "{}. {} {} (relevance: {:.2})\n",
-                i + 1,
-                severity,
-                preview,
-                item.score
+                "{}. [{}] {}",
+                index + 1,
+                severity_label(line).to_ascii_uppercase(),
+                lesson_line_body(line)
             ));
+            if line.relevance.is_some() {
+                text.push_str(&format!(" (relevance: {})", relevance_label(line)));
+            }
+            text.push('\n');
         }
         text.push('\n');
     }
     text
+}
+
+/// Format lesson items (L kind) from typed items through the shared renderer.
+fn format_typed_lessons(items: &[&SmartContextItem], compact: bool) -> String {
+    render_lessons_warning(&lesson_lines_from_typed(items), compact)
 }
 
 /// Check if server-side typed VCS items should supersede client-side VCS context.
@@ -6052,6 +6423,106 @@ where
 /// data in 50 ms — gating `context()`'s response time at p50 700 ms+
 /// despite the Context cache itself hitting in <50 ms. See lesson
 /// `53be7d19` (don't gate hot path on best-effort enrichment).
+/// Best-effort presence heartbeat for cross-agent coordination. Spawned so it
+/// never adds latency to `context()` / `init()`; failures are logged at debug.
+fn spawn_coordination_check_in(
+    client: &ContextStreamClient,
+    workspace_id: Option<Uuid>,
+    project_id: Option<Uuid>,
+    session_id: String,
+    task_summary: Option<String>,
+) {
+    let client = client.clone();
+    let session_key = mcp_client::get_task_session_key();
+    let caller_cache_identity = mcp_client::get_task_caller_cache_identity();
+    let auth_override = mcp_client::get_task_auth_override();
+    let config_override = mcp_client::get_task_config_override();
+    tokio::spawn(async move {
+        let result = with_caller_auth(
+            session_key,
+            caller_cache_identity,
+            auth_override,
+            config_override,
+            || async move {
+                client
+                    .coordination_check_in(
+                        workspace_id,
+                        project_id,
+                        &session_id,
+                        task_summary.as_deref(),
+                    )
+                    .await
+            },
+        )
+        .await;
+        if let Err(error) = result {
+            tracing::debug!("coordination check-in skipped: {}", error);
+        }
+    });
+}
+
+/// Short single-line task summary for the coordination check-in.
+fn coordination_task_summary(user_message: &str) -> Option<String> {
+    let collapsed = user_message
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    Some(collapsed.chars().take(120).collect())
+}
+
+/// Lessons for `session(action="ground")`: typed `/lessons/warnings` first,
+/// events-based `session_get_lessons` when the server answers 404 (recorded
+/// in `degraded` so the text can say `[PARTIAL]`).
+async fn fetch_lessons_for_ground(
+    client: &ContextStreamClient,
+    workspace_id: Option<Uuid>,
+    project_id: Option<Uuid>,
+    user_message: &str,
+) -> Result<Value> {
+    match client
+        .lessons_warnings(workspace_id, project_id, user_message, Some(5))
+        .await
+    {
+        Ok(mut payload) => {
+            if let Some(obj) = payload.as_object_mut() {
+                obj.insert(
+                    "source".to_string(),
+                    Value::String("lessons_warnings".to_string()),
+                );
+            }
+            Ok(payload)
+        }
+        Err(err) if is_not_found_error(&err) => {
+            let mut payload = client
+                .session_get_lessons(SessionGetLessonsParams {
+                    query: Some(user_message.to_string()),
+                    limit: Some(5),
+                    workspace_id,
+                    project_id,
+                })
+                .await?;
+            if let Some(obj) = payload.as_object_mut() {
+                obj.insert(
+                    "source".to_string(),
+                    Value::String("memory_events".to_string()),
+                );
+                obj.insert(
+                    "degraded".to_string(),
+                    serde_json::json!([{
+                        "source": "lessons_warnings",
+                        "detail": "GET /lessons/warnings returned 404; lessons listed from memory events"
+                    }]),
+                );
+            }
+            Ok(payload)
+        }
+        Err(err) => Err(err),
+    }
+}
+
 async fn proactive_grounding_recall(
     client: &ContextStreamClient,
     atlas_layer: &mcp_types::atlas_layer::AtlasLayer,
@@ -6548,8 +7019,7 @@ fn local_rules_content_drift_notice(folder_path: Option<&str>) -> Option<String>
     if installed == canonical {
         return None;
     }
-    Some(format!(
-        "[RULES_NOTICE] Rules content drifted ({} → {}). Run generate_rules(overwrite_existing=true) to refresh.",
+    Some(crate::notices::rules_notice_drift(
         &installed.chars().take(8).collect::<String>(),
         &canonical.chars().take(8).collect::<String>(),
     ))
@@ -7466,6 +7936,52 @@ impl ToolHandler for ContextTool {
             None
         };
 
+        // Coordination inbox (Wave 4b): fetched in parallel with the primary
+        // call and rendered as `[COORDINATION]` lines; never auto-acked. The
+        // fast route above skips it. The presence check-in is fire-and-forget.
+        let coordination_future = if workspace_id.is_some() {
+            let client_c = self.client.clone();
+            let session_key_c = mcp_client::get_task_session_key();
+            let caller_cache_identity_c = mcp_client::get_task_caller_cache_identity();
+            let auth_override_c = mcp_client::get_task_auth_override();
+            let config_override_c = mcp_client::get_task_config_override();
+            let ws_c = workspace_id;
+            let pid_c = project_id;
+            let sid_c = context_session_id.clone();
+            Some(tokio::spawn(async move {
+                with_caller_auth(
+                    session_key_c,
+                    caller_cache_identity_c,
+                    auth_override_c,
+                    config_override_c,
+                    || async move {
+                        client_c
+                            .coordination_inbox(
+                                ws_c,
+                                pid_c,
+                                sid_c.as_deref(),
+                                Some(
+                                    (crate::domains::coordination::NOTICE_RENDER_LIMIT + 1) as i64,
+                                ),
+                            )
+                            .await
+                    },
+                )
+                .await
+            }))
+        } else {
+            None
+        };
+        if let (Some(session_id), true) = (context_session_id.clone(), workspace_id.is_some()) {
+            spawn_coordination_check_in(
+                &self.client,
+                workspace_id,
+                project_id,
+                session_id,
+                coordination_task_summary(&user_message_for_relevance),
+            );
+        }
+
         // A8b: try the regional warm cache before the slow primary
         // call. If another pod in this region completed the same
         // coding-task scope within the last 5 min and deposited the
@@ -7773,6 +8289,29 @@ impl ToolHandler for ContextTool {
             Vec::new()
         };
 
+        let coordination_inbox: Option<Value> = if let Some(handle) = coordination_future {
+            match tokio::time::timeout(proactive_bound, handle).await {
+                Ok(Ok(Ok(inbox))) => Some(inbox),
+                Ok(Ok(Err(error))) => {
+                    tracing::debug!("coordination inbox unavailable: {}", error);
+                    None
+                }
+                _ => None, // join error or bound elapsed; task continues
+            }
+        } else {
+            None
+        };
+        let coordination_block = coordination_inbox
+            .as_ref()
+            .map(|inbox| {
+                crate::domains::coordination::format_coordination_notices(
+                    inbox,
+                    project_id,
+                    crate::domains::coordination::NOTICE_RENDER_LIMIT,
+                )
+            })
+            .unwrap_or_default();
+
         let post_compact_restore = if let Some(handle) = restore_context_future {
             match tokio::time::timeout(std::time::Duration::from_secs(4), handle).await {
                 Ok(Ok(Ok(value))) => {
@@ -7929,58 +8468,29 @@ impl ToolHandler for ContextTool {
                 // Text only shows critical alerts (only when no typed items already rendered).
                 if !has_typed {
                     if let Some(lessons) = &result.lessons {
-                        let important: Vec<_> = lessons
+                        // Structured mode: only critical/high lessons make the
+                        // text; the full list stays in structured_content.
+                        let important: Vec<mcp_types::api::Lesson> = lessons
                             .iter()
                             .filter(|l| {
                                 matches!(l.severity.as_deref(), Some("critical") | Some("high"))
                             })
+                            .cloned()
                             .collect();
-                        if !important.is_empty() {
-                            text.push_str(
-                                "\n[LESSONS_WARNING] Apply these lessons before proceeding; keep them active for this task.",
-                            );
-                            for l in important.iter().take(5) {
-                                let sev = if l.severity.as_deref() == Some("critical") {
-                                    "CRIT"
-                                } else {
-                                    "HIGH"
-                                };
-                                let title = l.title.as_deref().unwrap_or("Untitled");
-                                let prevention = l
-                                    .prevention
-                                    .as_deref()
-                                    .or(l.trigger.as_deref())
-                                    .unwrap_or("");
-                                let preview: String = prevention.chars().take(500).collect();
-                                text.push_str(&format!("\n [{}] {}: {}", sev, title, preview));
-                            }
-                        }
+                        text.push_str(&render_lessons_warning(
+                            &lesson_lines_from_api(&important),
+                            true,
+                        ));
                     }
                 }
             } else {
                 // No structured_content: condensed but complete text (fallback when no typed items)
                 if !has_typed {
                     if let Some(lessons) = &result.lessons {
-                        if !lessons.is_empty() {
-                            text.push_str(
-                                "\n[LESSONS_WARNING] Apply these lessons before proceeding; keep them active for this task.",
-                            );
-                            for l in lessons.iter().take(5) {
-                                let sev = match l.severity.as_deref() {
-                                    Some("critical") => "CRIT",
-                                    Some("high") => "HIGH",
-                                    _ => "note",
-                                };
-                                let title = l.title.as_deref().unwrap_or("Untitled");
-                                let prevention = l
-                                    .prevention
-                                    .as_deref()
-                                    .or(l.trigger.as_deref())
-                                    .unwrap_or("");
-                                let preview: String = prevention.chars().take(500).collect();
-                                text.push_str(&format!("\n [{}] {}: {}", sev, title, preview));
-                            }
-                        }
+                        text.push_str(&render_lessons_warning(
+                            &lesson_lines_from_api(lessons),
+                            true,
+                        ));
                     }
 
                     if let Some(items) = &result.remember_items {
@@ -8131,9 +8641,17 @@ impl ToolHandler for ContextTool {
             );
             if let Some(rules) = &result.rules_notice {
                 if rules.status == "missing" {
-                    text.push_str("\n[RULES_NOTICE] Run generate_rules()");
+                    text.push('\n');
+                    text.push_str(&crate::notices::rules_notice_missing(
+                        rules.update_command.as_deref(),
+                    ));
                 } else if rules.status == "behind" {
-                    text.push_str("\n[RULES_NOTICE] Run generate_rules(overwrite_existing=true)");
+                    text.push('\n');
+                    text.push_str(&crate::notices::rules_notice_behind(
+                        rules.current.as_deref().unwrap_or("none"),
+                        &rules.latest,
+                        rules.update_command.as_deref(),
+                    ));
                 }
             }
             // Content-drift fallback: if the server didn't already flag
@@ -8284,38 +8802,10 @@ impl ToolHandler for ContextTool {
             // Legacy fallback: lessons (when no typed L items)
             if !has_typed {
                 if let Some(lessons) = &result.lessons {
-                    if !lessons.is_empty() {
-                        text.push_str(
-                            "🚨 [LESSONS_WARNING] Past Mistakes Found - READ BEFORE PROCEEDING!\n",
-                        );
-                        text.push_str(
-                            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n",
-                        );
-                        for (i, lesson) in lessons.iter().take(5).enumerate() {
-                            let severity = match lesson.severity.as_deref() {
-                                Some("critical") => "🚨",
-                                Some("high") => "⚠️",
-                                _ => "📝",
-                            };
-                            let title = lesson.title.as_deref().unwrap_or("Untitled");
-                            let prevention = lesson
-                                .prevention
-                                .as_deref()
-                                .or(lesson.trigger.as_deref())
-                                .unwrap_or("");
-                            let preview: String = prevention.chars().take(500).collect();
-                            text.push_str(&format!(
-                                "{}. {} {}: {}\n",
-                                i + 1,
-                                severity,
-                                title,
-                                preview
-                            ));
-                        }
-                        text.push_str(
-                            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n",
-                        );
-                    }
+                    text.push_str(&render_lessons_warning(
+                        &lesson_lines_from_api(lessons),
+                        false,
+                    ));
                 }
             }
 
@@ -8347,14 +8837,17 @@ impl ToolHandler for ContextTool {
                 if rules.status == "behind" || rules.status == "missing" {
                     let current = rules.current.as_deref().unwrap_or("none");
                     if rules.status == "missing" {
-                        text.push_str(
-                            "[RULES_NOTICE] Rules missing. Run generate_rules() to install.\n\n",
-                        );
-                    } else {
-                        text.push_str(&format!(
-                            "[RULES_NOTICE] Rules {} → {}. Run generate_rules(overwrite_existing=true) to update.\n\n",
-                            current, rules.latest
+                        text.push_str(&crate::notices::rules_notice_missing(
+                            rules.update_command.as_deref(),
                         ));
+                        text.push_str("\n\n");
+                    } else {
+                        text.push_str(&crate::notices::rules_notice_behind(
+                            current,
+                            &rules.latest,
+                            rules.update_command.as_deref(),
+                        ));
+                        text.push_str("\n\n");
                     }
                 }
             }
@@ -8633,6 +9126,15 @@ impl ToolHandler for ContextTool {
             }
         }
 
+        // `[COORDINATION]` lines go after the warm-cache write so a later
+        // warm emit never replays stale notices.
+        if !coordination_block.is_empty() {
+            if !text.ends_with('\n') {
+                text.push('\n');
+            }
+            text.push_str(&coordination_block);
+        }
+
         let session_snap = self.session.state().await;
         let grounding_emit_path = session_snap
             .folder_path
@@ -8661,6 +9163,9 @@ impl ToolHandler for ContextTool {
                 "grounding_hits".to_string(),
                 serde_json::to_value(&grounding_hits).unwrap_or_else(|_| serde_json::json!([])),
             );
+            if let Some(inbox) = coordination_inbox {
+                obj.insert("coordination_inbox".to_string(), inbox);
+            }
             if let Some(restore) = post_compact_restore {
                 obj.insert("post_compact_restore".to_string(), restore);
             }
@@ -10507,6 +11012,72 @@ pub struct SessionCaptureLessonInput {
     pub project_id: Option<String>,
 }
 
+/// `[PARTIAL]` lines stated whenever the typed `/lessons` endpoints answer
+/// 404 and the events-based path is used instead.
+pub(crate) const LESSONS_CREATE_PARTIAL: &str = "[PARTIAL] /lessons endpoint unavailable (404); stored the lesson as a memory event via /memory/events.";
+pub(crate) const LESSONS_LIST_PARTIAL: &str =
+    "[PARTIAL] /lessons endpoint unavailable (404); listed lessons from memory events.";
+
+/// Where a lesson id was resolved and whether the typed endpoint exists.
+struct LessonTarget {
+    id: Uuid,
+    note: Option<String>,
+    /// `false` once `GET /lessons` answered 404 for this server.
+    lessons_api_available: bool,
+}
+
+/// Resolve a lesson from a UUID or lookup text: typed `/lessons` listing
+/// first, events-based search when the server answers 404.
+async fn resolve_lesson_target(
+    client: &ContextStreamClient,
+    workspace_id: Option<Uuid>,
+    project_id: Option<Uuid>,
+    lookup: &str,
+    limit: Option<i64>,
+) -> Result<LessonTarget> {
+    let lookup = lookup.trim();
+    if let Ok(id) = Uuid::parse_str(lookup) {
+        return Ok(LessonTarget {
+            id,
+            note: None,
+            lessons_api_available: true,
+        });
+    }
+    let search_limit = limit.unwrap_or(50).clamp(10, 100);
+    match client
+        .list_lessons(mcp_client::ListLessonsParams {
+            workspace_id,
+            project_id,
+            query: Some(lookup.to_string()),
+            include_superseded: Some(true),
+            limit: Some(search_limit),
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(envelope) => {
+            let items = extract_result_items(&envelope);
+            let ranked = rank_lesson_matches(&items, lookup);
+            let (id, note) = pick_lesson_match(lookup, &ranked)?;
+            Ok(LessonTarget {
+                id,
+                note,
+                lessons_api_available: true,
+            })
+        }
+        Err(err) if is_not_found_error(&err) => {
+            let (id, note) =
+                resolve_lesson_event_id(client, workspace_id, project_id, lookup, limit).await?;
+            Ok(LessonTarget {
+                id,
+                note,
+                lessons_api_available: false,
+            })
+        }
+        Err(err) => Err(err),
+    }
+}
+
 // Lesson deduplication: 2-minute window to prevent duplicate captures.
 const LESSON_DEDUP_WINDOW: Duration = Duration::from_secs(120);
 
@@ -10609,20 +11180,52 @@ impl ToolHandler for SessionCaptureLessonTool {
             ));
         }
 
-        let params = mcp_client::SessionCaptureLessonParams {
-            title: input.title.clone(),
-            trigger: input.trigger,
-            impact: input.impact,
-            prevention: input.prevention,
-            severity: input.severity,
-            category: input.category,
-            keywords: input.keywords,
+        // Typed `/lessons` first; the events path is only used when the
+        // server answers 404, and the tool text says so.
+        let typed = mcp_client::CreateLessonParams {
             workspace_id: scope.workspace_id,
             project_id: scope.project_id,
+            title: input.title.clone(),
+            trigger: input.trigger.clone(),
+            impact: input.impact.clone(),
+            prevention: input.prevention.clone(),
+            severity: input.severity.clone(),
+            category: input.category.clone(),
+            keywords: input.keywords.clone(),
         };
-        let mut params = params;
-        let mut result = match self.client.session_capture_lesson(params.clone()).await {
+        let mut partial_note: Option<&str> = None;
+        let mut result = match self.client.create_lesson(typed.clone()).await {
             Ok(result) => result,
+            Err(err) if is_not_found_error(&err) => {
+                partial_note = Some(LESSONS_CREATE_PARTIAL);
+                let mut params = mcp_client::SessionCaptureLessonParams {
+                    title: input.title.clone(),
+                    trigger: input.trigger.clone(),
+                    impact: input.impact.clone(),
+                    prevention: input.prevention.clone(),
+                    severity: input.severity.clone(),
+                    category: input.category.clone(),
+                    keywords: input.keywords.clone(),
+                    workspace_id: scope.workspace_id,
+                    project_id: scope.project_id,
+                };
+                match self.client.session_capture_lesson(params.clone()).await {
+                    Ok(result) => result,
+                    Err(err) => {
+                        scope = recover_write_scope_after_project_error(
+                            &self.client,
+                            self.session.as_ref(),
+                            input.workspace_id.as_deref(),
+                            input.project_id.as_deref(),
+                            err,
+                        )
+                        .await?;
+                        params.workspace_id = scope.workspace_id;
+                        params.project_id = scope.project_id;
+                        self.client.session_capture_lesson(params).await?
+                    }
+                }
+            }
             Err(err) => {
                 scope = recover_write_scope_after_project_error(
                     &self.client,
@@ -10632,12 +11235,26 @@ impl ToolHandler for SessionCaptureLessonTool {
                     err,
                 )
                 .await?;
-                params.workspace_id = scope.workspace_id;
-                params.project_id = scope.project_id;
-                self.client.session_capture_lesson(params).await?
+                let mut retry = typed;
+                retry.workspace_id = scope.workspace_id;
+                retry.project_id = scope.project_id;
+                self.client.create_lesson(retry).await?
             }
         };
         attach_scope_recovery_metadata(&mut result, &scope);
+        if let (Some(_), Some(obj)) = (partial_note, result.as_object_mut()) {
+            obj.insert(
+                "fallback".to_string(),
+                Value::String("memory_events".to_string()),
+            );
+            obj.insert(
+                "degraded".to_string(),
+                serde_json::json!([{
+                    "source": "lessons_create",
+                    "detail": "POST /lessons returned 404; lesson stored as a memory event"
+                }]),
+            );
+        }
         let event_id = result
             .get("id")
             .and_then(|v| v.as_str())
@@ -10659,10 +11276,14 @@ impl ToolHandler for SessionCaptureLessonTool {
                 }),
             );
         }
-        let text = format!(
+        let mut text = format!(
             "Lesson captured: {} (ID: {}).\nProgress: completed.",
             input.title, event_id
         );
+        if let Some(note) = partial_note {
+            text.push('\n');
+            text.push_str(note);
+        }
         let mut output = ToolResult::with_structured(text, result);
         if let Some(note) = scope.note {
             output = output.with_prefix(format!("{}\n", note));
@@ -10889,6 +11510,12 @@ async fn resolve_lesson_event_id(
     }
 
     let ranked = rank_lesson_matches(&lessons, lookup);
+    pick_lesson_match(lookup, &ranked)
+}
+
+/// Single high-confidence match wins; several close matches return the
+/// disambiguation list as a validation error.
+fn pick_lesson_match(lookup: &str, ranked: &[RankedLessonMatch]) -> Result<(Uuid, Option<String>)> {
     let best = ranked.first().ok_or_else(|| {
         Error::Validation(format!(
             "No lessons found matching \"{}\". Use session(action=\"get_lessons\", query=\"{}\") to inspect candidates.",
@@ -10898,7 +11525,7 @@ async fn resolve_lesson_event_id(
     let second_score = ranked.get(1).map(|m| m.score).unwrap_or_default();
     if !best.exact && second_score > 0 && best.score <= second_score + 200 {
         return Err(Error::Validation(format_lesson_disambiguation(
-            lookup, &ranked,
+            lookup, ranked,
         )));
     }
 
@@ -11202,6 +11829,95 @@ fn is_lesson_result(item: &Value) -> bool {
 /// Every-turn lesson warnings use a short-lived warm cache. Post-fetch
 /// severity, category, and deduplication filters remain request-local, so the
 /// cache key contains only `(workspace, project, query)`.
+/// Render a `lessons.v1` envelope from `GET /lessons` as a typed list.
+fn render_typed_lessons_result(envelope: Value, scope_note: Option<String>) -> ToolResult {
+    let items = extract_result_items(&envelope);
+    let total = envelope
+        .get("total")
+        .and_then(Value::as_u64)
+        .map(|value| value as usize)
+        .unwrap_or(items.len());
+    let mut text = String::new();
+    if items.is_empty() {
+        text.push_str("No lessons found matching your criteria.");
+    } else {
+        text.push_str(&format!(
+            "Found {} of {} lesson(s).\n\n",
+            items.len(),
+            total
+        ));
+        for (index, lesson) in items.iter().enumerate() {
+            let title = extract_lesson_title(lesson);
+            let severity = extract_lesson_severity(lesson);
+            let id = lesson
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let mut labels = format!("id={id}");
+            if let Some(status) = lesson.get("status").and_then(Value::as_str) {
+                labels.push_str(&format!(" status={status}"));
+            }
+            if let Some(category) = extract_lesson_category(lesson) {
+                labels.push_str(&format!(" category={category}"));
+            }
+            let preview = extract_lesson_prevention(lesson)
+                .or_else(|| {
+                    lesson
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .map(|value| {
+                    let mut short = value.chars().take(1000).collect::<String>();
+                    if value.chars().count() > 1000 {
+                        short.push_str("...");
+                    }
+                    short.replace('\n', " ")
+                })
+                .unwrap_or_default();
+            text.push_str(&format!(
+                "{}. [{}] {} {}\n   {}\n",
+                index + 1,
+                severity.to_uppercase(),
+                title,
+                labels,
+                preview
+            ));
+            if let Some(successor) = lesson.get("superseded_by").and_then(Value::as_str) {
+                text.push_str(&format!("   superseded_by={successor}\n"));
+            }
+            text.push('\n');
+        }
+        if let Some(next_offset) = envelope.get("next_offset").and_then(Value::as_u64) {
+            text.push_str(&format!(
+                "Next offset: {next_offset} (pass offset={next_offset} to continue).\n"
+            ));
+        }
+    }
+    let partial = crate::domains::memory::render_degraded_lines(&envelope);
+    if !partial.is_empty() {
+        text.push('\n');
+        text.push_str(partial.trim_end());
+    }
+    let mut structured = envelope;
+    if let Some(obj) = structured.as_object_mut() {
+        obj.insert("lessons".to_string(), Value::Array(items.clone()));
+        obj.insert(
+            "lessons_count".to_string(),
+            Value::Number((items.len() as u64).into()),
+        );
+        obj.insert(
+            "source".to_string(),
+            Value::String("lessons_api".to_string()),
+        );
+    }
+    let mut output = ToolResult::with_structured(text, structured);
+    if let Some(note) = scope_note {
+        output = output.with_prefix(format!("{}\n", note));
+    }
+    output
+}
+
 pub struct SessionGetLessonsTool {
     client: ContextStreamClient,
     session: Arc<SessionManager>,
@@ -11251,6 +11967,25 @@ impl ToolHandler for SessionGetLessonsTool {
                     .to_string(),
             ));
         }
+
+        // Typed `/lessons` envelope first (server-side severity/category
+        // filters); the events-based path below only runs on 404.
+        let typed_params = mcp_client::ListLessonsParams {
+            workspace_id,
+            project_id,
+            query: input.query.clone(),
+            min_severity: input.severity.clone(),
+            category: input.category.clone(),
+            limit: input.limit.or(Some(10)),
+            ..Default::default()
+        };
+        let legacy_note: Option<&str> = match self.client.list_lessons(typed_params).await {
+            Ok(envelope) => {
+                return Ok(render_typed_lessons_result(envelope, scope.note.clone()));
+            }
+            Err(err) if is_not_found_error(&err) => Some(LESSONS_LIST_PARTIAL),
+            Err(err) => return Err(err),
+        };
 
         let params = mcp_client::SessionGetLessonsParams {
             query: input.query.clone(),
@@ -11441,6 +12176,10 @@ impl ToolHandler for SessionGetLessonsTool {
             out
         };
 
+        let text = match legacy_note {
+            Some(note) => format!("{}\n\n{}", text.trim_end(), note),
+            None => text,
+        };
         let structured = if let Some(obj) = result.as_object() {
             let mut enriched = obj.clone();
             enriched.insert("lessons".to_string(), Value::Array(lessons.clone()));
@@ -11471,6 +12210,22 @@ impl ToolHandler for SessionGetLessonsTool {
             obj
         };
 
+        let mut structured = structured;
+        if legacy_note.is_some() {
+            if let Some(obj) = structured.as_object_mut() {
+                obj.insert(
+                    "source".to_string(),
+                    Value::String("memory_events".to_string()),
+                );
+                obj.insert(
+                    "degraded".to_string(),
+                    serde_json::json!([{
+                        "source": "lessons_list",
+                        "detail": "GET /lessons returned 404; lessons listed from memory events"
+                    }]),
+                );
+            }
+        }
         let mut output = ToolResult::with_structured(text, structured);
         if let Some(note) = scope.note {
             output = output.with_prefix(format!("{}\n", note));
@@ -12083,6 +12838,107 @@ pub struct SessionDecisionTraceInput {
     pub project_id: Option<String>,
 }
 
+fn trace_payload(result: &Value) -> &Value {
+    match result.get("data") {
+        Some(data) if data.is_object() => data,
+        _ => result,
+    }
+}
+
+fn trace_answer(result: &Value) -> Option<String> {
+    result
+        .get("answer")
+        .or_else(|| trace_payload(result).get("answer"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn trace_decisions(result: &Value) -> Vec<Value> {
+    let payload = trace_payload(result);
+    if let Some(list) = result
+        .get("decisions")
+        .or_else(|| payload.get("decisions"))
+        .and_then(Value::as_array)
+    {
+        return list.clone();
+    }
+    match payload.get("decision") {
+        Some(decision) if decision.is_object() => vec![decision.clone()],
+        _ => Vec::new(),
+    }
+}
+
+fn first_decision_id(result: &Value) -> Option<Uuid> {
+    trace_decisions(result)
+        .first()
+        .and_then(|decision| decision.get("id").and_then(Value::as_str))
+        .and_then(|raw| Uuid::parse_str(raw).ok())
+}
+
+/// `[DECISION_TRACE]` text: the server's answer first, then the matched
+/// decisions with their status, then any `[PARTIAL]` fallback note.
+pub(crate) fn render_decision_trace(query: &str, result: &Value) -> String {
+    let mut text = String::new();
+    match trace_answer(result) {
+        Some(answer) => text.push_str(&format!("[DECISION_TRACE] {answer}\n")),
+        None => text.push_str(
+            "[DECISION_TRACE] No synthesized answer from the server; matched decisions are listed below.\n",
+        ),
+    }
+    text.push_str(&format!("Decision trace for \"{query}\"\n\n"));
+    let decisions = trace_decisions(result);
+    if decisions.is_empty() {
+        text.push_str("No matching decisions.\n");
+    }
+    for (index, decision) in decisions.iter().take(5).enumerate() {
+        let title = decision
+            .get("title")
+            .or_else(|| decision.get("summary"))
+            .and_then(Value::as_str)
+            .unwrap_or("Untitled");
+        let date = decision
+            .get("created_at")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let status = decision
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let id = decision
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        text.push_str(&format!(
+            "{}. {title} — status={status} ({date}) id={id}\n",
+            index + 1
+        ));
+        if let Some(rationale) = decision
+            .get("structured")
+            .and_then(|value| value.get("rationale"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+        {
+            let preview: String = rationale.chars().take(160).collect();
+            text.push_str(&format!("   rationale: {}\n", preview.replace('\n', " ")));
+        }
+    }
+    if let Some(reason) = result.get("fallback_reason").and_then(Value::as_str) {
+        let hint = result
+            .get("hint")
+            .and_then(Value::as_str)
+            .map(|hint| format!(" — {hint}"))
+            .unwrap_or_default();
+        text.push_str(&format!(
+            "[PARTIAL] decision trace fallback: {reason}{hint}\n"
+        ));
+    }
+    text.push_str(&crate::domains::memory::render_degraded_lines(result));
+    text.push_str(crate::notices::DECISION_TRACE_HINT);
+    text
+}
+
 /// Session decision trace tool handler.
 pub struct SessionDecisionTraceTool {
     client: ContextStreamClient,
@@ -12121,24 +12977,41 @@ impl ToolHandler for SessionDecisionTraceTool {
             project_id,
         };
 
-        let result = self.client.session_decision_trace(params).await?;
-
-        let mut text = format!("Decision trace for \"{}\"\n\n", input.query);
-
-        if let Some(decisions) = result.get("decisions").and_then(|v| v.as_array()) {
-            for (i, decision) in decisions.iter().take(5).enumerate() {
-                let title = decision
-                    .get("title")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("Untitled");
-                let date = decision
-                    .get("created_at")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                text.push_str(&format!("{}. {} ({})\n", i + 1, title, date));
+        // A UUID query traces one decision through the typed endpoint; text
+        // queries go through the search trace and are enriched with the typed
+        // answer of the top decision when the server exposes it.
+        let query_uuid = Uuid::parse_str(input.query.trim()).ok();
+        let mut result = match query_uuid {
+            Some(id) => match self.client.get_decision_trace(id).await {
+                Ok(trace) => trace,
+                Err(err) if is_not_found_error(&err) => {
+                    self.client.session_decision_trace(params).await?
+                }
+                Err(err) => return Err(err),
+            },
+            None => self.client.session_decision_trace(params).await?,
+        };
+        if trace_answer(&result).is_none() {
+            if let Some(id) = first_decision_id(&result) {
+                if let Ok(trace) = self.client.get_decision_trace(id).await {
+                    if let (Some(answer), Some(obj)) =
+                        (trace_answer(&trace), result.as_object_mut())
+                    {
+                        obj.insert("answer".to_string(), Value::String(answer));
+                        obj.insert(
+                            "markers".to_string(),
+                            trace
+                                .get("markers")
+                                .cloned()
+                                .unwrap_or_else(|| serde_json::json!(["[DECISION_TRACE]"])),
+                        );
+                        obj.insert("trace_decision_id".to_string(), serde_json::json!(id));
+                    }
+                }
             }
         }
 
+        let text = render_decision_trace(&input.query, &result);
         Ok(ToolResult::with_structured(text, result))
     }
 
@@ -14393,12 +15266,7 @@ async fn execute_session_ground(
             include_decisions,
             include_docs,
         ),
-        client.session_get_lessons(SessionGetLessonsParams {
-            query: Some(user_message.to_string()),
-            limit: Some(5),
-            workspace_id: scope.workspace_id,
-            project_id: scope.project_id,
-        }),
+        fetch_lessons_for_ground(client, scope.workspace_id, scope.project_id, user_message),
         client.list_skills(
             scope.workspace_id,
             scope.project_id,
@@ -14457,20 +15325,31 @@ async fn execute_session_ground(
         )
         .await
     {
-        let notices = crate::domains::coordination::inbox_notices(&inbox);
-        for notice in notices.iter().take(5) {
-            let reason = notice
-                .get("reason")
-                .and_then(Value::as_str)
-                .unwrap_or("shared context");
-            let id = notice.get("id").and_then(Value::as_str).unwrap_or_default();
-            text.push_str(&format!(
-                "[COORDINATION] {reason} — ack via coordination(action=\"ack\", notice_id=\"{id}\")\n"
-            ));
-        }
-        if !notices.is_empty() {
+        let block = crate::domains::coordination::format_coordination_notices(
+            &inbox,
+            scope.project_id,
+            crate::domains::coordination::NOTICE_RENDER_LIMIT,
+        );
+        if !block.is_empty() {
+            text.push_str(&block);
             text.push('\n');
         }
+    }
+    // `[LESSONS_WARNING]` through the same renderer `context()` uses:
+    // stored severity, relevance shown separately.
+    let lesson_values: Vec<Value> = extract_result_items(&lessons)
+        .into_iter()
+        .filter(|item| item.get("lesson").is_some() || is_lesson_result(item))
+        .collect();
+    let lesson_lines = lesson_lines_from_values(&lesson_values);
+    if !lesson_lines.is_empty() {
+        text.push_str(render_lessons_warning(&lesson_lines, true).trim_start_matches('\n'));
+        text.push_str("\n\n");
+    }
+    let lessons_partial = crate::domains::memory::render_degraded_lines(&lessons);
+    if !lessons_partial.is_empty() {
+        text.push_str(&lessons_partial);
+        text.push('\n');
     }
     // Context Feeds grounding. Fail-open: a disabled feature gate, an error,
     // or a slow backend simply yields no [FEED] lines.
@@ -14644,6 +15523,20 @@ pub struct SessionInput {
     #[serde(default, deserialize_with = "deserialize_string_or_vec")]
     pub keywords: Option<Vec<String>>,
     pub lesson_id: Option<String>,
+    #[serde(default)]
+    pub successor_id: Option<String>,
+    // Decision fields: capture(event_type="decision") routes to the typed
+    // create when any of these is present.
+    #[serde(default)]
+    pub rationale: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub alternatives: Option<Vec<Value>>,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub confidence: Option<f64>,
+    #[serde(default)]
+    pub supersedes: Option<String>,
     // Query fields
     pub query: Option<String>,
     /// Natural-language anchor for `action="ground"` (falls back to `query`).
@@ -14742,6 +15635,41 @@ impl ToolHandler for SessionTool {
                     .unwrap_or_else(|| "uncategorized".to_string());
                 if is_reserved_plan_event_type(Some(&event_type)) {
                     return Err(reserved_plan_event_error());
+                }
+                // A decision with structured fields is a typed decision:
+                // route it to memory(create_decision) (typed endpoint first,
+                // events fallback on 404 with a [PARTIAL] line).
+                if event_type == "decision"
+                    && crate::domains::memory::has_structured_decision_fields(
+                        input.rationale.as_deref(),
+                        input.alternatives.as_deref(),
+                        input.scope.as_deref(),
+                        input.confidence,
+                    )
+                {
+                    let title = input
+                        .title
+                        .ok_or_else(|| Error::Validation("title is required".to_string()))?;
+                    let decision_input = crate::domains::memory::CreateDecisionInput {
+                        workspace_id: input.workspace_id,
+                        project_id: input.project_id,
+                        title,
+                        content: input.content,
+                        rationale: input.rationale,
+                        alternatives: input.alternatives,
+                        scope: input.scope,
+                        confidence: input.confidence,
+                        supersedes: input.supersedes,
+                        category: input.category,
+                        tags: input.tags,
+                        session_id: input.session_id,
+                    };
+                    return crate::domains::memory::execute_create_decision(
+                        &self.client,
+                        self.session.as_ref(),
+                        decision_input,
+                    )
+                    .await;
                 }
                 let title = input
                     .title
@@ -14958,7 +15886,7 @@ impl ToolHandler for SessionTool {
                     .project_id
                     .as_deref()
                     .and_then(|s| Uuid::parse_str(s).ok());
-                let (lesson_id, resolution_note) = resolve_lesson_event_id(
+                let target = resolve_lesson_target(
                     &self.client,
                     workspace_id,
                     project_id,
@@ -14966,23 +15894,65 @@ impl ToolHandler for SessionTool {
                     input.limit,
                 )
                 .await?;
-                let result = self
-                    .client
-                    .update_memory_event(
-                        lesson_id,
-                        mcp_client::UpdateMemoryEventParams {
-                            title: input.title,
-                            content: input.content,
-                            metadata: None,
-                        },
-                    )
-                    .await?;
                 let mut text = String::new();
-                if let Some(note) = resolution_note {
+                if let Some(note) = target.note.as_deref() {
                     text.push_str(&format!("{}\n", note));
                 }
-                text.push_str(&format!("Lesson updated: {}.", lesson_id));
-                Ok(ToolResult::with_structured(text, result))
+                // Typed lessons have no free-form body: a bare `content` is
+                // applied to `prevention` (stated below) on the typed path.
+                let content_as_prevention =
+                    input.prevention.is_none() && input.content.is_some();
+                let typed = mcp_client::UpdateLessonParams {
+                    title: input.title.clone(),
+                    trigger: input.trigger.clone(),
+                    impact: input.impact.clone(),
+                    prevention: input.prevention.clone().or_else(|| input.content.clone()),
+                    severity: input.severity.clone(),
+                    category: input.category.clone(),
+                    keywords: input.keywords.clone(),
+                };
+                if typed.is_empty() {
+                    return Err(Error::Validation(
+                        "update_lesson needs at least one of: title, trigger, impact, prevention (or content), severity, category, keywords"
+                            .to_string(),
+                    ));
+                }
+                let typed_result = if target.lessons_api_available {
+                    match self.client.update_lesson(target.id, typed).await {
+                        Ok(result) => Some(result),
+                        Err(err) if is_not_found_error(&err) => None,
+                        Err(err) => return Err(err),
+                    }
+                } else {
+                    None
+                };
+                match typed_result {
+                    Some(result) => {
+                        text.push_str(&format!("Lesson updated: {}.", target.id));
+                        if content_as_prevention {
+                            text.push_str("\nnote: `content` was applied to the lesson's prevention field (typed lessons have no free-form body).");
+                        }
+                        Ok(ToolResult::with_structured(text, result))
+                    }
+                    None => {
+                        let result = self
+                            .client
+                            .update_memory_event(
+                                target.id,
+                                mcp_client::UpdateMemoryEventParams {
+                                    title: input.title,
+                                    content: input.content,
+                                    metadata: None,
+                                },
+                            )
+                            .await?;
+                        text.push_str(&format!(
+                            "Lesson updated: {id}.\n[PARTIAL] /lessons endpoint unavailable (404); updated the lesson event via PUT /memory/events/{id}.",
+                            id = target.id
+                        ));
+                        Ok(ToolResult::with_structured(text, result))
+                    }
+                }
             }
             "delete_lesson" => {
                 let lesson_lookup = input
@@ -14996,7 +15966,7 @@ impl ToolHandler for SessionTool {
                     .project_id
                     .as_deref()
                     .and_then(|s| Uuid::parse_str(s).ok());
-                let (lesson_id, resolution_note) = resolve_lesson_event_id(
+                let target = resolve_lesson_target(
                     &self.client,
                     workspace_id,
                     project_id,
@@ -15004,13 +15974,115 @@ impl ToolHandler for SessionTool {
                     input.limit,
                 )
                 .await?;
-                let result = self.client.delete_memory_event(lesson_id).await?;
                 let mut text = String::new();
-                if let Some(note) = resolution_note {
+                if let Some(note) = target.note.as_deref() {
                     text.push_str(&format!("{}\n", note));
                 }
-                text.push_str(&format!("Lesson deleted: {}.", lesson_id));
-                Ok(ToolResult::with_structured(text, result))
+                let typed_result = if target.lessons_api_available {
+                    match self.client.delete_lesson(target.id).await {
+                        Ok(result) => Some(result),
+                        Err(err) if is_not_found_error(&err) => None,
+                        Err(err) => return Err(err),
+                    }
+                } else {
+                    None
+                };
+                match typed_result {
+                    Some(result) => {
+                        text.push_str(&format!("Lesson deleted: {}.", target.id));
+                        Ok(ToolResult::with_structured(text, result))
+                    }
+                    None => {
+                        let result = self.client.delete_memory_event(target.id).await?;
+                        text.push_str(&format!(
+                            "Lesson deleted: {id}.\n[PARTIAL] /lessons endpoint unavailable (404); deleted the lesson event via DELETE /memory/events/{id}.",
+                            id = target.id
+                        ));
+                        Ok(ToolResult::with_structured(text, result))
+                    }
+                }
+            }
+            "supersede_lesson" => {
+                let lesson_lookup = input
+                    .lesson_id
+                    .ok_or_else(|| Error::Validation("lesson_id is required".to_string()))?;
+                let workspace_id = input
+                    .workspace_id
+                    .as_deref()
+                    .and_then(|s| Uuid::parse_str(s).ok());
+                let project_id = input
+                    .project_id
+                    .as_deref()
+                    .and_then(|s| Uuid::parse_str(s).ok());
+                let target = resolve_lesson_target(
+                    &self.client,
+                    workspace_id,
+                    project_id,
+                    lesson_lookup.trim(),
+                    input.limit,
+                )
+                .await?;
+                let successor_id = match input
+                    .successor_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                {
+                    Some(lookup) => Some(
+                        resolve_lesson_target(
+                            &self.client,
+                            workspace_id,
+                            project_id,
+                            lookup,
+                            input.limit,
+                        )
+                        .await?
+                        .id,
+                    ),
+                    None => None,
+                };
+                if successor_id.is_none()
+                    && input.title.as_deref().map(str::trim).is_none_or(str::is_empty)
+                {
+                    return Err(Error::Validation(
+                        "supersede_lesson needs successor_id (an existing lesson) or the replacement lesson fields (title, trigger, impact, prevention)".to_string(),
+                    ));
+                }
+                let body = serde_json::json!({
+                    "successor_id": successor_id,
+                    "title": input.title,
+                    "trigger": input.trigger,
+                    "impact": input.impact,
+                    "prevention": input.prevention,
+                    "severity": input.severity,
+                    "category": input.category,
+                    "keywords": input.keywords,
+                });
+                match self.client.supersede_lesson(target.id, body).await {
+                    Ok(result) => {
+                        let mut text = String::new();
+                        if let Some(note) = target.note.as_deref() {
+                            text.push_str(&format!("{}\n", note));
+                        }
+                        let successor = successor_id
+                            .map(|id| id.to_string())
+                            .or_else(|| {
+                                result
+                                    .get("successor_id")
+                                    .or_else(|| result.get("successor").and_then(|s| s.get("id")))
+                                    .and_then(Value::as_str)
+                                    .map(str::to_string)
+                            })
+                            .unwrap_or_else(|| "new lesson".to_string());
+                        text.push_str(&format!("Lesson superseded: {} → {}.", target.id, successor));
+                        Ok(ToolResult::with_structured(text, result))
+                    }
+                    Err(err) if is_not_found_error(&err) => Err(Error::Validation(format!(
+                        "supersede_lesson needs POST /lessons/{}/supersede, which this server does not expose (404). No events-based fallback exists; use update_lesson or delete_lesson instead.",
+                        target.id
+                    ))),
+                    Err(err) => Err(err),
+                }
             }
             "ground" => {
                 execute_session_ground(&self.client, &self.session, &self.atlas_layer, &input).await
@@ -15353,7 +16425,10 @@ impl ToolHandler for SessionTool {
                     project_id: input.project_id.and_then(|s| Uuid::parse_str(&s).ok()),
                 };
                 let result = self.client.list_suggested_rules(params).await?;
-                Ok(ToolResult::text(serde_json::to_string_pretty(&result)?))
+                Ok(ToolResult::with_structured(
+                    render_suggested_rules_list(&result),
+                    result,
+                ))
             }
             "suggested_rule_action" => {
                 use mcp_client::SuggestedRuleActionParams;
@@ -15365,6 +16440,7 @@ impl ToolHandler for SessionTool {
                 let rule_action = input
                     .rule_action
                     .ok_or_else(|| Error::Validation("rule_action is required".to_string()))?;
+                let rule_action_label = rule_action.clone();
                 let params = SuggestedRuleActionParams {
                     rule_id,
                     rule_action,
@@ -15372,15 +16448,21 @@ impl ToolHandler for SessionTool {
                     modified_keywords: input.modified_keywords,
                 };
                 let result = self.client.suggested_rule_action(params).await?;
-                Ok(ToolResult::text(serde_json::to_string_pretty(&result)?))
+                Ok(ToolResult::with_structured(
+                    render_suggested_rule_action(&rule_id, &rule_action_label, &result),
+                    result,
+                ))
             }
             "suggested_rules_stats" => {
                 let workspace_id = input.workspace_id.and_then(|s| Uuid::parse_str(&s).ok());
                 let result = self.client.suggested_rules_stats(workspace_id).await?;
-                Ok(ToolResult::text(serde_json::to_string_pretty(&result)?))
+                Ok(ToolResult::with_structured(
+                    render_suggested_rules_stats(&result),
+                    result,
+                ))
             }
             _ => Err(Error::Validation(format!(
-                "Unknown action: {}. Use 'capture', 'retro_capture', 'capture_lesson', 'get_lessons', 'update_lesson', 'delete_lesson', 'recall', 'ground', 'set_account_mode', 'remember', 'user_context', 'summary', 'compress', 'delta', 'smart_search', 'decision_trace', 'list_recaps', 'trigger_recap', 'restore_context', 'capture_plan', 'get_plan', 'update_plan', 'list_plans', 'list_suggested_rules', 'suggested_rule_action', or 'suggested_rules_stats'.",
+                "Unknown action: {}. Use 'capture', 'retro_capture', 'capture_lesson', 'get_lessons', 'update_lesson', 'delete_lesson', 'supersede_lesson', 'recall', 'ground', 'set_account_mode', 'remember', 'user_context', 'summary', 'compress', 'delta', 'smart_search', 'decision_trace', 'list_recaps', 'trigger_recap', 'restore_context', 'capture_plan', 'get_plan', 'update_plan', 'list_plans', 'list_suggested_rules', 'suggested_rule_action', or 'suggested_rules_stats'.",
                 input.action
             ))),
         }
@@ -15391,7 +16473,7 @@ impl ToolHandler for SessionTool {
         METADATA.get_or_init(|| ToolMetadata {
             name: "session".to_string(),
             title: "Session Operations".to_string(),
-            description: "Session and memory management — NOT for codebase/file search (use the 'search' tool for that). LESSONS LIVE HERE: when a mistake or correction happens, call action='capture_lesson' (NEVER write lessons to ~/.claude/.../memory/, .cursorrules, or other local markdown — local files are invisible to [LESSONS_WARNING] auto-surfacing on future turns and across sessions). Lesson maintenance is supported via action='update_lesson' and action='delete_lesson' with lesson_id (UUID or lookup text). PAST SESSIONS LIVE HERE: transcripts of every prior session are captured + indexed and are queryable. `context()` auto-surfaces `[GROUNDING]` prior-work hits; when that grounding is fresh, relevant, and sufficient, do not immediately call action='recall' for the same request. Call action='recall' as the first explicit escalation when `[GROUNDING]` is absent, thin, stale, off-topic, or when the user explicitly requests broader or session-specific history. For after-the-fact durable saves, use action='retro_capture' with title plus content and/or query/transcript_id; it stores the capture rationale, source query, transcript IDs, and source snippets in provenance. Use action='ground' with user_message for a one-shot bundle (recall + docs + decisions + lessons + skills + git) outside context(). Also `memory(action=\"list_transcripts\"|\"search_transcripts\"|\"get_transcript\")` for chronological + full-text access. Save a session_snapshot at turning points so the NEXT session can pick up: action='capture', event_type='session_snapshot'. Daily Recaps run around 23:00 in the user's timezone, not at MCP session boundaries; use list_recaps for timestamped history and trigger_recap for a manual asynchronous run. Team/personal mode: action='set_account_mode' with account_mode=team|personal|auto. Actions: capture, retro_capture (after-the-fact decision/note/snapshot capture from prior work with source provenance), capture_lesson (mistakes/corrections — title+trigger+impact+prevention), get_lessons, update_lesson, delete_lesson, recall (retrieve past conversation context when auto-grounding is insufficient), ground (one-shot prior-work bundle — requires user_message or query), remember, user_context, summary, compress, delta, smart_search (searches MEMORY/conversation history only, not code), decision_trace, list_recaps, trigger_recap, restore_context, set_account_mode. Plan actions: capture_plan, get_plan, update_plan, list_plans. Use capture_plan for plans; do not use action='capture' with event_type='plan'. capture_plan requires structured steps and creates linked tasks by default with plan_id and plan_step_id. Suggested rules actions: list_suggested_rules, suggested_rule_action, suggested_rules_stats.".to_string(),
+            description: "Session and memory management — NOT for codebase/file search (use the 'search' tool for that). LESSONS LIVE HERE: when a mistake or correction happens, call action='capture_lesson' (NEVER write lessons to ~/.claude/.../memory/, .cursorrules, or other local markdown — local files are invisible to [LESSONS_WARNING] auto-surfacing on future turns and across sessions). Lesson maintenance is supported via action='update_lesson', action='delete_lesson', and action='supersede_lesson' with lesson_id (UUID or lookup text); lessons go to the typed /lessons endpoints first and fall back to memory events only when the server answers 404 (stated with a [PARTIAL] line). DECISIONS: action='capture' with event_type='decision' plus rationale/alternatives/scope/confidence routes to the typed decision create (same as memory(action=\"create_decision\")). PAST SESSIONS LIVE HERE: transcripts of every prior session are captured + indexed and are queryable. `context()` auto-surfaces `[GROUNDING]` prior-work hits; when that grounding is fresh, relevant, and sufficient, do not immediately call action='recall' for the same request. Call action='recall' as the first explicit escalation when `[GROUNDING]` is absent, thin, stale, off-topic, or when the user explicitly requests broader or session-specific history. For after-the-fact durable saves, use action='retro_capture' with title plus content and/or query/transcript_id; it stores the capture rationale, source query, transcript IDs, and source snippets in provenance. Use action='ground' with user_message for a one-shot bundle (recall + docs + decisions + lessons + skills + git) outside context(). Also `memory(action=\"list_transcripts\"|\"search_transcripts\"|\"get_transcript\")` for chronological + full-text access. Save a session_snapshot at turning points so the NEXT session can pick up: action='capture', event_type='session_snapshot'. Daily Recaps run around 23:00 in the user's timezone, not at MCP session boundaries; use list_recaps for timestamped history and trigger_recap for a manual asynchronous run. Team/personal mode: action='set_account_mode' with account_mode=team|personal|auto. Actions: capture, retro_capture (after-the-fact decision/note/snapshot capture from prior work with source provenance), capture_lesson (mistakes/corrections — title+trigger+impact+prevention), get_lessons, update_lesson, delete_lesson, supersede_lesson, recall (retrieve past conversation context when auto-grounding is insufficient), ground (one-shot prior-work bundle — requires user_message or query), remember, user_context, summary, compress, delta, smart_search (searches MEMORY/conversation history only, not code), decision_trace, list_recaps, trigger_recap, restore_context, set_account_mode. Plan actions: capture_plan, get_plan, update_plan, list_plans. Use capture_plan for plans; do not use action='capture' with event_type='plan'. capture_plan requires structured steps and creates linked tasks by default with plan_id and plan_step_id. Suggested rules actions: list_suggested_rules, suggested_rule_action, suggested_rules_stats.".to_string(),
             category: ToolCategory::Session,
             annotations: ToolAnnotations::destructive(),
             is_pro: false,
@@ -15412,6 +16494,7 @@ impl ToolHandler for SessionTool {
                     "get_lessons",
                     "update_lesson",
                     "delete_lesson",
+                    "supersede_lesson",
                     "recall",
                     "ground",
                     "set_account_mode",
@@ -15536,7 +16619,41 @@ impl ToolHandler for SessionTool {
             )
             .string(
                 "lesson_id",
-                "Lesson ID or lookup text (for update_lesson/delete_lesson)",
+                "Lesson ID or lookup text (for update_lesson/delete_lesson/supersede_lesson)",
+                false,
+            )
+            .string(
+                "successor_id",
+                "Successor lesson ID or lookup text (for supersede_lesson)",
+                false,
+            )
+            .string(
+                "rationale",
+                "Why the decision was made (capture with event_type=decision; routes to the typed decision create)",
+                false,
+            )
+            .property(
+                "alternatives",
+                serde_json::json!({
+                    "type": "array",
+                    "description": "Alternatives considered for a decision: strings or {option, rejected_reason} objects",
+                    "items": {"anyOf": [{"type": "string"}, {"type": "object"}]}
+                }),
+                false,
+            )
+            .string(
+                "scope",
+                "Scope of a decision (capture with event_type=decision)",
+                false,
+            )
+            .number(
+                "confidence",
+                "Confidence in a decision, 0.0-1.0 (capture with event_type=decision)",
+                false,
+            )
+            .string(
+                "supersedes",
+                "Decision id or lookup text this decision replaces (capture with event_type=decision)",
                 false,
             )
             .string("since", "ISO timestamp (for delta)", false)

--- a/crates/mcp-tools/src/domains/session_tests.rs
+++ b/crates/mcp-tools/src/domains/session_tests.rs
@@ -4383,6 +4383,12 @@ mod validation_tests {
         let lesson_id = "11111111-1111-4111-8111-111111111111";
         let (base_url, server_thread) = spawn_ordered_http_server(vec![
             (
+                "GET".to_string(),
+                "/api/v1/lessons?".to_string(),
+                404,
+                serde_json::json!({"error": "not found"}).to_string(),
+            ),
+            (
                 "POST".to_string(),
                 "/api/v1/memory/search".to_string(),
                 200,
@@ -4425,6 +4431,7 @@ mod validation_tests {
         let text = extract_text(&result);
         assert!(text.contains("Resolved lesson"));
         assert!(text.contains("Lesson updated"));
+        assert!(text.contains("[PARTIAL] /lessons endpoint unavailable (404)"));
         server_thread.join().expect("mock server should complete");
     }
 
@@ -4432,6 +4439,12 @@ mod validation_tests {
     async fn test_session_tool_delete_lesson_resolves_lookup_and_deletes_event() {
         let lesson_id = "22222222-2222-4222-8222-222222222222";
         let (base_url, server_thread) = spawn_ordered_http_server(vec![
+            (
+                "GET".to_string(),
+                "/api/v1/lessons?".to_string(),
+                404,
+                serde_json::json!({"error": "not found"}).to_string(),
+            ),
             (
                 "POST".to_string(),
                 "/api/v1/memory/search".to_string(),
@@ -4473,6 +4486,7 @@ mod validation_tests {
         let text = extract_text(&result);
         assert!(text.contains("Resolved lesson"));
         assert!(text.contains("Lesson deleted"));
+        assert!(text.contains("[PARTIAL] /lessons endpoint unavailable (404)"));
         server_thread.join().expect("mock server should complete");
     }
 
@@ -4481,8 +4495,8 @@ mod validation_tests {
         let lesson_a = "33333333-3333-4333-8333-333333333333";
         let lesson_b = "44444444-4444-4444-8444-444444444444";
         let (base_url, server_thread) = spawn_ordered_http_server(vec![(
-            "POST".to_string(),
-            "/api/v1/memory/search".to_string(),
+            "GET".to_string(),
+            "/api/v1/lessons?".to_string(),
             200,
             serde_json::json!({
                 "results": [
@@ -5514,8 +5528,16 @@ mod rules_content_drift_tests {
             "notice must be tagged so the agent recognizes it"
         );
         assert!(
-            notice.contains("generate_rules(overwrite_existing=true)"),
-            "notice must include the recovery command"
+            notice.contains(crate::notices::RULES_REFRESH_COMMAND),
+            "notice must include the real recovery command, not a phantom tool"
+        );
+        assert!(
+            !notice.contains("generate_rules("),
+            "notice must not name a tool that does not exist"
+        );
+        assert!(
+            notice.contains(crate::notices::RULES_PREVIEW_CALL),
+            "notice must point at the tool that previews the rules content"
         );
         assert!(
             notice.contains("drifted"),
@@ -5539,7 +5561,8 @@ mod rules_content_drift_tests {
         // We can't tell whether it's stale, so we stay silent rather
         // than spamming `[RULES_NOTICE]` indefinitely. The first
         // `generate_rules()` re-write will install a marker and the
-        // check starts working from there.
+        // check starts working from there (the next `contextstream-mcp
+        // update` re-write installs one).
         rules_hash::set_canonical_rules_hash("aabbccddeeff0011");
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("CLAUDE.md");
@@ -5674,17 +5697,24 @@ mod typed_item_formatting_tests {
     }
 
     #[test]
-    fn format_typed_lessons_compact_uses_score_severity() {
+    fn format_typed_lessons_compact_keeps_stored_severity_and_relevance_separate() {
         let items = [
-            make_item("L", "Always run tests before commit", 0.9),
+            make_item(
+                "L",
+                "## Always run tests before commit\n**Severity:** high\n### Prevention\nRun cargo test first.",
+                0.9,
+            ),
             make_item("L", "Minor style issue", 0.3),
         ];
         let refs: Vec<&SmartContextItem> = items.iter().collect();
         let result = format_typed_lessons(&refs, true);
-        assert!(result.contains("[LESSONS_WARNING]"));
-        assert!(result.contains("severity=CRIT"));
-        assert!(result.contains("severity=note"));
-        assert!(result.contains("relevance=0.90"));
+        assert_eq!(result.matches("[LESSONS_WARNING]").count(), 2);
+        // Stored severity is rendered; relevance never becomes a severity.
+        assert!(result.contains(
+            "severity=high relevance=0.90 Always run tests before commit: Run cargo test first."
+        ));
+        assert!(result.contains("severity=unspecified relevance=0.30 Minor style issue"));
+        assert!(!result.contains("severity=CRIT"));
     }
 
     #[test]
@@ -5692,8 +5722,53 @@ mod typed_item_formatting_tests {
         let items = [make_item("L", "Always run tests before commit", 0.9)];
         let refs: Vec<&SmartContextItem> = items.iter().collect();
         let result = format_typed_lessons(&refs, false);
-        assert!(result.contains("[LESSONS_WARNING]"));
-        assert!(result.contains("relevance: 0.90"));
+        assert!(result.contains(crate::notices::LESSONS_WARNING_HEADER));
+        assert!(
+            result.contains("1. [UNSPECIFIED] Always run tests before commit (relevance: 0.90)")
+        );
+    }
+
+    #[test]
+    fn one_lessons_renderer_serves_typed_api_and_json_sources() {
+        use super::{
+            lesson_lines_from_api, lesson_lines_from_values, render_lessons_warning,
+            LessonWarningLine,
+        };
+        let api = vec![mcp_types::api::Lesson {
+            title: Some("Quote shell paths".to_string()),
+            trigger: Some("spaces in paths".to_string()),
+            prevention: Some("Always quote paths.".to_string()),
+            severity: Some("critical".to_string()),
+        }];
+        let from_api = lesson_lines_from_api(&api);
+        assert_eq!(from_api[0].severity.as_deref(), Some("critical"));
+        assert_eq!(from_api[0].relevance, None);
+
+        let warnings = json!([{
+            "lesson": {"id": "l-1", "title": "Quote shell paths", "severity": "critical", "prevention": "Always quote paths."},
+            "relevance": 0.83,
+            "reason": "matched keyword shell"
+        }]);
+        let from_values = lesson_lines_from_values(warnings.as_array().unwrap());
+        assert_eq!(from_values[0].id.as_deref(), Some("l-1"));
+        assert_eq!(from_values[0].relevance, Some(0.83));
+        assert_eq!(from_values[0].severity.as_deref(), Some("critical"));
+
+        let compact_api = render_lessons_warning(&from_api, true);
+        let compact_values = render_lessons_warning(&from_values, true);
+        assert!(compact_api.contains("[LESSONS_WARNING] severity=critical relevance=n/a Quote shell paths: Always quote paths."));
+        assert!(compact_values.contains("[LESSONS_WARNING] severity=critical relevance=0.83 Quote shell paths: Always quote paths. id=l-1"));
+
+        let superseded = LessonWarningLine {
+            title: "Old rule".to_string(),
+            guidance: String::new(),
+            severity: None,
+            relevance: None,
+            id: None,
+            superseded: true,
+        };
+        assert!(render_lessons_warning(&[superseded], true).contains("Old rule [superseded]"));
+        assert!(render_lessons_warning(&[], true).is_empty());
     }
 
     #[test]

--- a/crates/mcp-tools/src/lib.rs
+++ b/crates/mcp-tools/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod atlas_flags;
 pub mod domains;
+pub mod notices;
 pub mod registry;
 pub mod schema;
 pub mod wire_tokens;

--- a/crates/mcp-tools/src/notices.rs
+++ b/crates/mcp-tools/src/notices.rs
@@ -1,0 +1,191 @@
+//! Canonical `[NOTICE]` line templates shared by the tool renderers.
+//!
+//! Every notice that names a tool call is rendered from here so a single
+//! test can prove that each referenced tool actually exists on the MCP
+//! surface (see `notice_tool_names` and the registry conformance test in
+//! `crates/mcp-server/tests/integration_tests.rs`). Terminal commands such as
+//! `contextstream-mcp update` are deliberately not tool calls and are written
+//! without parentheses so the extractor never mistakes them for one.
+
+/// Terminal command that refreshes installed rules, hooks, and MCP configs.
+pub const RULES_REFRESH_COMMAND: &str = "contextstream-mcp update";
+
+/// Terminal command that installs rules for a folder that has none yet.
+pub const RULES_INSTALL_COMMAND: &str =
+    "contextstream-mcp setup --yes --editors <editor> --project-path <folder>";
+
+/// Tool call that previews the rules content without touching disk.
+pub const RULES_PREVIEW_CALL: &str = "help(action=\"editor_rules\")";
+
+/// Header emitted once above rendered lessons in verbose mode.
+pub const LESSONS_WARNING_HEADER: &str =
+    "[LESSONS_WARNING] Apply these lessons before proceeding; keep them active for this task.";
+
+/// `[RULES_NOTICE]` for a folder with no installed rules.
+pub fn rules_notice_missing(update_command: Option<&str>) -> String {
+    format!(
+        "[RULES_NOTICE] Rules missing. Run `{}` in a terminal to install them; {} previews the content without writing files.",
+        update_command
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(RULES_INSTALL_COMMAND),
+        RULES_PREVIEW_CALL
+    )
+}
+
+/// `[RULES_NOTICE]` for installed rules that are behind the bundled version.
+pub fn rules_notice_behind(current: &str, latest: &str, update_command: Option<&str>) -> String {
+    format!(
+        "[RULES_NOTICE] Rules {} → {}. Run `{}` in a terminal to refresh installed rules; {} previews the content.",
+        current,
+        latest,
+        update_command
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(RULES_REFRESH_COMMAND),
+        RULES_PREVIEW_CALL
+    )
+}
+
+/// `[RULES_NOTICE]` for a content-hash drift between the installed file and
+/// the binary's bundled teaching.
+pub fn rules_notice_drift(installed_hash: &str, canonical_hash: &str) -> String {
+    format!(
+        "[RULES_NOTICE] Rules content drifted ({} → {}). Run `{}` in a terminal to refresh installed rules; {} previews the content.",
+        installed_hash, canonical_hash, RULES_REFRESH_COMMAND, RULES_PREVIEW_CALL
+    )
+}
+
+/// One `[COORDINATION]` line. `other_project` prefixes the reason with
+/// `[other project]`; the line always ends with the manual ack call and is
+/// never acked automatically.
+pub fn coordination_notice_line(
+    reason: &str,
+    notice_id: &str,
+    other_project: bool,
+    urgency: Option<&str>,
+) -> String {
+    let mut line = String::from("[COORDINATION] ");
+    if other_project {
+        line.push_str("[other project] ");
+    }
+    line.push_str(reason);
+    if let Some(urgency) = urgency
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("normal"))
+    {
+        line.push_str(&format!(" (urgency={urgency})"));
+    }
+    line.push_str(&format!(
+        " — ack via coordination(action=\"ack\", notice_id=\"{notice_id}\")"
+    ));
+    line
+}
+
+/// Truncation trailer for coordination notices that did not fit.
+pub fn coordination_more_line(remaining: usize) -> String {
+    format!(
+        "[COORDINATION] … {remaining} more — coordination(action=\"inbox\") lists them; ack each one explicitly."
+    )
+}
+
+/// Header for typed suggested-rule lines.
+pub const SUGGESTED_RULES_HEADER: &str = "[SUGGESTED_RULES] ContextStream detected patterns and suggests new rules. Present these to the user and let them accept/reject via session(action=\"suggested_rule_action\", rule_id=\"...\", rule_action=\"accept|reject\").";
+
+/// Hint appended to `[DECISION_TRACE]` output.
+pub const DECISION_TRACE_HINT: &str = "Refresh a specific decision with memory(action=\"decisions\", query=\"...\") or act on it with memory(action=\"decision_action\", decision_id=\"...\", decision_action=\"verify|dispute|supersede|invalidate|choose_successor\").";
+
+/// Every static notice template plus one rendered example of each dynamic
+/// notice, for the tool-name conformance test.
+pub fn notice_templates() -> Vec<String> {
+    vec![
+        rules_notice_missing(None),
+        rules_notice_behind("1.0.0", "1.0.1", None),
+        rules_notice_drift("abcd1234", "ef567890"),
+        coordination_notice_line("API contract changed", "n1", true, Some("high")),
+        coordination_more_line(3),
+        LESSONS_WARNING_HEADER.to_string(),
+        SUGGESTED_RULES_HEADER.to_string(),
+        DECISION_TRACE_HINT.to_string(),
+        RULES_PREVIEW_CALL.to_string(),
+    ]
+}
+
+/// Extract every `tool_name(` reference from a notice. Only identifiers
+/// immediately followed by `(` count, so terminal commands and prose never
+/// register as tool calls.
+pub fn notice_tool_names(text: &str) -> Vec<String> {
+    let bytes = text.as_bytes();
+    let mut names = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        let ch = bytes[index] as char;
+        if ch.is_ascii_lowercase() || ch == '_' {
+            let start = index;
+            while index < bytes.len()
+                && ((bytes[index] as char).is_ascii_lowercase()
+                    || (bytes[index] as char).is_ascii_digit()
+                    || bytes[index] == b'_')
+            {
+                index += 1;
+            }
+            let preceded_by_word = start > 0
+                && ((bytes[start - 1] as char).is_ascii_alphanumeric()
+                    || bytes[start - 1] == b'_'
+                    || bytes[start - 1] == b'-'
+                    || bytes[start - 1] == b'.');
+            if index < bytes.len() && bytes[index] == b'(' && !preceded_by_word {
+                let name = &text[start..index];
+                if !names.iter().any(|existing| existing == name) {
+                    names.push(name.to_string());
+                }
+            }
+        } else {
+            index += 1;
+        }
+    }
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_name_extraction_ignores_terminal_commands() {
+        let names = notice_tool_names(&rules_notice_behind("1", "2", None));
+        assert_eq!(names, vec!["help".to_string()]);
+        let names = notice_tool_names(&coordination_notice_line("r", "id", false, None));
+        assert_eq!(names, vec!["coordination".to_string()]);
+        assert!(notice_tool_names("run contextstream-mcp update now").is_empty());
+        // A method call is not a tool call: `foo` is not followed by `(`,
+        // and `bar` is preceded by a word character.
+        assert!(notice_tool_names("foo.bar(1)").is_empty());
+        assert_eq!(
+            notice_tool_names("memory(action=\"decisions\")"),
+            vec!["memory".to_string()]
+        );
+    }
+
+    #[test]
+    fn rules_notice_never_names_a_phantom_tool() {
+        for template in notice_templates() {
+            assert!(
+                !template.contains("generate_rules("),
+                "phantom tool referenced: {template}"
+            );
+        }
+        assert!(rules_notice_missing(Some("contextstream-mcp setup --yes"))
+            .contains("contextstream-mcp setup --yes"));
+    }
+
+    #[test]
+    fn coordination_line_marks_other_projects_and_urgency() {
+        let line = coordination_notice_line("Shared decision", "n1", true, Some("high"));
+        assert!(line.starts_with("[COORDINATION] [other project] Shared decision (urgency=high)"));
+        assert!(line.ends_with("notice_id=\"n1\")"));
+        let plain = coordination_notice_line("Shared decision", "n2", false, Some("normal"));
+        assert!(!plain.contains("[other project]"));
+        assert!(!plain.contains("urgency"));
+    }
+}

--- a/crates/mcp-tools/src/registry.rs
+++ b/crates/mcp-tools/src/registry.rs
@@ -1825,7 +1825,6 @@ const LIGHT_TOOLS: &[&str] = &[
     // Graph
     "graph",
     "graph_related",
-    "graph_decisions",
     // Project
     "project",
     "projects_list",
@@ -1982,6 +1981,9 @@ const CONSOLIDATED_TOOLS: &[&str] = &[
     "memory_create_todo",
     "memory_complete_todo",
     "memory_create_event",
+    // Read alias for `memory(action="decisions")`; previously registered
+    // but unreachable in consolidated mode.
+    "memory_decisions",
 ];
 
 /// Core bundle (always enabled in progressive mode)

--- a/crates/mcp-tools/src/registry_tests.rs
+++ b/crates/mcp-tools/src/registry_tests.rs
@@ -718,6 +718,17 @@ mod constants_tests {
     }
 
     #[test]
+    fn toolset_lists_name_no_phantom_tools() {
+        // `graph_decisions` was listed in the light toolset but never
+        // registered by any domain; `memory_decisions` is registered and must
+        // stay reachable in consolidated mode.
+        assert!(!LIGHT_TOOLS.contains(&"graph_decisions"));
+        assert!(!STANDARD_TOOLS.contains(&"graph_decisions"));
+        assert!(CONSOLIDATED_TOOLS.contains(&"memory_decisions"));
+        assert!(LIGHT_TOOLS.contains(&"memory_decisions"));
+    }
+
+    #[test]
     fn test_standard_tools() {
         assert!(STANDARD_TOOLS.contains(&"workspaces_create"));
         assert!(STANDARD_TOOLS.contains(&"reminders_create"));

--- a/crates/mcp-types/src/harness.rs
+++ b/crates/mcp-types/src/harness.rs
@@ -52,6 +52,11 @@ pub enum HarnessId {
     OpenAiResponses,
     #[serde(rename = "contextstream-cli")]
     ContextStreamCli,
+    /// ContextCode — ContextStream's own agent harness (`csc`). Runtime-only:
+    /// it drives the hosted MCP surface directly and receives dynamic guidance
+    /// through tool results rather than installed rules files or hooks.
+    #[serde(rename = "contextcode")]
+    ContextCode,
 }
 
 impl HarnessId {
@@ -71,6 +76,7 @@ impl HarnessId {
         Self::ChatGptGateway,
         Self::OpenAiResponses,
         Self::ContextStreamCli,
+        Self::ContextCode,
     ];
 
     /// Harnesses that the local setup wizard can configure.
@@ -105,6 +111,7 @@ impl HarnessId {
             Self::ChatGptGateway => "chatgpt-gateway",
             Self::OpenAiResponses => "openai-responses",
             Self::ContextStreamCli => "contextstream-cli",
+            Self::ContextCode => "contextcode",
         }
     }
 
@@ -125,6 +132,7 @@ impl HarnessId {
             Self::ChatGptGateway => "ChatGPT Gateway",
             Self::OpenAiResponses => "OpenAI Responses",
             Self::ContextStreamCli => "ContextStream CLI",
+            Self::ContextCode => "ContextCode",
         }
     }
 
@@ -154,6 +162,8 @@ impl HarnessId {
                 Some(Self::OpenAiResponses)
             }
             "contextstream-cli" | "contextstream_cli" | "cli" => Some(Self::ContextStreamCli),
+            "contextcode" | "context-code" | "context_code" | "csc" | "contextcode-cli"
+            | "contextcode-engine" | "contextcode-vscode" => Some(Self::ContextCode),
             _ => None,
         }
     }
@@ -294,6 +304,16 @@ impl HarnessId {
                 TeachingLoadEvidence::BehavioralInference,
             ),
             Self::ContextStreamCli => HarnessProfile::runtime_only(
+                self,
+                McpTransportSupport::LocalAndRemote,
+                TeachingLoadEvidence::BehavioralInference,
+            ),
+            // ContextCode reaches the hosted MCP surface over both transports
+            // and re-reads tool-result guidance every turn, so it gets the
+            // capability-aware (MCP-tools) teaching path instead of the
+            // capability-free unknown-client path. No rules files, hooks, or
+            // hard first-call enforcement are claimed for it.
+            Self::ContextCode => HarnessProfile::runtime_only(
                 self,
                 McpTransportSupport::LocalAndRemote,
                 TeachingLoadEvidence::BehavioralInference,
@@ -633,6 +653,14 @@ mod tests {
             HarnessId::from_client_hint("openai-responses-e2e"),
             Some(HarnessId::OpenAiResponses)
         );
+        assert_eq!(
+            HarnessId::from_client_hint("contextcode-vscode/0.7.156"),
+            Some(HarnessId::ContextCode)
+        );
+        assert_eq!(
+            HarnessId::from_client_hint("csc 0.7"),
+            Some(HarnessId::ContextCode)
+        );
         assert_eq!(HarnessId::from_client_hint("my-cursor-proxy"), None);
         assert_eq!(HarnessId::from_client_hint("claude-code-wrapper"), None);
         assert_eq!(HarnessId::from_client_hint(""), None);
@@ -650,6 +678,24 @@ mod tests {
         assert_eq!(direct, vec![HarnessId::ClaudeCode]);
         assert!(HarnessId::ClaudeCode.profile().hooks.instructions_loaded);
         assert!(!HarnessId::Cursor.profile().hooks.instructions_loaded);
+    }
+
+    #[test]
+    fn contextcode_is_runtime_only_with_real_mcp_transport() {
+        let profile = HarnessId::ContextCode.profile();
+        assert!(!profile.installable);
+        assert!(!HarnessId::INSTALLABLE.contains(&HarnessId::ContextCode));
+        assert_eq!(profile.mcp_support, McpTransportSupport::LocalAndRemote);
+        assert_eq!(profile.rules_format, RulesFormat::None);
+        assert_eq!(profile.hooks, HookCapabilities::none());
+        assert!(!profile.hard_first_call_enforcement);
+        assert_eq!(
+            profile.teaching_load_evidence,
+            TeachingLoadEvidence::BehavioralInference
+        );
+        for alias in ["contextcode", "csc", "context-code", "contextcode-cli"] {
+            assert_eq!(HarnessId::from_alias(alias), Some(HarnessId::ContextCode));
+        }
     }
 
     #[test]

--- a/scripts/ovh-cargo.sh
+++ b/scripts/ovh-cargo.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Run a cargo command for the CURRENT working tree on the OVH dev host.
+#
+# Builds never run on the Mac. This ships the working tree as a git patch over
+# ssh (never rsync): the remote worktree is reset to the same upstream base
+# commit (merge-base with origin/main), the patch of committed-but-unpushed,
+# uncommitted, and untracked changes is applied, then cargo runs there with a
+# per-worktree target directory.
+#
+# Usage:
+#   scripts/ovh-cargo.sh check --workspace
+#   scripts/ovh-cargo.sh test -p mcp-tools lessons -- --nocapture
+#   scripts/ovh-cargo.sh clippy --workspace --all-targets -- -D warnings
+#   scripts/ovh-cargo.sh fmt --check
+#
+# Env: OVH_HOST (default ovh-dev),
+#      OVH_REMOTE_DIR (default ~/dev/maker/mcp-server-wt-parity),
+#      OVH_TARGET_DIR (default ~/dev/maker/mcp-server-wt-parity/target),
+#      OVH_EXTRA_ENV (extra `KEY=value` pairs exported before cargo).
+set -euo pipefail
+
+HOST=${OVH_HOST:-ovh-dev}
+REMOTE_DIR=${OVH_REMOTE_DIR:-'$HOME/dev/maker/mcp-server-wt-parity'}
+TARGET_DIR=${OVH_TARGET_DIR:-'$HOME/dev/maker/mcp-server-wt-parity/target'}
+EXTRA_ENV=${OVH_EXTRA_ENV:-}
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "ovh-cargo: run from inside the mcp-server checkout" >&2
+  exit 2
+fi
+if ! git rev-parse --verify -q origin/main >/dev/null; then
+  echo "ovh-cargo: origin/main is unknown locally; run 'git fetch origin' first" >&2
+  exit 2
+fi
+if [ "$#" -eq 0 ]; then
+  echo "ovh-cargo: pass the cargo subcommand and arguments" >&2
+  exit 2
+fi
+
+BASE=$(git merge-base HEAD origin/main)
+PATCH=$(mktemp -t ovh-cargo-patch.XXXXXX)
+UNTRACKED=$(mktemp -t ovh-cargo-untracked.XXXXXX)
+trap 'rm -f "$PATCH" "$UNTRACKED"' EXIT
+
+git ls-files --others --exclude-standard -z > "$UNTRACKED"
+if [ -s "$UNTRACKED" ]; then
+  xargs -0 git add -N -- < "$UNTRACKED"
+fi
+git diff --binary --no-color "$BASE" > "$PATCH"
+if [ -s "$UNTRACKED" ]; then
+  xargs -0 git reset -q -- < "$UNTRACKED"
+fi
+
+CARGO_ARGS=$(printf '%q ' "$@")
+echo "ovh-cargo: base $(git rev-parse --short "$BASE"), patch $(wc -c < "$PATCH" | tr -d ' ') bytes, host $HOST: cargo $*" >&2
+
+# shellcheck disable=SC2029
+ssh -o BatchMode=yes "$HOST" "export PATH=\$HOME/.cargo/bin:\$PATH; set -e
+REMOTE_DIR=$REMOTE_DIR
+MAIN_DIR=\$HOME/dev/maker/mcp-server
+if [ ! -d \"\$MAIN_DIR/.git\" ]; then git clone -q git@github.com:contextstream/mcp-server.git \"\$MAIN_DIR\"; fi
+git -C \"\$MAIN_DIR\" fetch -q origin
+if [ ! -e \"\$REMOTE_DIR/.git\" ]; then git -C \"\$MAIN_DIR\" worktree add -q --detach \"\$REMOTE_DIR\" $BASE; fi
+cd \"\$REMOTE_DIR\"
+git checkout -q --detach $BASE
+git reset -q --hard
+git clean -qfd -e target
+git apply --binary --whitespace=nowarn --allow-empty -
+echo \"== applied: \$(git status --short | wc -l | tr -d ' ') paths differ from base\" >&2
+git status --short | sed 's/^/==   /' >&2
+export CARGO_TARGET_DIR=$TARGET_DIR
+export CARGO_INCREMENTAL=0
+$EXTRA_ENV
+cargo $CARGO_ARGS" < "$PATCH"


### PR DESCRIPTION
Brings the MCP server up to the decisions and lessons contract the backend now
exposes, so every client reads and writes the same shapes.

- `memory(decisions)` passes `category`, `sort`, `status`, `since` and `offset`
  through, asks for the typed envelope, and renders `[DECISIONS]` lines with a
  `[PARTIAL]` marker when the server reports a degraded source.
- New `memory(create_decision)` and `memory(decision_action)`;
  `session(capture, decision)` routes to the typed write when structured fields
  are present, and `supersede_node` accepts lookup text rather than only a UUID.
- One lessons renderer replaces the four that disagreed on severity, and
  `ground()` now emits `[LESSONS_WARNING]`. Lesson tools call `/lessons`, with a
  stated fallback to events only on 404.
- `context()` delivers `[COORDINATION]` and calls `check_in` when a session id is
  present; `kind` is validated and truncation is reported rather than silently
  dropped.
- `HarnessId` gains `contextcode`/`csc` aliases so the CLI is no longer taught
  capability-free.

Four schema hashes move deliberately (coordination, memory, session, and the new
memory_decisions); the other 29 are unchanged.

Verified on the OVH dev host: `cargo test --workspace`,
`cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)