### PR TITLE
fix(coordination): match the share kind validator to the API enum

### DIFF
--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -2427,7 +2427,7 @@ mod tests {
             // Coordination v2: action=reply with `message`, and `metadata`
             // (git branch/commit) on check_in as judge evidence.
             "coordination",
-            "e43264391eb4844f2ee5d0255dae9d9808d290d4fecd3ac13c5427b5af04ddef",
+            "63a765be22dd19970e1aed0999ea8befd851514cad42382deee364e808707c37",
         ),
         (
             "entity",

--- a/crates/mcp-tools/src/domains/coordination.rs
+++ b/crates/mcp-tools/src/domains/coordination.rs
@@ -19,17 +19,22 @@ const VALID_ACTIONS: &[&str] = &[
 ];
 
 /// Coordination item kinds accepted by `POST /coordinations`. Validated
-/// client-side so a typo fails fast instead of round-tripping a 4xx.
+/// client-side so a typo fails fast instead of round-tripping a 4xx. This
+/// list must stay identical to the API's `coordination_kind_is_known`
+/// (decision, constraint, api_contract, risk, status, knowledge): 1.0.1
+/// shipped a divergent list and every `status`/`risk` share failed client-side
+/// while the only client-accepted default (`note`) was refused by the API.
 pub const VALID_KINDS: &[&str] = &[
     "decision",
     "constraint",
-    "warning",
-    "insight",
-    "blocker",
-    "request",
-    "handoff",
-    "note",
+    "api_contract",
+    "risk",
+    "status",
+    "knowledge",
 ];
+
+/// Kind applied when `share` omits one; matches the API default.
+pub const DEFAULT_KIND: &str = "knowledge";
 
 /// Default number of `[COORDINATION]` lines rendered by `context()` /
 /// `session(action="ground")` before the `… N more` trailer.
@@ -307,7 +312,7 @@ impl ToolHandler for CoordinationTool {
             )
             .string_enum(
                 "kind",
-                "Kind of shared item (defaults to note).",
+                "Kind of shared item: decision, constraint, api_contract, risk, status, or knowledge (defaults to knowledge; mirrors the API enum).",
                 VALID_KINDS,
                 false,
             )
@@ -349,11 +354,11 @@ fn coordination_id(value: &Value) -> Option<&str> {
     payload.get("id").and_then(Value::as_str)
 }
 
-/// Validate a `kind` for `share`; `None` defaults to `note`.
+/// Validate a `kind` for `share`; `None` defaults to [`DEFAULT_KIND`].
 pub fn validate_kind(kind: Option<&str>) -> Result<String> {
     let kind = kind.map(str::trim).filter(|value| !value.is_empty());
     match kind {
-        None => Ok("note".to_string()),
+        None => Ok(DEFAULT_KIND.to_string()),
         Some(value) => {
             let normalized = value.to_ascii_lowercase();
             if VALID_KINDS.contains(&normalized.as_str()) {
@@ -600,14 +605,31 @@ mod tests {
 
     #[test]
     fn share_kind_is_validated_client_side() {
-        assert_eq!(validate_kind(None).unwrap(), "note");
+        assert_eq!(validate_kind(None).unwrap(), "knowledge");
         assert_eq!(validate_kind(Some("Decision")).unwrap(), "decision");
+        assert_eq!(validate_kind(Some(" STATUS ")).unwrap(), "status");
         for kind in VALID_KINDS {
             assert_eq!(validate_kind(Some(kind)).unwrap(), *kind);
         }
-        let err = validate_kind(Some("knowledge")).unwrap_err().to_string();
-        assert!(err.contains("Invalid coordination kind"));
-        assert!(err.contains("handoff"));
+        // The API enum (handlers/coordination.rs coordination_kind_is_known).
+        assert_eq!(
+            VALID_KINDS,
+            &[
+                "decision",
+                "constraint",
+                "api_contract",
+                "risk",
+                "status",
+                "knowledge"
+            ]
+        );
+        for legacy in [
+            "note", "warning", "insight", "blocker", "request", "handoff",
+        ] {
+            let err = validate_kind(Some(legacy)).unwrap_err().to_string();
+            assert!(err.contains("Invalid coordination kind"), "{legacy}");
+            assert!(err.contains("knowledge"), "{legacy}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- \`coordination(action=share)\` on 1.0.1 validates \`kind\` against a list the API never accepted (\`warning\`, \`insight\`, \`blocker\`, \`request\`, \`handoff\`, \`note\`), while rejecting the API's real kinds \`api_contract\`, \`risk\`, \`status\`, \`knowledge\`. Every deploy status/risk notice fails client-side and the client default \`note\` is refused by the API with 422.
- Align \`VALID_KINDS\` with the API enum, default an omitted kind to \`knowledge\` exactly like the API, and spell the enum out in the tool schema. Schema hash for \`coordination\` updated.

## Verification
- \`cargo test -p mcp-tools coordination\` (11 passed; the test now pins the list to the API enum)
- \`cargo test -p mcp-server broad_input_schemas\`
- Reproduced against the hosted 1.0.1 gateway: \`kind=status\` rejected client-side, \`kind=note\` rejected by the API.

Ticket: ContextStream 09c8bc8e. Intended for a 1.0.2 release followed by a deploy-mcp-http roll to ovh-east/ovh-west.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fQTc1rSCr6Ds1pvLbrJwH