### PR TITLE
chore(release): v1.0.2

### DIFF
--- a/.github/scripts/test_public_boundary.py
+++ b/.github/scripts/test_public_boundary.py
@@ -18,7 +18,7 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
 class PublicBoundaryTest(unittest.TestCase):
     def test_repository_satisfies_public_boundary(self) -> None:
-        self.assertEqual(boundary.verify(REPOSITORY_ROOT), "1.0.1")
+        self.assertEqual(boundary.verify(REPOSITORY_ROOT), "1.0.2")
 
     def test_forbidden_private_source_is_detected(self) -> None:
         with tempfile.TemporaryDirectory(prefix="public-boundary-") as temporary:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2
+
+- fix(coordination): `coordination(action=share)` validates `kind` against the API enum (decision, constraint, api_contract, risk, status, knowledge) and defaults an omitted kind to `knowledge` like the API; 1.0.1 rejected `status`/`risk` client-side and sent an API-refused `note` default (#88).
+
 ## 1.0.1
 
 - Answer: `answer` actions for query, recent changes, receipt recovery, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mcp-acceleration-products"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-client"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-model-registry"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "mcp-types",
  "serde",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-session"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "chrono",
  "dashmap",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-tools"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-types"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"
@@ -89,12 +89,12 @@ fs2 = "0.4"
 notify = "6"
 
 # Workspace crates
-mcp-types = { version = "=1.0.1", path = "crates/mcp-types" }
-mcp-client = { version = "=1.0.1", path = "crates/mcp-client" }
-mcp-session = { version = "=1.0.1", path = "crates/mcp-session" }
-mcp-tools = { version = "=1.0.1", path = "crates/mcp-tools" }
-mcp-model-registry = { version = "=1.0.1", path = "crates/mcp-model-registry" }
-mcp-acceleration-products = { version = "=1.0.1", path = "crates/mcp-acceleration-products" }
+mcp-types = { version = "=1.0.2", path = "crates/mcp-types" }
+mcp-client = { version = "=1.0.2", path = "crates/mcp-client" }
+mcp-session = { version = "=1.0.2", path = "crates/mcp-session" }
+mcp-tools = { version = "=1.0.2", path = "crates/mcp-tools" }
+mcp-model-registry = { version = "=1.0.2", path = "crates/mcp-model-registry" }
+mcp-acceleration-products = { version = "=1.0.2", path = "crates/mcp-acceleration-products" }
 
 # Testing
 mockall = "0.13"

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -2427,7 +2427,7 @@ mod tests {
             // Coordination v2: action=reply with `message`, and `metadata`
             // (git branch/commit) on check_in as judge evidence.
             "coordination",
-            "e43264391eb4844f2ee5d0255dae9d9808d290d4fecd3ac13c5427b5af04ddef",
+            "63a765be22dd19970e1aed0999ea8befd851514cad42382deee364e808707c37",
         ),
         (
             "entity",

--- a/crates/mcp-tools/src/domains/coordination.rs
+++ b/crates/mcp-tools/src/domains/coordination.rs
@@ -19,17 +19,22 @@ const VALID_ACTIONS: &[&str] = &[
 ];
 
 /// Coordination item kinds accepted by `POST /coordinations`. Validated
-/// client-side so a typo fails fast instead of round-tripping a 4xx.
+/// client-side so a typo fails fast instead of round-tripping a 4xx. This
+/// list must stay identical to the API's `coordination_kind_is_known`
+/// (decision, constraint, api_contract, risk, status, knowledge): 1.0.1
+/// shipped a divergent list and every `status`/`risk` share failed client-side
+/// while the only client-accepted default (`note`) was refused by the API.
 pub const VALID_KINDS: &[&str] = &[
     "decision",
     "constraint",
-    "warning",
-    "insight",
-    "blocker",
-    "request",
-    "handoff",
-    "note",
+    "api_contract",
+    "risk",
+    "status",
+    "knowledge",
 ];
+
+/// Kind applied when `share` omits one; matches the API default.
+pub const DEFAULT_KIND: &str = "knowledge";
 
 /// Default number of `[COORDINATION]` lines rendered by `context()` /
 /// `session(action="ground")` before the `… N more` trailer.
@@ -307,7 +312,7 @@ impl ToolHandler for CoordinationTool {
             )
             .string_enum(
                 "kind",
-                "Kind of shared item (defaults to note).",
+                "Kind of shared item: decision, constraint, api_contract, risk, status, or knowledge (defaults to knowledge; mirrors the API enum).",
                 VALID_KINDS,
                 false,
             )
@@ -349,11 +354,11 @@ fn coordination_id(value: &Value) -> Option<&str> {
     payload.get("id").and_then(Value::as_str)
 }
 
-/// Validate a `kind` for `share`; `None` defaults to `note`.
+/// Validate a `kind` for `share`; `None` defaults to [`DEFAULT_KIND`].
 pub fn validate_kind(kind: Option<&str>) -> Result<String> {
     let kind = kind.map(str::trim).filter(|value| !value.is_empty());
     match kind {
-        None => Ok("note".to_string()),
+        None => Ok(DEFAULT_KIND.to_string()),
         Some(value) => {
             let normalized = value.to_ascii_lowercase();
             if VALID_KINDS.contains(&normalized.as_str()) {
@@ -600,14 +605,31 @@ mod tests {
 
     #[test]
     fn share_kind_is_validated_client_side() {
-        assert_eq!(validate_kind(None).unwrap(), "note");
+        assert_eq!(validate_kind(None).unwrap(), "knowledge");
         assert_eq!(validate_kind(Some("Decision")).unwrap(), "decision");
+        assert_eq!(validate_kind(Some(" STATUS ")).unwrap(), "status");
         for kind in VALID_KINDS {
             assert_eq!(validate_kind(Some(kind)).unwrap(), *kind);
         }
-        let err = validate_kind(Some("knowledge")).unwrap_err().to_string();
-        assert!(err.contains("Invalid coordination kind"));
-        assert!(err.contains("handoff"));
+        // The API enum (handlers/coordination.rs coordination_kind_is_known).
+        assert_eq!(
+            VALID_KINDS,
+            &[
+                "decision",
+                "constraint",
+                "api_contract",
+                "risk",
+                "status",
+                "knowledge"
+            ]
+        );
+        for legacy in [
+            "note", "warning", "insight", "blocker", "request", "handoff",
+        ] {
+            let err = validate_kind(Some(legacy)).unwrap_err().to_string();
+            assert!(err.contains("Invalid coordination kind"), "{legacy}");
+            assert!(err.contains("knowledge"), "{legacy}");
+        }
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextstream/mcp-server",
   "mcpName": "io.github.contextstream/mcp-server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Verified npm launcher for the open-source ContextStream Rust MCP server",
   "type": "module",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.contextstream/mcp-server",
   "title": "ContextStream MCP Server",
   "description": "Project memory, semantic code search, and grounded agent context.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": {
     "url": "https://github.com/contextstream/mcp-server",
     "source": "github"
@@ -20,7 +20,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@contextstream/mcp-server",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Bump the workspace, internal crate pins, npm launcher, and server.json to 1.0.2 and record the changelog entry for #88 (coordination share kinds realigned with the API enum).
- Stacked on #88; merge #88 first, then this PR shows only the version bump.

## Verification
- \`.github/scripts\` unit tests and \`release_contract.py\` pass locally.
- After merge: tag \`v1.0.2\` on the merge commit, approve the \`public-release\` gate, then roll \`deploy-mcp-http.yml\` with \`mcp_version=1.0.2\` to ovh-east/ovh-west.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fQTc1rSCr6Ds1pvLbrJwH