### PR TITLE
chore(release): v1.0.1

### DIFF
--- a/.github/scripts/test_public_boundary.py
+++ b/.github/scripts/test_public_boundary.py
@@ -18,7 +18,7 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
 class PublicBoundaryTest(unittest.TestCase):
     def test_repository_satisfies_public_boundary(self) -> None:
-        self.assertEqual(boundary.verify(REPOSITORY_ROOT), "1.0.0")
+        self.assertEqual(boundary.verify(REPOSITORY_ROOT), "1.0.1")
 
     def test_forbidden_private_source_is_detected(self) -> None:
         with tempfile.TemporaryDirectory(prefix="public-boundary-") as temporary:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## 1.0.1
+
+- Answer: `answer` actions for query, recent changes, receipt recovery, and
+  feedback against the ContextStream Answer API. Mutations are one-shot with
+  no retry or session-refresh replay; request and receipt identity are
+  validated with strict closed schemas, and recorded-only feedback is
+  reported as such (#83).
 
 - Decision conflicts: the API flags a decision capture that overlaps another
   session's recent decision on the same subject (`possible_conflicts`, either

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mcp-acceleration-products"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-model-registry"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "mcp-types",
  "serde",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-server"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-session"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "dashmap",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-tools"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"
@@ -89,12 +89,12 @@ fs2 = "0.4"
 notify = "6"
 
 # Workspace crates
-mcp-types = { version = "=1.0.0", path = "crates/mcp-types" }
-mcp-client = { version = "=1.0.0", path = "crates/mcp-client" }
-mcp-session = { version = "=1.0.0", path = "crates/mcp-session" }
-mcp-tools = { version = "=1.0.0", path = "crates/mcp-tools" }
-mcp-model-registry = { version = "=1.0.0", path = "crates/mcp-model-registry" }
-mcp-acceleration-products = { version = "=1.0.0", path = "crates/mcp-acceleration-products" }
+mcp-types = { version = "=1.0.1", path = "crates/mcp-types" }
+mcp-client = { version = "=1.0.1", path = "crates/mcp-client" }
+mcp-session = { version = "=1.0.1", path = "crates/mcp-session" }
+mcp-tools = { version = "=1.0.1", path = "crates/mcp-tools" }
+mcp-model-registry = { version = "=1.0.1", path = "crates/mcp-model-registry" }
+mcp-acceleration-products = { version = "=1.0.1", path = "crates/mcp-acceleration-products" }
 
 # Testing
 mockall = "0.13"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextstream/mcp-server",
   "mcpName": "io.github.contextstream/mcp-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Verified npm launcher for the open-source ContextStream Rust MCP server",
   "type": "module",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.contextstream/mcp-server",
   "title": "ContextStream MCP Server",
   "description": "Project memory, semantic code search, and grounded agent context.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "url": "https://github.com/contextstream/mcp-server",
     "source": "github"
@@ -20,7 +20,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@contextstream/mcp-server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
Release identity bump to 1.0.1 across the Cargo workspace, `package.json`, `server.json`, and the changelog (Unreleased → 1.0.1). Contents since 1.0.0:
- Wave 3b parity: typed decisions and lessons, one lessons renderer, coordination in `context()` (#84)
- Capture-time decision conflict rendering in grounding, decisions blocks, hooks, and capture (#85)
- Coordination v2: `reply` action and check-in presence metadata (#86)

After merge, the annotated tag `v1.0.1` on the merge commit triggers the release workflow (build, SBOM, attestation, approval gates).

## Test plan
- [x] `python3 .github/scripts/release_contract.py resolve-version . workflow_dispatch refs/heads/main` → 1.0.1
- [x] `python3 .github/scripts/public_boundary.py .`
- [x] `cargo check -p mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)