### PR TITLE
feat(coordination): reply action and check-in presence metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- Decision conflicts: the API flags a decision capture that overlaps another
+  session's recent decision on the same subject (`possible_conflicts`, either
+  direction). `[DECISIONS]` / `[RECENT_DECISIONS]` lines carry a
+  `⚠️ possible conflict with "…"` note plus a `[DECISION_CONFLICT]` rule,
+  `[GROUNDING]` hits get a `conflict-check` label and a `DECISION_CONFLICT`
+  line naming the other decision, the session-start and subagent-start
+  briefings show the note, and `session(action="capture")` announces it so
+  the agent confirms with the user which decision stands and supersedes the
+  other. Older API builds render nothing extra.
+- Coordination v2: `coordination(action="reply", notice_id, message)` answers
+  a notice back to the session that raised it (identical replies dedup;
+  fan-in and ended-session notices have no origin and are reported as "ack or
+  dismiss instead"); `check_in` forwards an optional `metadata` object (git
+  branch/commit) as presence metadata the coordination judge sees as
+  evidence; a `(blocking)` notice is a direct conflict with another session,
+  to be read before continuing and then acked or replied to.
+
 - Wave 3b parity: `memory(action="decisions")` requests the typed
   `decisions.v1` envelope (query, category, sort, status, since, offset) and
   renders `[DECISIONS]` / `[DECISION]` lines with status, freshness, category,

--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -13816,6 +13816,7 @@ impl ContextStreamClient {
         project_id: Option<Uuid>,
         session_id: &str,
         task_summary: Option<&str>,
+        metadata: Option<&serde_json::Value>,
     ) -> Result<serde_json::Value> {
         let config = self.config.read().await;
         let ws_id = workspace_id.or(config.default_workspace_id);
@@ -13833,6 +13834,11 @@ impl ContextStreamClient {
         if let Some(summary) = task_summary {
             body["task_summary"] = serde_json::json!(summary);
         }
+        // Presence metadata (git branch/commit) is evidence for the
+        // coordination judge; only objects are forwarded.
+        if let Some(metadata) = metadata.filter(|value| value.is_object()) {
+            body["metadata"] = metadata.clone();
+        }
         self.post("/coordination/check-in", &body).await
     }
 
@@ -13847,6 +13853,19 @@ impl ContextStreamClient {
     pub async fn get_coordination_notice(&self, notice_id: Uuid) -> Result<serde_json::Value> {
         self.get(&format!("/coordination/notices/{}", notice_id))
             .await
+    }
+
+    /// Answer a coordination notice back to the session that raised it.
+    pub async fn reply_coordination_notice(
+        &self,
+        notice_id: Uuid,
+        message: &str,
+    ) -> Result<serde_json::Value> {
+        self.post(
+            &format!("/coordination/notices/{}/reply", notice_id),
+            &serde_json::json!({ "message": message }),
+        )
+        .await
     }
 
     pub async fn ack_coordination_notice(&self, notice_id: Uuid) -> Result<serde_json::Value> {

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -2417,8 +2417,10 @@ mod tests {
             // Advanced in Wave 4b: `kind` became a validated enum
             // (decision|constraint|warning|insight|blocker|request|handoff|note)
             // so an invalid kind fails client-side instead of round-tripping.
+            // Coordination v2: action=reply with `message`, and `metadata`
+            // (git branch/commit) on check_in as judge evidence.
             "coordination",
-            "54c1a6f6df03f8c9d4c78538d7e4d82e24d61219eac2469d4add36ca9305a5ea",
+            "e43264391eb4844f2ee5d0255dae9d9808d290d4fecd3ac13c5427b5af04ddef",
         ),
         (
             "entity",

--- a/crates/mcp-tools/src/domains/coordination.rs
+++ b/crates/mcp-tools/src/domains/coordination.rs
@@ -15,7 +15,7 @@ use crate::registry::ToolHandler;
 use crate::schema::SchemaBuilder;
 
 const VALID_ACTIONS: &[&str] = &[
-    "check_in", "inbox", "list", "get", "share", "ack", "dismiss", "settings",
+    "check_in", "inbox", "list", "get", "share", "ack", "reply", "dismiss", "settings",
 ];
 
 /// Coordination item kinds accepted by `POST /coordinations`. Validated
@@ -52,6 +52,10 @@ pub struct CoordinationInput {
     pub target_project_ids: Option<Vec<String>>,
     pub enabled: Option<bool>,
     pub limit: Option<i64>,
+    /// Reply text for action=reply.
+    pub message: Option<String>,
+    /// Presence metadata for check_in, e.g. {"git": {"branch", "commit"}}.
+    pub metadata: Option<Value>,
 }
 
 pub struct CoordinationTool {
@@ -108,6 +112,7 @@ impl ToolHandler for CoordinationTool {
                         project_id,
                         &session_id,
                         input.task_summary.as_deref(),
+                        input.metadata.as_ref(),
                     )
                     .await?;
                 Ok(ToolResult::with_structured(
@@ -192,6 +197,25 @@ impl ToolHandler for CoordinationTool {
                     result,
                 ))
             }
+            "reply" => {
+                let notice_id = input
+                    .notice_id
+                    .or(input.id)
+                    .ok_or_else(|| Error::Validation("notice_id is required for reply".into()))?;
+                let uuid = Uuid::parse_str(&notice_id)
+                    .map_err(|_| Error::Validation("Invalid notice_id".into()))?;
+                let message = input
+                    .message
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|m| !m.is_empty())
+                    .ok_or_else(|| Error::Validation("message is required for reply".into()))?;
+                let result = self.client.reply_coordination_notice(uuid, message).await?;
+                Ok(ToolResult::with_structured(
+                    format_reply(&result, &notice_id),
+                    result,
+                ))
+            }
             "dismiss" => {
                 let notice_id = input
                     .notice_id
@@ -237,8 +261,11 @@ impl ToolHandler for CoordinationTool {
                 coordination items when knowledge from one workspace/project is needed \
                 in another. Distinct from handoffs (ownership transfer) and capsules \
                 (portable bundles). Actions: check_in, inbox/list, get, share, ack, \
-                dismiss, settings. context() and init() already heartbeat presence. \
-                When [COORDINATION] appears, read it before continuing and ack after use."
+                reply, dismiss, settings. context() and init() already heartbeat presence. \
+                When [COORDINATION] appears, read it before continuing and ack after use. \
+                A (blocking) notice is a direct conflict with another session: read it \
+                before continuing, then ack or reply (action=reply, notice_id, message) so \
+                the other session sees your answer on its next turn."
                 .to_string(),
             category: ToolCategory::Memory,
             annotations: ToolAnnotations::destructive(),
@@ -259,8 +286,18 @@ impl ToolHandler for CoordinationTool {
             .uuid("project_id", "Project ID. Defaults to active scope.", false)
             .string("session_id", "Live session id for check_in / inbox.", false)
             .string("task_summary", "What this agent is working on.", false)
+            .object(
+                "metadata",
+                "Presence metadata for check_in shown to the judge as evidence, e.g. {\"git\": {\"branch\": \"...\", \"commit\": \"...\"}}.",
+                false,
+            )
             .string("id", "Coordination item id for get.", false)
-            .string("notice_id", "Notice id for ack / dismiss.", false)
+            .string("notice_id", "Notice id for ack / reply / dismiss.", false)
+            .string(
+                "message",
+                "Reply text for action=reply; delivered to the session that raised the notice.",
+                false,
+            )
             .string("title", "Title when sharing an item.", false)
             .string("summary", "Short summary of the shared knowledge.", false)
             .string(
@@ -438,6 +475,25 @@ fn format_item(result: &Value, id: &str) -> String {
     format!("Coordination item {id} ({kind}): {title}")
 }
 
+fn format_reply(result: &Value, notice_id: &str) -> String {
+    let payload = result.get("data").unwrap_or(result);
+    let created = payload
+        .get("created")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let to_session = payload
+        .pointer("/notice/to_session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("the origin session");
+    if created {
+        format!(
+            "Replied to coordination notice {notice_id}; {to_session} sees it on its next turn. The original notice is still open — ack it when you are done."
+        )
+    } else {
+        format!("An identical reply to coordination notice {notice_id} already exists; nothing new was sent.")
+    }
+}
+
 fn format_notice(result: &Value, id: &str) -> String {
     let payload = result.get("data").unwrap_or(result);
     let reason = payload
@@ -552,6 +608,17 @@ mod tests {
         let err = validate_kind(Some("knowledge")).unwrap_err().to_string();
         assert!(err.contains("Invalid coordination kind"));
         assert!(err.contains("handoff"));
+    }
+
+    #[test]
+    fn reply_text_names_the_origin_session_and_dedup_outcome() {
+        let created = json!({"data": {"created": true, "notice": {"to_session_id": "origin-1"}, "reply_to": "n1"}});
+        let text = format_reply(&created, "n1");
+        assert!(text.contains("Replied to coordination notice n1"));
+        assert!(text.contains("origin-1 sees it on its next turn"));
+        let duplicate = json!({"created": false, "notice": {"to_session_id": "origin-1"}});
+        assert!(format_reply(&duplicate, "n1").contains("already exists"));
+        assert!(VALID_ACTIONS.contains(&"reply"));
     }
 
     #[test]

--- a/crates/mcp-tools/src/domains/session.rs
+++ b/crates/mcp-tools/src/domains/session.rs
@@ -6450,6 +6450,7 @@ fn spawn_coordination_check_in(
                         project_id,
                         &session_id,
                         task_summary.as_deref(),
+                        None,
                     )
                     .await
             },


### PR DESCRIPTION
## Summary
Coordination v2 (contextstream plan 53913d23, API side in contextstream `feat/coordination-v2`) makes multi-session awareness two-way:
- `coordination(action="reply", notice_id, message)` posts to the new `POST /coordination/notices/:id/reply`, which sends an info notice back to the session that raised the original one. Identical replies dedup; fan-in and ended-session notices have no origin session and return 400, reported as "ack or dismiss instead".
- `check_in` forwards an optional `metadata` object (git branch/commit) as presence metadata; the API shows it to the coordination judge as evidence.
- Tool description covers the new `(blocking)` tier: a direct conflict with another session, read before continuing, then ack or reply.

## Test plan
- [x] `cargo test -p mcp-tools -p mcp-client -p mcp-server --lib -- coordination` (new `reply_text_names_the_origin_session_and_dedup_outcome`)
- [ ] Live smoke after the API rolls: two sessions exchanging notice → reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)