### PR TITLE
Preserve grounding provenance and add shadow-only qualification gates

### DIFF
--- a/.github/scripts/test_public_boundary.py
+++ b/.github/scripts/test_public_boundary.py
@@ -18,7 +18,7 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
 class PublicBoundaryTest(unittest.TestCase):
     def test_repository_satisfies_public_boundary(self) -> None:
-        self.assertEqual(boundary.verify(REPOSITORY_ROOT), "1.0.2")
+        self.assertEqual(boundary.verify(REPOSITORY_ROOT), "1.0.3")
 
     def test_forbidden_private_source_is_detected(self) -> None:
         with tempfile.TemporaryDirectory(prefix="public-boundary-") as temporary:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.3
+
+- Grounding: preserve evidence provenance, distinguish ranking signals from
+  relevance, and admit relevant evidence before canonical deduplication.
+- Context caching: bypass composite cache reuse when checkout or session state
+  requires fresh grounding.
+- Add offline grounding replay and scoped qualification controls. Candidate
+  ranking remains shadow-only by default; serving changes require explicit
+  operator configuration and independently qualified evidence.
+
 ## 1.0.2
 
 - fix(coordination): `coordination(action=share)` validates `kind` against the API enum (decision, constraint, api_contract, risk, status, knowledge) and defaults an omitted kind to `knowledge` like the API; 1.0.1 rejected `status`/`risk` client-side and sent an API-refused `note` default (#88).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mcp-acceleration-products"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-client"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-model-registry"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "mcp-types",
  "serde",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-server"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-session"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "chrono",
  "dashmap",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-tools"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"
@@ -89,12 +89,12 @@ fs2 = "0.4"
 notify = "6"
 
 # Workspace crates
-mcp-types = { version = "=1.0.2", path = "crates/mcp-types" }
-mcp-client = { version = "=1.0.2", path = "crates/mcp-client" }
-mcp-session = { version = "=1.0.2", path = "crates/mcp-session" }
-mcp-tools = { version = "=1.0.2", path = "crates/mcp-tools" }
-mcp-model-registry = { version = "=1.0.2", path = "crates/mcp-model-registry" }
-mcp-acceleration-products = { version = "=1.0.2", path = "crates/mcp-acceleration-products" }
+mcp-types = { version = "=1.0.3", path = "crates/mcp-types" }
+mcp-client = { version = "=1.0.3", path = "crates/mcp-client" }
+mcp-session = { version = "=1.0.3", path = "crates/mcp-session" }
+mcp-tools = { version = "=1.0.3", path = "crates/mcp-tools" }
+mcp-model-registry = { version = "=1.0.3", path = "crates/mcp-model-registry" }
+mcp-acceleration-products = { version = "=1.0.3", path = "crates/mcp-acceleration-products" }
 
 # Testing
 mockall = "0.13"

--- a/crates/mcp-tools/examples/grounding_replay.rs
+++ b/crates/mcp-tools/examples/grounding_replay.rs
@@ -1,0 +1,35 @@
+//! JSONL replay of the actual selectors, with no model/network calls.
+use mcp_tools::domains::grounding::{replay_selection, rollout::POLICY_REVISION};
+use serde_json::{json, Value};
+use std::io::{self, BufRead};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    for line in io::stdin().lock().lines() {
+        let input: Value = serde_json::from_str(&line?)?;
+        let query_id = input
+            .get("query_id")
+            .and_then(Value::as_str)
+            .ok_or("missing query_id")?;
+        let recall = input.get("recall").ok_or("missing recall")?;
+        let session = input.get("session_id").and_then(Value::as_str);
+        let start = std::time::Instant::now();
+        let legacy = replay_selection(recall.clone(), session, false);
+        let legacy_us = start.elapsed().as_micros();
+        let start = std::time::Instant::now();
+        let candidate = replay_selection(recall.clone(), session, true);
+        let candidate_us = start.elapsed().as_micros();
+        let ids = |hits: &[mcp_tools::domains::grounding::GroundingHit]| {
+            hits.iter().map(|hit|
+            json!({"id":hit.id_hint,"project_id":hit.source_project_id,"stale":hit.stale,"stale_reason":hit.stale_reason})
+        ).collect::<Vec<_>>()
+        };
+        println!(
+            "{}",
+            json!({"query_id":query_id,"policy_revision":POLICY_REVISION,
+            "retrieval_status":legacy.status,"candidate_status":candidate.status,
+            "legacy":ids(&legacy.hits),"candidate":ids(&candidate.hits),
+            "selector_only_legacy_us":legacy_us,"selector_only_candidate_us":candidate_us})
+        );
+    }
+    Ok(())
+}

--- a/crates/mcp-tools/src/domains/atlas_warm_cache.rs
+++ b/crates/mcp-tools/src/domains/atlas_warm_cache.rs
@@ -693,7 +693,7 @@ pub fn scope_hash_for_recall(
     query: &str,
 ) -> String {
     format!(
-        "{}:{}:{}:recall:{}",
+        "{}:{}:{}:recall-provenance-v1:{}",
         workspace_id,
         user_scope.unwrap_or("shared"),
         project_id
@@ -714,7 +714,7 @@ pub fn scope_hash_for_ground(
     user_message: &str,
 ) -> String {
     format!(
-        "{}:{}:{}:ground:{}",
+        "{}:{}:{}:ground-provenance-v1:{}",
         workspace_id,
         user_scope.unwrap_or("shared"),
         project_id

--- a/crates/mcp-tools/src/domains/grounding.rs
+++ b/crates/mcp-tools/src/domains/grounding.rs
@@ -93,6 +93,11 @@ pub fn recall_with_shadow(mut recall: Value, session_id: Option<&str>) -> Ground
     {
         let mut seen = std::collections::HashSet::new();
         results.retain(|item| {
+            // An irrelevant projection must not consume the canonical identity
+            // before a later projection proves query relevance.
+            if !candidate_evidence_admits(retrieval_provenance(item)) {
+                return false;
+            }
             let identity =
                 metadata_str(item, "source_entity_id").or_else(|| metadata_str(item, "id"));
             identity
@@ -464,6 +469,26 @@ pub fn parse_recall_results(recall: &Value) -> Vec<GroundingHit> {
     parse_recall_results_with_policy(recall, false)
 }
 
+fn retrieval_provenance(item: &Value) -> Option<&Value> {
+    item.get("retrieval_provenance").or_else(|| {
+        item.get("metadata")
+            .and_then(|m| m.get("retrieval_provenance"))
+    })
+}
+
+fn candidate_evidence_admits(provenance: Option<&Value>) -> bool {
+    provenance.is_some_and(|p| {
+        p.get("score_kind").and_then(Value::as_str) == Some("rank_decay")
+            && p.get("query_term_matches")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+                > 0
+            && p.get("lexical_query_coverage")
+                .and_then(Value::as_f64)
+                .is_some_and(|c| c.is_finite() && (0.4..=1.0).contains(&c))
+    })
+}
+
 /// Candidate admission policy is shadow-only until held-out qualification.
 /// Rank positions never count as relevance in the candidate policy. The
 /// legacy selector is retained for rollout comparison, not called confidence.
@@ -480,34 +505,11 @@ pub fn parse_recall_results_with_policy(
         .iter()
         .filter_map(|item| {
             let score = item_score(item);
-            let provenance = item
-                .get("retrieval_provenance")
-                .or_else(|| {
-                    item.get("metadata")
-                        .and_then(|m| m.get("retrieval_provenance"))
-                })
-                .cloned();
-            let ordinal = provenance
-                .as_ref()
-                .and_then(|p| p.get("score_kind"))
-                .and_then(Value::as_str)
-                == Some("rank_decay");
+            let provenance = retrieval_provenance(item).cloned();
             let admitted = if enforce_evidence {
                 // Coverage is observable lexical evidence, not a probability.
                 // Similarity is deliberately not thresholded without calibration.
-                ordinal
-                    && provenance
-                        .as_ref()
-                        .and_then(|p| p.get("query_term_matches"))
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0)
-                        > 0
-                    && provenance
-                        .as_ref()
-                        .and_then(|p| p.get("lexical_query_coverage"))
-                        .and_then(Value::as_f64)
-                        .map(|c| c.is_finite() && c >= 0.4 && c <= 1.0)
-                        .unwrap_or(false)
+                candidate_evidence_admits(provenance.as_ref())
             } else {
                 score.is_finite() && score >= min
             };
@@ -1401,6 +1403,21 @@ fn candidate_deduplication_respects_source_project() {
     );
     assert_eq!(outcome.hits.len(), 3);
     assert_eq!(outcome.shadow_hit_count, 2);
+}
+
+#[test]
+fn irrelevant_projection_cannot_hide_a_relevant_canonical_hit() {
+    let item = |matches, coverage| {
+        serde_json::json!({"id":"projection","source_entity_id":"canonical",
+        "title":"Prior work","score":0.95,"metadata":{"retrieval_provenance":{
+            "score_kind":"rank_decay","query_term_matches":matches,"lexical_query_coverage":coverage}}})
+    };
+    let outcome = recall_with_shadow(
+        serde_json::json!({"results":[item(0, 0.0),item(1, 1.0)]}),
+        None,
+    );
+    assert_eq!(outcome.hits.len(), 2);
+    assert_eq!(outcome.shadow_hit_count, 1);
 }
 
 #[test]

--- a/crates/mcp-tools/src/domains/grounding.rs
+++ b/crates/mcp-tools/src/domains/grounding.rs
@@ -16,6 +16,12 @@ pub struct GroundingHit {
     pub kind: String,
     pub title: String,
     pub score: f64,
+    /// Evidence is separate from legacy ordinal scores. Missing means unknown,
+    /// not calibrated confidence (including responses from older servers).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retrieval_provenance: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_project_id: Option<String>,
     /// UUID or natural key for follow-up tool calls.
     pub id_hint: Option<String>,
     /// Source field used for `id_hint`, when known.
@@ -41,6 +47,88 @@ pub struct GroundingHit {
     /// Rendered note when the API flagged this decision as overlapping
     /// another session's decision on the same subject (`possible_conflicts`).
     pub conflict_note: Option<String>,
+}
+
+/// Missing evidence and unavailable retrieval are intentionally different.
+/// Selection is evaluated after immutable recall-cache lookup; session state
+/// never contaminates another session's cached evidence bundle.
+#[derive(Debug, Clone, Serialize)]
+pub struct GroundingRecall {
+    pub hits: Vec<GroundingHit>,
+    pub status: String,
+    pub selection_mode: &'static str,
+    pub shadow_hit_count: usize,
+}
+
+impl GroundingRecall {
+    pub fn unavailable() -> Self {
+        Self::empty("unavailable")
+    }
+    pub fn disabled() -> Self {
+        Self::empty("disabled")
+    }
+    fn empty(status: &str) -> Self {
+        Self {
+            hits: vec![],
+            status: status.to_string(),
+            selection_mode: "shadow",
+            shadow_hit_count: 0,
+        }
+    }
+}
+
+pub fn recall_with_shadow(mut recall: Value, session_id: Option<&str>) -> GroundingRecall {
+    normalize_recall_payload(&mut recall);
+    if !recall.get("results").is_some_and(Value::is_array) {
+        return GroundingRecall::unavailable();
+    }
+    let hits = parse_recall_results(&recall);
+    // Work on a private copy. Current-session evidence can break ties only
+    // after the candidate proves query relevance. No active directives are
+    // synthesized from recalled approvals or old permission requests.
+    let mut shadow_payload = recall.clone();
+    if let Some(results) = shadow_payload
+        .get_mut("results")
+        .and_then(Value::as_array_mut)
+    {
+        let mut seen = std::collections::HashSet::new();
+        results.retain(|item| {
+            let identity =
+                metadata_str(item, "source_entity_id").or_else(|| metadata_str(item, "id"));
+            identity
+                .map(|id| {
+                    seen.insert((
+                        metadata_str(item, "source_project_id")
+                            .or_else(|| metadata_str(item, "project_id")),
+                        id,
+                    ))
+                })
+                .unwrap_or(true)
+        });
+        if let Some(session) = session_id.filter(|s| !s.is_empty()) {
+            results.sort_by(|a, b| {
+                item_score(b)
+                    .partial_cmp(&item_score(a))
+                    .unwrap_or(Ordering::Equal)
+                    .then_with(|| {
+                        (metadata_str(a, "session_id").as_deref() != Some(session))
+                            .cmp(&(metadata_str(b, "session_id").as_deref() != Some(session)))
+                    })
+            });
+        }
+    }
+    let shadow = parse_recall_results_with_policy(&shadow_payload, true);
+    GroundingRecall {
+        status: if hits.is_empty() {
+            "no_evidence"
+        } else {
+            "available"
+        }
+        .to_string(),
+        shadow_hit_count: shadow.len(),
+        hits,
+        selection_mode: "shadow",
+    }
 }
 
 /// Appended to a compact decisions block when any entry carries a conflict flag.
@@ -373,6 +461,16 @@ fn id_hint(item: &Value) -> (Option<String>, Option<String>) {
 
 /// Extract ranked hits from a `/session/recall` JSON body.
 pub fn parse_recall_results(recall: &Value) -> Vec<GroundingHit> {
+    parse_recall_results_with_policy(recall, false)
+}
+
+/// Candidate admission policy is shadow-only until held-out qualification.
+/// Rank positions never count as relevance in the candidate policy. The
+/// legacy selector is retained for rollout comparison, not called confidence.
+pub fn parse_recall_results_with_policy(
+    recall: &Value,
+    enforce_evidence: bool,
+) -> Vec<GroundingHit> {
     let Some(results) = recall.get("results").and_then(|r| r.as_array()) else {
         return Vec::new();
     };
@@ -382,7 +480,38 @@ pub fn parse_recall_results(recall: &Value) -> Vec<GroundingHit> {
         .iter()
         .filter_map(|item| {
             let score = item_score(item);
-            if score < min {
+            let provenance = item
+                .get("retrieval_provenance")
+                .or_else(|| {
+                    item.get("metadata")
+                        .and_then(|m| m.get("retrieval_provenance"))
+                })
+                .cloned();
+            let ordinal = provenance
+                .as_ref()
+                .and_then(|p| p.get("score_kind"))
+                .and_then(Value::as_str)
+                == Some("rank_decay");
+            let admitted = if enforce_evidence {
+                // Coverage is observable lexical evidence, not a probability.
+                // Similarity is deliberately not thresholded without calibration.
+                ordinal
+                    && provenance
+                        .as_ref()
+                        .and_then(|p| p.get("query_term_matches"))
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0)
+                        > 0
+                    && provenance
+                        .as_ref()
+                        .and_then(|p| p.get("lexical_query_coverage"))
+                        .and_then(Value::as_f64)
+                        .map(|c| c.is_finite() && c >= 0.4 && c <= 1.0)
+                        .unwrap_or(false)
+            } else {
+                score.is_finite() && score >= min
+            };
+            if !admitted {
                 return None;
             }
             let (id_hint, id_field) = id_hint(item);
@@ -428,6 +557,9 @@ pub fn parse_recall_results(recall: &Value) -> Vec<GroundingHit> {
                 kind,
                 title,
                 score,
+                retrieval_provenance: provenance,
+                source_project_id: metadata_str(item, "source_project_id")
+                    .or_else(|| metadata_str(item, "project_id")),
                 search_keywords,
                 id_hint,
                 id_field,
@@ -442,12 +574,14 @@ pub fn parse_recall_results(recall: &Value) -> Vec<GroundingHit> {
         })
         .collect();
 
-    hits.sort_by(|a, b| {
-        a.historical_status_claim
-            .cmp(&b.historical_status_claim)
-            .then_with(|| a.stale.cmp(&b.stale))
-            .then_with(|| b.score.partial_cmp(&a.score).unwrap_or(Ordering::Equal))
-    });
+    if !enforce_evidence {
+        hits.sort_by(|a, b| {
+            a.historical_status_claim
+                .cmp(&b.historical_status_claim)
+                .then_with(|| a.stale.cmp(&b.stale))
+                .then_with(|| b.score.partial_cmp(&a.score).unwrap_or(Ordering::Equal))
+        });
+    }
     hits.truncate(grounding_max_hits());
     hits
 }
@@ -496,6 +630,18 @@ fn format_hit_label(hit: &GroundingHit) -> String {
             hit.title.chars().take(100).collect::<String>()
         )
     }
+}
+
+fn format_score_label(hit: &GroundingHit) -> String {
+    if let Some(provenance) = &hit.retrieval_provenance {
+        if provenance.get("score_kind").and_then(Value::as_str) == Some("rank_decay") {
+            return match provenance.get("rank").and_then(Value::as_u64) {
+                Some(rank) => format!("rank {rank}; relevance uncalibrated"),
+                None => "ranked; relevance uncalibrated".to_string(),
+            };
+        }
+    }
+    format!("score {:.2}; relevance uncalibrated", hit.score)
 }
 
 fn recall_hint_keywords(hit: &GroundingHit, item_keywords: &str) -> String {
@@ -636,10 +782,10 @@ pub fn format_grounding_block(hits: &[GroundingHit], compact: bool) -> String {
         for (i, hit) in hits.iter().enumerate() {
             let hint = action_hint(hit, &hit.search_keywords);
             out.push_str(&format!(
-                "\n  {}. {} (score {:.2}) → {}",
+                "\n  {}. {} ({}) → {}",
                 i + 1,
                 format_hit_label(hit),
-                hit.score,
+                format_score_label(hit),
                 hint
             ));
             if hit.historical_status_claim {
@@ -668,11 +814,11 @@ pub fn format_grounding_block(hits: &[GroundingHit], compact: bool) -> String {
         for (i, hit) in hits.iter().enumerate() {
             let hint = action_hint(hit, &hit.search_keywords);
             out.push_str(&format!(
-                "{}. **{}** (kind: `{}`, score: {:.2})\n   → {}\n",
+                "{}. **{}** (kind: `{}`, {})\n   → {}\n",
                 i + 1,
                 format_hit_label(hit),
                 hit.kind,
-                hit.score,
+                format_score_label(hit),
                 hint
             ));
             if hit.historical_status_claim {
@@ -1062,6 +1208,8 @@ mod tests {
             kind: "transcript".to_string(),
             title: "Fix auth".to_string(),
             score: 0.8,
+            retrieval_provenance: None,
+            source_project_id: None,
             id_hint: Some("abc".to_string()),
             id_field: Some("transcript_id".to_string()),
             date: None,
@@ -1110,6 +1258,8 @@ mod tests {
             kind: "doc".to_string(),
             title: "Prod DB migration runbook".to_string(),
             score: 0.95,
+            retrieval_provenance: None,
+            source_project_id: None,
             id_hint: Some("doc-1".to_string()),
             id_field: Some("doc_id".to_string()),
             date: Some("2026-05-10".to_string()),
@@ -1188,4 +1338,81 @@ mod tests {
         assert!(block.contains("feed(action=\"ground\", query=\""));
         assert!(!block.contains("get_event"));
     }
+}
+#[test]
+fn ordinal_rank_is_not_relevance_and_shadow_does_not_change_serving() {
+    let payload = serde_json::json!({"results":[{
+        "id":"unrelated", "title":"Old unrelated work", "score":0.95,
+        "metadata":{"retrieval_provenance":{"score_kind":"rank_decay","rank":1,
+            "query_term_matches":0,"lexical_query_coverage":0.0}}
+    }]});
+    let outcome = recall_with_shadow(payload.clone(), None);
+    assert_eq!(outcome.hits.len(), 1);
+    assert_eq!(outcome.shadow_hit_count, 0);
+    assert_eq!(outcome.selection_mode, "shadow");
+    let text = format_grounding_block(&outcome.hits, true);
+    assert!(text.contains("rank 1; relevance uncalibrated"));
+    assert!(!text.contains("score 0.95"));
+    assert!(parse_recall_results_with_policy(&payload, true).is_empty());
+}
+
+#[test]
+fn matching_historical_evidence_is_not_demoted_in_candidate_policy() {
+    let payload = serde_json::json!({"results":[
+        {"id":"old", "title":"Prior routing failure", "event_type":"session_snapshot", "score":0.95,
+         "content":"Work stopped, no output", "occurred_at":"2025-01-01T00:00:00Z",
+         "metadata":{"retrieval_provenance":{"score_kind":"rank_decay","rank":1,"query_term_matches":2,"lexical_query_coverage":1.0}}},
+        {"id":"new", "title":"Current routing", "score":0.92,
+         "metadata":{"retrieval_provenance":{"score_kind":"rank_decay","rank":2,"query_term_matches":1,"lexical_query_coverage":0.5}}}
+    ]});
+    let hits = parse_recall_results_with_policy(&payload, true);
+    assert_eq!(hits[0].id_hint.as_deref(), Some("old"));
+    assert!(hits[0].stale);
+}
+
+#[test]
+fn retrieval_outcomes_distinguish_empty_from_unavailable() {
+    let empty = recall_with_shadow(serde_json::json!({"results":[]}), None);
+    assert_eq!(empty.status, "no_evidence");
+    assert_eq!(GroundingRecall::unavailable().status, "unavailable");
+    assert_eq!(GroundingRecall::disabled().status, "disabled");
+}
+
+#[test]
+fn legacy_scores_are_served_compatibly_but_not_candidate_evidence() {
+    let payload =
+        serde_json::json!({"results":[{"id":"legacy","title":"Legacy hit","score":0.99}]});
+    let outcome = recall_with_shadow(payload, None);
+    assert_eq!(outcome.hits.len(), 1);
+    assert_eq!(outcome.shadow_hit_count, 0);
+    assert!(format_grounding_block(&outcome.hits, true).contains("relevance uncalibrated"));
+}
+
+#[test]
+fn candidate_deduplication_respects_source_project() {
+    let item = |project| {
+        serde_json::json!({"id":"projection","source_entity_id":"canonical","source_project_id":project,
+        "title":"Matching work","score":0.95,"metadata":{"retrieval_provenance":{
+            "score_kind":"rank_decay","query_term_matches":1,"lexical_query_coverage":1.0}}})
+    };
+    let outcome = recall_with_shadow(
+        serde_json::json!({"results":[item("a"),item("a"),item("b")]}),
+        None,
+    );
+    assert_eq!(outcome.hits.len(), 3);
+    assert_eq!(outcome.shadow_hit_count, 2);
+}
+
+#[test]
+fn session_selection_never_changes_cached_or_served_bundle() {
+    let payload = serde_json::json!({"results":[
+        {"id":"one", "title":"Same subject", "score":0.95,"session_id":"one",
+         "metadata":{"retrieval_provenance":{"score_kind":"rank_decay","query_term_matches":1,"lexical_query_coverage":1.0}}},
+        {"id":"two", "title":"Same subject", "score":0.92,"session_id":"two",
+         "metadata":{"retrieval_provenance":{"score_kind":"rank_decay","query_term_matches":1,"lexical_query_coverage":1.0}}}
+    ]});
+    let a = recall_with_shadow(payload.clone(), Some("one"));
+    let b = recall_with_shadow(payload.clone(), Some("two"));
+    assert_eq!(a.hits[0].id_hint, b.hits[0].id_hint);
+    assert_eq!(payload["results"][0]["id"], "one");
 }

--- a/crates/mcp-tools/src/domains/grounding.rs
+++ b/crates/mcp-tools/src/domains/grounding.rs
@@ -10,6 +10,9 @@ use serde_json::Value;
 use std::cmp::Ordering;
 use std::time::Duration;
 
+#[path = "grounding_rollout.rs"]
+pub mod rollout;
+
 /// One ranked prior-work hit for display in `context()`.
 #[derive(Debug, Clone, Serialize)]
 pub struct GroundingHit {
@@ -58,6 +61,8 @@ pub struct GroundingRecall {
     pub status: String,
     pub selection_mode: &'static str,
     pub shadow_hit_count: usize,
+    pub legacy_hit_count: usize,
+    pub overlap_count: usize,
 }
 
 impl GroundingRecall {
@@ -73,11 +78,52 @@ impl GroundingRecall {
             status: status.to_string(),
             selection_mode: "shadow",
             shadow_hit_count: 0,
+            legacy_hit_count: 0,
+            overlap_count: 0,
         }
     }
 }
 
-pub fn recall_with_shadow(mut recall: Value, session_id: Option<&str>) -> GroundingRecall {
+pub fn recall_with_shadow(recall: Value, session_id: Option<&str>) -> GroundingRecall {
+    recall_with_mode(recall, session_id, "shadow")
+}
+
+pub fn recall_with_rollout(
+    recall: Value,
+    session_id: Option<&str>,
+    subject: Option<&str>,
+    workspace: Option<&str>,
+    project: Option<&str>,
+) -> GroundingRecall {
+    // A custom presentation threshold/cap has not passed the frozen evaluator.
+    let mode = if grounding_max_hits() == 5 && grounding_min_score() == 0.4 {
+        rollout::serving_mode(subject, workspace, project)
+    } else {
+        "shadow"
+    };
+    recall_with_mode(recall, session_id, mode)
+}
+
+/// Offline evaluator uses the exact runtime selector, not a reimplementation.
+/// This does not change the process-wide serving configuration.
+pub fn replay_selection(
+    recall: Value,
+    session_id: Option<&str>,
+    candidate: bool,
+) -> GroundingRecall {
+    recall_with_mode(
+        recall,
+        session_id,
+        if candidate { "evaluation" } else { "shadow" },
+    )
+}
+
+fn recall_with_mode(
+    mut recall: Value,
+    session_id: Option<&str>,
+    mode: &'static str,
+) -> GroundingRecall {
+    let started = std::time::Instant::now();
     normalize_recall_payload(&mut recall);
     if !recall.get("results").is_some_and(Value::is_array) {
         return GroundingRecall::unavailable();
@@ -123,6 +169,30 @@ pub fn recall_with_shadow(mut recall: Value, session_id: Option<&str>) -> Ground
         }
     }
     let shadow = parse_recall_results_with_policy(&shadow_payload, true);
+    let legacy_hit_count = hits.len();
+    let overlap_count = shadow
+        .iter()
+        .filter(|candidate| {
+            candidate.id_hint.is_some()
+                && hits.iter().any(|legacy| {
+                    legacy.id_hint == candidate.id_hint
+                        && legacy.source_project_id == candidate.source_project_id
+                })
+        })
+        .count();
+    let shadow_hit_count = shadow.len();
+    let hits = if mode == "shadow" { hits } else { shadow };
+    // Only closed labels and counts leave the selection layer as telemetry.
+    // No query, title, subject, project, source id or recalled content is logged.
+    tracing::debug!(
+        policy_revision = rollout::POLICY_REVISION,
+        selection_mode = mode,
+        legacy_hit_count,
+        candidate_hit_count = shadow_hit_count,
+        overlap_count,
+        elapsed_us = started.elapsed().as_micros() as u64,
+        "grounding selection"
+    );
     GroundingRecall {
         status: if hits.is_empty() {
             "no_evidence"
@@ -130,9 +200,19 @@ pub fn recall_with_shadow(mut recall: Value, session_id: Option<&str>) -> Ground
             "available"
         }
         .to_string(),
-        shadow_hit_count: shadow.len(),
+        shadow_hit_count,
+        legacy_hit_count,
+        overlap_count,
         hits,
-        selection_mode: "shadow",
+        selection_mode: mode,
+    }
+}
+
+impl GroundingRecall {
+    pub fn telemetry(&self) -> Value {
+        serde_json::json!({"status":self.status,"selection_mode":self.selection_mode,
+            "policy_revision":rollout::POLICY_REVISION,"shadow_hit_count":self.shadow_hit_count,
+            "legacy_hit_count":self.legacy_hit_count,"overlap_count":self.overlap_count})
     }
 }
 
@@ -1432,4 +1512,30 @@ fn session_selection_never_changes_cached_or_served_bundle() {
     let b = recall_with_shadow(payload.clone(), Some("two"));
     assert_eq!(a.hits[0].id_hint, b.hits[0].id_hint);
     assert_eq!(payload["results"][0]["id"], "one");
+}
+
+#[test]
+fn candidate_rejects_priority_flooding_without_hiding_relevant_evidence() {
+    let mut results: Vec<Value> = (0..100).map(|i| serde_json::json!({
+        "id":format!("irrelevant-{i}"),"title":"Priority reminder","priority":"critical","score":0.99,
+        "retrieval_provenance":{"score_kind":"rank_decay","query_term_matches":0,"lexical_query_coverage":0.0}
+    })).collect();
+    results.push(serde_json::json!({"id":"relevant","title":"Matching current work","score":0.3,
+        "retrieval_provenance":{"score_kind":"rank_decay","query_term_matches":1,"lexical_query_coverage":1.0}}));
+    let selected = replay_selection(serde_json::json!({"results":results}), None, true);
+    assert_eq!(selected.hits.len(), 1);
+    assert_eq!(selected.hits[0].id_hint.as_deref(), Some("relevant"));
+    assert_eq!(selected.legacy_hit_count, 5);
+    assert_eq!(selected.overlap_count, 0);
+}
+
+#[test]
+fn selection_telemetry_cannot_export_query_or_source_identity() {
+    let outcome = recall_with_shadow(
+        serde_json::json!({"results":[{"id":"private-id","title":"private title","score":0.9,"project_id":"private-project"}]}),
+        None,
+    );
+    let metrics = outcome.telemetry().to_string();
+    assert!(!metrics.contains("private"));
+    assert!(metrics.contains(rollout::POLICY_REVISION));
 }

--- a/crates/mcp-tools/src/domains/grounding_rollout.rs
+++ b/crates/mcp-tools/src/domains/grounding_rollout.rs
@@ -1,0 +1,297 @@
+//! Operator-controlled rollout. No client request or recalled memory can opt in.
+//! Default/invalid configuration and the independent kill switch serve legacy.
+use serde::Deserialize;
+
+pub const POLICY_REVISION: &str = "grounding-evidence-v1";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Qualification {
+    pub policy_revision: String,
+    pub corpus_sha256: String,
+    pub candidate_sha256: String,
+    pub development_queries: u64,
+    pub holdout_queries: u64,
+    pub independent_labels: bool,
+    pub coding_qualified: bool,
+    pub evaluated_at_unix: i64,
+    pub false_grounding_rate: f64,
+    pub known_item_top1: f64,
+    pub precision_at_5: f64,
+    pub baseline_p95_ms: f64,
+    pub candidate_p95_ms: f64,
+    pub privacy_violations: u64,
+    pub authority_violations: u64,
+    pub false_completion_violations: u64,
+}
+
+impl Qualification {
+    pub fn passes(&self, candidate: &str, corpus: &str) -> bool {
+        let fraction = |v: f64| v.is_finite() && (0.0..=1.0).contains(&v);
+        self.policy_revision == POLICY_REVISION
+            && sha256(candidate)
+            && sha256(corpus)
+            && self.candidate_sha256 == candidate
+            && self.corpus_sha256 == corpus
+            && self.development_queries == 60
+            && self.holdout_queries == 60
+            && self.independent_labels
+            && self.coding_qualified
+            && fraction(self.false_grounding_rate)
+            && self.false_grounding_rate <= 0.05
+            && fraction(self.known_item_top1)
+            && self.known_item_top1 >= 0.95
+            && fraction(self.precision_at_5)
+            && self.precision_at_5 >= 0.8
+            && self.baseline_p95_ms.is_finite()
+            && self.baseline_p95_ms > 0.0
+            && self.candidate_p95_ms.is_finite()
+            && self.candidate_p95_ms > 0.0
+            && self.candidate_p95_ms <= self.baseline_p95_ms * 1.10
+            && self.privacy_violations == 0
+            && self.authority_violations == 0
+            && self.false_completion_violations == 0
+    }
+}
+
+fn sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanaryEvidence {
+    pub policy_revision: String,
+    pub candidate_sha256: String,
+    pub corpus_sha256: String,
+    pub started_at_unix: i64,
+    pub observed_until_unix: i64,
+    pub eligible_operations: u64,
+    pub privacy_violations: u64,
+    pub authority_violations: u64,
+    pub false_completion_violations: u64,
+    pub baseline_p95_ms: f64,
+    pub candidate_p95_ms: f64,
+}
+
+impl CanaryEvidence {
+    fn passes(&self, now: i64, candidate: &str, corpus: &str) -> bool {
+        self.policy_revision == POLICY_REVISION
+            && self.candidate_sha256 == candidate
+            && self.corpus_sha256 == corpus
+            && self.started_at_unix > 0
+            && self.observed_until_unix <= now
+            && self
+                .observed_until_unix
+                .saturating_sub(self.started_at_unix)
+                >= 48 * 60 * 60
+            && self.eligible_operations >= 1000
+            && self.privacy_violations == 0
+            && self.authority_violations == 0
+            && self.false_completion_violations == 0
+            && self.baseline_p95_ms.is_finite()
+            && self.baseline_p95_ms > 0.0
+            && self.candidate_p95_ms.is_finite()
+            && self.candidate_p95_ms > 0.0
+            && self.candidate_p95_ms <= self.baseline_p95_ms * 1.10
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Rollout {
+    pub phase: String,
+    pub candidate_sha256: String,
+    pub corpus_sha256: String,
+    pub cohort_salt: String,
+    #[serde(default)]
+    pub internal_subjects: Vec<String>,
+    pub qualification: Qualification,
+    pub canary: Option<CanaryEvidence>,
+}
+
+impl Rollout {
+    pub fn mode(
+        &self,
+        subject: Option<&str>,
+        workspace: Option<&str>,
+        project: Option<&str>,
+        now: i64,
+    ) -> &'static str {
+        if !self
+            .qualification
+            .passes(&self.candidate_sha256, &self.corpus_sha256)
+        {
+            return "shadow";
+        }
+        if self.qualification.evaluated_at_unix <= 0
+            || self.qualification.evaluated_at_unix > now
+            || now.saturating_sub(self.qualification.evaluated_at_unix) > 7 * 24 * 60 * 60
+        {
+            return "shadow";
+        }
+        let (Some(subject), Some(workspace)) = (
+            subject.filter(|s| !s.is_empty()),
+            workspace.filter(|s| !s.is_empty()),
+        ) else {
+            return "shadow";
+        };
+        match self.phase.as_str() {
+            "internal" if self.internal_subjects.iter().any(|s| s == subject) => "internal",
+            "canary"
+                if self.cohort_salt.len() >= 16
+                    && cohort_bucket(&self.cohort_salt, subject, workspace, project) < 500 =>
+            {
+                "canary"
+            }
+            "general"
+                if self.canary.as_ref().is_some_and(|c| {
+                    c.passes(now, &self.candidate_sha256, &self.corpus_sha256)
+                }) =>
+            {
+                "general"
+            }
+            _ => "shadow",
+        }
+    }
+}
+
+// Versioned FNV-1a with length-framed fields, stable across processes/platforms.
+// This is sampling, not authentication. Subjects come from authenticated scope.
+fn cohort_bucket(salt: &str, subject: &str, workspace: &str, project: Option<&str>) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for field in [
+        POLICY_REVISION,
+        salt,
+        subject,
+        workspace,
+        project.unwrap_or(""),
+    ] {
+        for byte in (field.len() as u64)
+            .to_le_bytes()
+            .iter()
+            .chain(field.as_bytes())
+        {
+            hash = (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3);
+        }
+    }
+    hash % 10_000
+}
+
+pub fn configured() -> bool {
+    std::env::var_os("CONTEXTSTREAM_GROUNDING_ROLLOUT").is_some()
+        || std::env::var_os("CONTEXTSTREAM_GROUNDING_FORCE_SHADOW").is_some()
+}
+
+pub fn serving_mode(
+    subject: Option<&str>,
+    workspace: Option<&str>,
+    project: Option<&str>,
+) -> &'static str {
+    if force_shadow(
+        std::env::var("CONTEXTSTREAM_GROUNDING_FORCE_SHADOW")
+            .ok()
+            .as_deref(),
+    ) {
+        return "shadow";
+    }
+    std::env::var("CONTEXTSTREAM_GROUNDING_ROLLOUT")
+        .ok()
+        .filter(|v| v.len() <= 64 * 1024)
+        .and_then(|v| serde_json::from_str::<Rollout>(&v).ok())
+        .map(|r| r.mode(subject, workspace, project, chrono::Utc::now().timestamp()))
+        .unwrap_or("shadow")
+}
+
+fn force_shadow(value: Option<&str>) -> bool {
+    // Malformed kill-switch configuration is fail-closed, not an opt-in.
+    value.is_some_and(|v| {
+        !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off"
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn kill_switch_is_case_insensitive_and_malformed_values_fail_closed() {
+        for value in ["1", "true", "TRUE", "on", "unexpected", ""] {
+            assert!(force_shadow(Some(value)));
+        }
+        for value in ["0", "false", "OFF"] {
+            assert!(!force_shadow(Some(value)));
+        }
+        assert!(!force_shadow(None));
+    }
+    fn config() -> Rollout {
+        serde_json::from_value(serde_json::json!({
+            "phase":"internal", "candidate_sha256":"a".repeat(64), "corpus_sha256":"b".repeat(64),
+            "cohort_salt":"fixed-sampling-salt", "internal_subjects":["internal"],
+            "qualification": {"policy_revision":POLICY_REVISION, "candidate_sha256":"a".repeat(64), "corpus_sha256":"b".repeat(64),
+                "development_queries":60,"holdout_queries":60,"independent_labels":true,"coding_qualified":true,"evaluated_at_unix":1,
+                "false_grounding_rate":0.05,"known_item_top1":0.95,"precision_at_5":0.8,
+                "baseline_p95_ms":100.0,"candidate_p95_ms":110.0,
+                "privacy_violations":0,"authority_violations":0,"false_completion_violations":0}
+        })).unwrap()
+    }
+    #[test]
+    fn internal_requires_explicit_subject_and_qualification() {
+        let mut r = config();
+        assert_eq!(r.mode(Some("internal"), Some("ws"), None, 1), "internal");
+        assert_eq!(r.mode(Some("external"), Some("ws"), None, 1), "shadow");
+        assert_eq!(r.mode(None, Some("ws"), None, 1), "shadow");
+        r.qualification.independent_labels = false;
+        assert_eq!(r.mode(Some("internal"), Some("ws"), None, 1), "shadow");
+        r.qualification.independent_labels = true;
+        r.qualification.candidate_p95_ms = f64::NAN;
+        assert_eq!(r.mode(Some("internal"), Some("ws"), None, 1), "shadow");
+    }
+    #[test]
+    fn five_percent_is_sticky_and_scope_framed() {
+        let mut r = config();
+        r.phase = "canary".into();
+        let selected = (0..10_000)
+            .filter(|i| r.mode(Some(&i.to_string()), Some("ws"), Some("project"), 1) == "canary")
+            .count();
+        assert!((400..600).contains(&selected), "{selected}");
+        assert_eq!(
+            cohort_bucket("salt", "one", "ws", None),
+            cohort_bucket("salt", "one", "ws", None)
+        );
+        assert_ne!(
+            cohort_bucket("salt", "ab", "c", None),
+            cohort_bucket("salt", "a", "bc", None)
+        );
+    }
+    #[test]
+    fn expansion_needs_time_and_volume_and_clean_safety() {
+        let mut r = config();
+        r.phase = "general".into();
+        assert_eq!(r.mode(Some("u"), Some("ws"), None, 200_000), "shadow");
+        r.canary = Some(CanaryEvidence {
+            policy_revision: POLICY_REVISION.into(),
+            candidate_sha256: "a".repeat(64),
+            corpus_sha256: "b".repeat(64),
+            started_at_unix: 1,
+            observed_until_unix: 172_801,
+            eligible_operations: 1000,
+            privacy_violations: 0,
+            authority_violations: 0,
+            false_completion_violations: 0,
+            baseline_p95_ms: 100.0,
+            candidate_p95_ms: 110.0,
+        });
+        assert_eq!(r.mode(Some("u"), Some("ws"), None, 200_000), "general");
+        r.canary.as_mut().unwrap().eligible_operations = 999;
+        assert_eq!(r.mode(Some("u"), Some("ws"), None, 200_000), "shadow");
+        r.canary.as_mut().unwrap().eligible_operations = 1000;
+        r.canary.as_mut().unwrap().observed_until_unix = 172_800;
+        assert_eq!(r.mode(Some("u"), Some("ws"), None, 200_000), "shadow");
+        r.canary.as_mut().unwrap().observed_until_unix = 172_801;
+        r.canary.as_mut().unwrap().authority_violations = 1;
+        assert_eq!(r.mode(Some("u"), Some("ws"), None, 200_000), "shadow");
+    }
+}

--- a/crates/mcp-tools/src/domains/session.rs
+++ b/crates/mcp-tools/src/domains/session.rs
@@ -8402,7 +8402,7 @@ impl ToolHandler for ContextTool {
             config.tool_surface_profile == ToolSurfaceProfile::OpenaiAgentic;
 
         let mut grounding_fragment =
-            crate::domains::grounding::format_grounding_block(&grounding_hits, is_compact);
+            crate::domains::grounding::format_grounding_block(grounding_hits, is_compact);
         if grounding_recall.status == "unavailable" {
             grounding_fragment.push_str("\n[GROUNDING_UNAVAILABLE] Prior-work retrieval did not complete. This is not evidence that no prior work exists. Preserve scope and read-before-edit requirements; use the authorized local-discovery fallback when applicable.\n");
         }
@@ -9216,7 +9216,7 @@ impl ToolHandler for ContextTool {
             .or(folder_path_for_grounding.as_deref());
         if let Some(fp) = grounding_emit_path {
             let summary = if crate::domains::grounding::grounding_enabled() {
-                crate::domains::grounding::grounding_summary(&grounding_hits)
+                crate::domains::grounding::grounding_summary(grounding_hits)
             } else {
                 mcp_session::grounding_state::GroundingSummary::default()
             };
@@ -9232,14 +9232,12 @@ impl ToolHandler for ContextTool {
             );
             obj.insert(
                 "grounding_freshness".to_string(),
-                serde_json::to_value(crate::domains::grounding::grounding_summary(
-                    &grounding_hits,
-                ))
-                .unwrap_or_else(|_| serde_json::json!({})),
+                serde_json::to_value(crate::domains::grounding::grounding_summary(grounding_hits))
+                    .unwrap_or_else(|_| serde_json::json!({})),
             );
             obj.insert(
                 "grounding_hits".to_string(),
-                serde_json::to_value(&grounding_hits).unwrap_or_else(|_| serde_json::json!([])),
+                serde_json::to_value(grounding_hits).unwrap_or_else(|_| serde_json::json!([])),
             );
             if let Some(inbox) = coordination_inbox {
                 obj.insert("coordination_inbox".to_string(), inbox);
@@ -15519,7 +15517,7 @@ async fn execute_session_ground(
         text.push('\n');
     }
     text.push_str(&crate::domains::grounding::format_grounding_block(
-        &hits, false,
+        hits, false,
     ));
     if !decisions.is_empty() {
         text.push('\n');
@@ -15559,7 +15557,7 @@ async fn execute_session_ground(
         "lessons": lessons,
         "skills": skills,
         "recent_media": recent_media,
-        "grounding_hits": serde_json::to_value(&hits).unwrap_or_else(|_| serde_json::json!([])),
+        "grounding_hits": serde_json::to_value(hits).unwrap_or_else(|_| serde_json::json!([])),
         "feed_items": feed_items,
     });
 

--- a/crates/mcp-tools/src/domains/session.rs
+++ b/crates/mcp-tools/src/domains/session.rs
@@ -3790,12 +3790,41 @@ fn routing_scope_key(
     project_id: Option<Uuid>,
     folder_path: Option<&str>,
 ) -> String {
-    format!(
-        "{}|{}|{}",
-        workspace_id.map(|id| id.to_string()).unwrap_or_default(),
-        project_id.map(|id| id.to_string()).unwrap_or_default(),
-        folder_path.unwrap_or_default()
+    routing_scope_key_for_caller(
+        workspace_id,
+        project_id,
+        folder_path,
+        super::atlas_warm_cache::current_user_scope_token().as_deref(),
     )
+}
+
+fn routing_scope_key_for_caller(
+    workspace_id: Option<Uuid>,
+    project_id: Option<Uuid>,
+    folder_path: Option<&str>,
+    caller: Option<&str>,
+) -> String {
+    // A shared hosted process must never let one caller silence another's
+    // grounding/setup warning. With no verified caller identity, do not damp.
+    let Some(caller) = caller.filter(|value| !value.is_empty()) else {
+        return format!("unscoped:{}", Uuid::new_v4());
+    };
+    serde_json::json!([caller, workspace_id, project_id, folder_path]).to_string()
+}
+
+#[test]
+fn routing_notices_are_caller_partitioned_and_anonymous_calls_are_not_damped() {
+    let ws = Some(Uuid::new_v4());
+    let first = routing_scope_key_for_caller(ws, None, Some("/checkout"), Some("caller-a"));
+    let second = routing_scope_key_for_caller(ws, None, Some("/checkout"), Some("caller-b"));
+    assert_ne!(first, second);
+    assert!(routing_notice_first_emission(&first, "notice", false));
+    assert!(!routing_notice_first_emission(&first, "notice", false));
+    assert!(routing_notice_first_emission(&second, "notice", false));
+    assert_ne!(
+        routing_scope_key_for_caller(ws, None, None, None),
+        routing_scope_key_for_caller(ws, None, None, None)
+    );
 }
 
 /// Records the notice for this scope and reports whether it should be shown.
@@ -6534,7 +6563,7 @@ async fn proactive_grounding_recall(
     session_id: Option<&str>,
 ) -> crate::domains::grounding::GroundingRecall {
     use crate::domains::grounding::{
-        grounding_enabled, grounding_timeout, recall_with_shadow, GroundingRecall,
+        grounding_enabled, grounding_timeout, recall_with_rollout, GroundingRecall,
     };
 
     if !grounding_enabled() || workspace_id.is_none() {
@@ -6573,7 +6602,13 @@ async fn proactive_grounding_recall(
     )
     .await
     {
-        return recall_with_shadow(bundle.payload.clone(), session_id);
+        return recall_with_rollout(
+            bundle.payload.clone(),
+            session_id,
+            user_scope,
+            Some(&ws.to_string()),
+            project_id.map(|p| p.to_string()).as_deref(),
+        );
     }
 
     // Cache miss: run the primary recall, then write back so the next
@@ -6593,7 +6628,13 @@ async fn proactive_grounding_recall(
                 scope_for_put,
                 value.clone(),
             );
-            recall_with_shadow(value, session_id)
+            recall_with_rollout(
+                value,
+                session_id,
+                user_scope,
+                Some(&ws.to_string()),
+                project_id.map(|p| p.to_string()).as_deref(),
+            )
         }
         _ => GroundingRecall::unavailable(),
     }
@@ -7514,6 +7555,7 @@ impl ToolHandler for ContextTool {
         // Saving an exchange is an API side effect; a cache hit would silently
         // skip transcript capture, so this lane is deliberately uncached.
         let context_cache_allowed = context_cache_identity.is_some()
+            && !crate::domains::grounding::rollout::configured()
             && !checkout_scope_unroutable
             && !should_save
             && context_cache_messages_admissible(
@@ -9184,11 +9226,10 @@ impl ToolHandler for ContextTool {
         let mut structured = serde_json::to_value(&result).unwrap_or_default();
         attach_scope_guidance(&mut structured, workspace_id, project_id);
         if let Some(obj) = structured.as_object_mut() {
-            obj.insert("grounding_retrieval".to_string(), serde_json::json!({
-                "status": grounding_recall.status,
-                "selection_mode": grounding_recall.selection_mode,
-                "shadow_hit_count": grounding_recall.shadow_hit_count,
-            }));
+            obj.insert(
+                "grounding_retrieval".to_string(),
+                grounding_recall.telemetry(),
+            );
             obj.insert(
                 "grounding_freshness".to_string(),
                 serde_json::to_value(crate::domains::grounding::grounding_summary(
@@ -15242,6 +15283,7 @@ fn composite_ground_cache_eligible(input: &SessionInput, has_checkout: bool) -> 
     // session-selected evidence. Only the default, workspace-only read is
     // shareable by its existing key. Raw recall remains independently cached.
     !has_checkout
+        && !crate::domains::grounding::rollout::configured()
         && input.session_id.is_none()
         && input.include_decisions.unwrap_or(true)
         && input.include_related.unwrap_or(true)
@@ -15249,12 +15291,20 @@ fn composite_ground_cache_eligible(input: &SessionInput, has_checkout: bool) -> 
 
 #[test]
 fn composite_ground_cache_never_reuses_checkout_or_session_state() {
-    let input: SessionInput = serde_json::from_value(serde_json::json!({"action":"ground"})).unwrap();
+    let input: SessionInput =
+        serde_json::from_value(serde_json::json!({"action":"ground"})).unwrap();
     assert!(composite_ground_cache_eligible(&input, false));
     assert!(!composite_ground_cache_eligible(&input, true));
-    for extra in [serde_json::json!({"session_id":"session-a"}), serde_json::json!({"include_decisions":false}), serde_json::json!({"include_related":false})] {
+    for extra in [
+        serde_json::json!({"session_id":"session-a"}),
+        serde_json::json!({"include_decisions":false}),
+        serde_json::json!({"include_related":false}),
+    ] {
         let mut value = serde_json::json!({"action":"ground"});
-        value.as_object_mut().unwrap().extend(extra.as_object().unwrap().clone());
+        value
+            .as_object_mut()
+            .unwrap()
+            .extend(extra.as_object().unwrap().clone());
         let input: SessionInput = serde_json::from_value(value).unwrap();
         assert!(!composite_ground_cache_eligible(&input, false));
     }
@@ -15285,7 +15335,8 @@ async fn execute_session_ground(
     )
     .await?;
 
-    let cache_eligible = composite_ground_cache_eligible(input, session.state().await.folder_path.is_some());
+    let cache_eligible =
+        composite_ground_cache_eligible(input, session.state().await.folder_path.is_some());
 
     // P0 #3 — Atlas regional warm cache for `session(ground)`. Ground
     // is a composite of recall + docs + decisions + lessons + skills
@@ -15395,7 +15446,13 @@ async fn execute_session_ground(
         .map(str::to_string)
         .or(session_state.session_id.clone());
 
-    let grounding_recall = crate::domains::grounding::recall_with_shadow(recall_val.clone(), session_id.as_deref());
+    let grounding_recall = crate::domains::grounding::recall_with_rollout(
+        recall_val.clone(),
+        session_id.as_deref(),
+        user_scope_token.as_deref(),
+        scope.workspace_id.map(|id| id.to_string()).as_deref(),
+        scope.project_id.map(|id| id.to_string()).as_deref(),
+    );
     let hits = &grounding_recall.hits;
 
     let mut text =
@@ -15496,7 +15553,7 @@ async fn execute_session_ground(
 
     let structured = serde_json::json!({
         "recall": recall_val,
-        "grounding_retrieval": {"status":grounding_recall.status,"selection_mode":grounding_recall.selection_mode,"shadow_hit_count":grounding_recall.shadow_hit_count},
+        "grounding_retrieval": grounding_recall.telemetry(),
         "decision_matches": decisions,
         "doc_matches": docs,
         "lessons": lessons,
@@ -15515,7 +15572,10 @@ async fn execute_session_ground(
     // P0 #3 — write-back: cache the formatted ToolResult so the same
     // user_message within the next 5 min serves from regional Atlas
     // instead of the ~1.5s composite. Idempotent per turn.
-    if let Some(ws) = scope.workspace_id.filter(|_| cache_eligible && grounding_recall.status != "unavailable") {
+    if let Some(ws) = scope
+        .workspace_id
+        .filter(|_| cache_eligible && grounding_recall.status != "unavailable")
+    {
         if let Ok(payload) = serde_json::to_value(&final_result) {
             let cache_scope = mcp_types::atlas_layer::AtlasFederationScope {
                 workspace_id: ws,

--- a/crates/mcp-tools/src/domains/session.rs
+++ b/crates/mcp-tools/src/domains/session.rs
@@ -6531,13 +6531,14 @@ async fn proactive_grounding_recall(
     workspace_id: Option<Uuid>,
     project_id: Option<Uuid>,
     user_message: &str,
-) -> Vec<crate::domains::grounding::GroundingHit> {
+    session_id: Option<&str>,
+) -> crate::domains::grounding::GroundingRecall {
     use crate::domains::grounding::{
-        grounding_enabled, grounding_timeout, parse_recall_results_normalized,
+        grounding_enabled, grounding_timeout, recall_with_shadow, GroundingRecall,
     };
 
     if !grounding_enabled() || workspace_id.is_none() {
-        return Vec::new();
+        return GroundingRecall::disabled();
     }
     let ws = workspace_id.unwrap();
 
@@ -6572,7 +6573,7 @@ async fn proactive_grounding_recall(
     )
     .await
     {
-        return parse_recall_results_normalized(bundle.payload.clone());
+        return recall_with_shadow(bundle.payload.clone(), session_id);
     }
 
     // Cache miss: run the primary recall, then write back so the next
@@ -6592,9 +6593,9 @@ async fn proactive_grounding_recall(
                 scope_for_put,
                 value.clone(),
             );
-            parse_recall_results_normalized(value)
+            recall_with_shadow(value, session_id)
         }
-        _ => Vec::new(),
+        _ => GroundingRecall::unavailable(),
     }
 }
 
@@ -7879,6 +7880,7 @@ impl ToolHandler for ContextTool {
                 let ws_g = workspace_id;
                 let pid_g = project_id;
                 let q_g = user_message_for_relevance.clone();
+                let sid_g = context_session_id.clone();
                 Some(tokio::spawn(async move {
                     with_caller_auth(
                         session_key_g,
@@ -7893,6 +7895,7 @@ impl ToolHandler for ContextTool {
                                 ws_g,
                                 pid_g,
                                 &q_g,
+                                sid_g.as_deref(),
                             )
                             .await
                         },
@@ -8280,15 +8283,16 @@ impl ToolHandler for ContextTool {
             crate::domains::grounding::grounding_timeout()
         };
 
-        let grounding_hits = if let Some(handle) = grounding_future {
+        let grounding_recall = if let Some(handle) = grounding_future {
             match tokio::time::timeout(proactive_bound, handle).await {
                 Ok(Ok(hits)) => hits,
-                Ok(Err(_)) => Vec::new(), // join error / panic
-                Err(_) => Vec::new(),     // bound elapsed; task continues
+                Ok(Err(_)) => crate::domains::grounding::GroundingRecall::unavailable(),
+                Err(_) => crate::domains::grounding::GroundingRecall::unavailable(),
             }
         } else {
-            Vec::new()
+            crate::domains::grounding::GroundingRecall::disabled()
         };
+        let grounding_hits = &grounding_recall.hits;
 
         let coordination_inbox: Option<Value> = if let Some(handle) = coordination_future {
             match tokio::time::timeout(proactive_bound, handle).await {
@@ -8355,8 +8359,11 @@ impl ToolHandler for ContextTool {
         let openai_agentic_surface =
             config.tool_surface_profile == ToolSurfaceProfile::OpenaiAgentic;
 
-        let grounding_fragment =
+        let mut grounding_fragment =
             crate::domains::grounding::format_grounding_block(&grounding_hits, is_compact);
+        if grounding_recall.status == "unavailable" {
+            grounding_fragment.push_str("\n[GROUNDING_UNAVAILABLE] Prior-work retrieval did not complete. This is not evidence that no prior work exists. Preserve scope and read-before-edit requirements; use the authorized local-discovery fallback when applicable.\n");
+        }
 
         // Build response text
         let mut text = String::new();
@@ -9177,6 +9184,11 @@ impl ToolHandler for ContextTool {
         let mut structured = serde_json::to_value(&result).unwrap_or_default();
         attach_scope_guidance(&mut structured, workspace_id, project_id);
         if let Some(obj) = structured.as_object_mut() {
+            obj.insert("grounding_retrieval".to_string(), serde_json::json!({
+                "status": grounding_recall.status,
+                "selection_mode": grounding_recall.selection_mode,
+                "shadow_hit_count": grounding_recall.shadow_hit_count,
+            }));
             obj.insert(
                 "grounding_freshness".to_string(),
                 serde_json::to_value(crate::domains::grounding::grounding_summary(
@@ -15358,10 +15370,14 @@ async fn execute_session_ground(
         .map(str::to_string)
         .or(session_state.session_id.clone());
 
-    let hits = crate::domains::grounding::parse_recall_results_normalized(recall_val.clone());
+    let grounding_recall = crate::domains::grounding::recall_with_shadow(recall_val.clone(), session_id.as_deref());
+    let hits = &grounding_recall.hits;
 
     let mut text =
         String::from("[GROUNDING_BUNDLE] One-shot prior-work pack for this message.\n\n");
+    if grounding_recall.status == "unavailable" {
+        text.push_str("[GROUNDING_UNAVAILABLE] Prior-work retrieval was unavailable; do not interpret this as no prior work.\n\n");
+    }
     if let Ok(inbox) = client
         .coordination_inbox(
             scope.workspace_id,
@@ -15455,6 +15471,7 @@ async fn execute_session_ground(
 
     let structured = serde_json::json!({
         "recall": recall_val,
+        "grounding_retrieval": {"status":grounding_recall.status,"selection_mode":grounding_recall.selection_mode,"shadow_hit_count":grounding_recall.shadow_hit_count},
         "decision_matches": decisions,
         "doc_matches": docs,
         "lessons": lessons,
@@ -15473,7 +15490,7 @@ async fn execute_session_ground(
     // P0 #3 — write-back: cache the formatted ToolResult so the same
     // user_message within the next 5 min serves from regional Atlas
     // instead of the ~1.5s composite. Idempotent per turn.
-    if let Some(ws) = scope.workspace_id {
+    if let Some(ws) = scope.workspace_id.filter(|_| grounding_recall.status != "unavailable") {
         if let Ok(payload) = serde_json::to_value(&final_result) {
             let cache_scope = mcp_types::atlas_layer::AtlasFederationScope {
                 workspace_id: ws,

--- a/crates/mcp-tools/src/domains/session.rs
+++ b/crates/mcp-tools/src/domains/session.rs
@@ -15237,6 +15237,29 @@ async fn consume_grounding_session(session: &Arc<SessionManager>) {
 /// Upper bound on the Context Feeds grounding read inside `session(ground)`.
 const FEED_GROUNDING_TIMEOUT_MS: u64 = 2_000;
 
+fn composite_ground_cache_eligible(input: &SessionInput, has_checkout: bool) -> bool {
+    // This cache contains a formatted bundle, including checkout state and
+    // session-selected evidence. Only the default, workspace-only read is
+    // shareable by its existing key. Raw recall remains independently cached.
+    !has_checkout
+        && input.session_id.is_none()
+        && input.include_decisions.unwrap_or(true)
+        && input.include_related.unwrap_or(true)
+}
+
+#[test]
+fn composite_ground_cache_never_reuses_checkout_or_session_state() {
+    let input: SessionInput = serde_json::from_value(serde_json::json!({"action":"ground"})).unwrap();
+    assert!(composite_ground_cache_eligible(&input, false));
+    assert!(!composite_ground_cache_eligible(&input, true));
+    for extra in [serde_json::json!({"session_id":"session-a"}), serde_json::json!({"include_decisions":false}), serde_json::json!({"include_related":false})] {
+        let mut value = serde_json::json!({"action":"ground"});
+        value.as_object_mut().unwrap().extend(extra.as_object().unwrap().clone());
+        let input: SessionInput = serde_json::from_value(value).unwrap();
+        assert!(!composite_ground_cache_eligible(&input, false));
+    }
+}
+
 /// One-shot grounding bundle: recall + doc/decision augmentations + lessons + skills + git.
 async fn execute_session_ground(
     client: &ContextStreamClient,
@@ -15262,6 +15285,8 @@ async fn execute_session_ground(
     )
     .await?;
 
+    let cache_eligible = composite_ground_cache_eligible(input, session.state().await.folder_path.is_some());
+
     // P0 #3 — Atlas regional warm cache for `session(ground)`. Ground
     // is a composite of recall + docs + decisions + lessons + skills
     // + git for a given user_message. The composite ToolResult is
@@ -15272,7 +15297,7 @@ async fn execute_session_ground(
     // cached via P0 #1 (lessons), P0 #2 (recall), P0 #4 (decisions),
     // so even cold-ground populates those downstream caches.
     let user_scope_token = super::atlas_warm_cache::current_user_scope_token();
-    if let Some(ws) = scope.workspace_id {
+    if let Some(ws) = scope.workspace_id.filter(|_| cache_eligible) {
         let cache_scope = mcp_types::atlas_layer::AtlasFederationScope {
             workspace_id: ws,
             project_id: scope.project_id,
@@ -15490,7 +15515,7 @@ async fn execute_session_ground(
     // P0 #3 — write-back: cache the formatted ToolResult so the same
     // user_message within the next 5 min serves from regional Atlas
     // instead of the ~1.5s composite. Idempotent per turn.
-    if let Some(ws) = scope.workspace_id.filter(|_| grounding_recall.status != "unavailable") {
+    if let Some(ws) = scope.workspace_id.filter(|_| cache_eligible && grounding_recall.status != "unavailable") {
         if let Ok(payload) = serde_json::to_value(&final_result) {
             let cache_scope = mcp_types::atlas_layer::AtlasFederationScope {
                 workspace_id: ws,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextstream/mcp-server",
   "mcpName": "io.github.contextstream/mcp-server",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Verified npm launcher for the open-source ContextStream Rust MCP server",
   "type": "module",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.contextstream/mcp-server",
   "title": "ContextStream MCP Server",
   "description": "Project memory, semantic code search, and grounded agent context.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "url": "https://github.com/contextstream/mcp-server",
     "source": "github"
@@ -20,7 +20,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@contextstream/mcp-server",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "transport": {
         "type": "stdio"
       },

--- a/testing/grounding/.gitignore
+++ b/testing/grounding/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/testing/grounding/qualify.py
+++ b/testing/grounding/qualify.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Frozen 60/60 grounding evaluation using the actual Rust selector.
+
+No labels or queries are generated here. Supply a reviewed corpus and separate
+development/holdout labels. Author-generated examples cannot qualify holdout.
+Selector timing is explicitly NOT end-to-end context latency or canary evidence.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import time
+
+POLICY = "grounding-evidence-v1"
+CATEGORIES = {"continuation", "paraphrase", "history", "supersession", "scope", "no_answer"}
+SPLITS = ("development", "holdout")
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def digest(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def read(path):
+    return json.loads(Path(path).read_text())
+
+
+def corpus_queries(corpus, split):
+    require(isinstance(corpus, dict) and corpus.get("schema_version") == 1, "unsupported corpus")
+    require(isinstance(corpus.get("authors"), list) and corpus["authors"] and all(isinstance(a, str) and a for a in corpus["authors"]), "missing corpus authors")
+    queries = corpus.get("queries")
+    require(isinstance(queries, list) and len(queries) == 120, "exactly 120 frozen queries required")
+    seen, texts = set(), set()
+    for query in queries:
+        require(isinstance(query, dict), "invalid query")
+        query_id, text = query.get("id"), query.get("text")
+        require(isinstance(query_id, str) and query_id and query_id not in seen, "duplicate/missing query id")
+        require(isinstance(text, str) and text.strip() and text.strip().casefold() not in texts, "duplicate/missing query text")
+        require(query.get("split") in SPLITS and query.get("category") in CATEGORIES, "invalid split/category")
+        projects = query.get("allowed_project_ids")
+        require(isinstance(projects, list) and projects and all(p is None or isinstance(p, str) and p for p in projects), "explicit authorized project scopes required")
+        seen.add(query_id)
+        texts.add(text.strip().casefold())
+    for part in SPLITS:
+        for category in CATEGORIES:
+            require(sum(q["split"] == part and q["category"] == category for q in queries) == 10, "each split requires ten queries in each category")
+    return {q["id"]: q for q in queries if q["split"] == split}
+
+
+def identity(item):
+    require(isinstance(item, dict) and isinstance(item.get("id"), str) and item["id"], "missing source identity")
+    require("project_id" in item and (item["project_id"] is None or isinstance(item["project_id"], str)), "missing source scope")
+    return item["project_id"], item["id"]
+
+
+def indexed(items, key):
+    require(isinstance(items, list) and all(isinstance(i, dict) for i in items), "invalid result array")
+    result = {}
+    for item in items:
+        value = item.get(key)
+        require(isinstance(value, str) and value and value not in result, "duplicate/missing result identity")
+        result[value] = item
+    return result
+
+
+def measure(corpus, split, labels, replay):
+    queries = corpus_queries(corpus, split)
+    require(labels.get("split") == split and labels.get("schema_version") == 1, "labels have wrong split/schema")
+    require(replay.get("split") == split and replay.get("policy_revision") == POLICY, "replay has wrong split/policy")
+    label_map = indexed(labels.get("labels"), "query_id")
+    runs = indexed(replay.get("results"), "query_id")
+    require(set(queries) == set(label_map) == set(runs), "incomplete or foreign query coverage")
+    known, top1, relevant_at_5, answerable, no_answer, false_ground, unavailable, scope_violations = (0,) * 8
+    independent = labels.get("provenance") == "independent_review"
+    for query_id, query in queries.items():
+        label, run = label_map[query_id], runs[query_id]
+        reviewer = label.get("reviewer_id")
+        independent = independent and isinstance(reviewer, str) and bool(reviewer) and reviewer not in corpus["authors"]
+        relevant_list = label.get("relevant")
+        require(isinstance(relevant_list, list), "missing relevant-source labels")
+        relevant = {identity(item) for item in relevant_list}
+        require(len(relevant) == len(relevant_list), "duplicate relevance labels")
+        require(all(project in query["allowed_project_ids"] for project, _ in relevant), "label crosses authorized scope")
+        expected = identity(label["known_item"]) if label.get("known_item") is not None else None
+        require(expected is None or expected in relevant, "known item must be relevant")
+        require(run.get("policy_revision") == POLICY, "foreign selector policy")
+        require(run.get("retrieval_status") in {"available", "no_evidence", "unavailable"}, "unknown retrieval status")
+        if run["retrieval_status"] == "unavailable":
+            unavailable += 1
+        retrieved = run.get("candidate")
+        require(isinstance(retrieved, list) and len(retrieved) <= 5, "candidate must contain at most five hits")
+        ids = [identity(item) for item in retrieved]
+        require(len(ids) == len(set(ids)), "duplicate candidate identities")
+        scope_violations += sum(project not in query["allowed_project_ids"] for project, _ in ids)
+        if expected is not None:
+            known += 1
+            top1 += bool(ids and ids[0] == expected)
+        if relevant:
+            answerable += 1
+            relevant_at_5 += sum(item in relevant for item in ids)
+        else:
+            no_answer += 1
+            false_ground += bool(ids)
+    require(known > 0 and answerable > 0 and no_answer >= 10, "known-item and no-answer coverage required")
+    return {"query_count": len(queries), "known_item_queries": known, "known_item_top1": top1 / known,
+            # Fixed denominator: returning fewer hits cannot inflate precision@5.
+            "precision_at_5": relevant_at_5 / (5 * answerable),
+            "no_answer_queries": no_answer, "false_grounding_rate": false_ground / no_answer,
+            "unavailable_queries": unavailable, "scope_violations": scope_violations,
+            "independent_labels": bool(independent)}
+
+
+def approved_development(report):
+    return (report.get("schema_version") == 1 and report.get("split") == "development"
+            and report.get("policy_revision") == POLICY and report.get("development_approved") is True
+            and report.get("source_dirty") is False and type(report.get("sealed_at_unix")) is int
+            and 0 < report["sealed_at_unix"] <= int(time.time()))
+
+
+def evaluate(corpus_path, split, labels, replay, development=None):
+    corpus = read(corpus_path)
+    corpus_hash = digest(corpus_path)
+    require(labels.get("corpus_sha256") == corpus_hash == replay.get("corpus_sha256"), "corpus/label/replay fingerprint mismatch")
+    metrics = measure(corpus, split, labels, replay)
+    result = {"schema_version": 1, "split": split, "policy_revision": POLICY, "minimum_lexical_coverage": 0.4,
+              "corpus_sha256": corpus_hash, "replay_binary_sha256": replay.get("replay_binary_sha256"),
+              "source_commit": replay.get("source_commit"), "source_dirty": replay.get("source_dirty"),
+              "sealed_at_unix": int(time.time()), "metrics": metrics,
+              "development_approved": False, "retrieval_qualified": False, "release_qualified": False}
+    clean = replay.get("source_dirty") is False and isinstance(replay.get("source_commit"), str) and bool(replay["source_commit"])
+    clean = clean and isinstance(replay.get("replay_binary_sha256"), str) and len(replay["replay_binary_sha256"]) == 64
+    safe = metrics["unavailable_queries"] == 0 and metrics["scope_violations"] == 0 and metrics["false_grounding_rate"] <= 0.05
+    if split == "development":
+        # This revision has a fixed 0.4 policy. If it fails, change/calibrate on
+        # development and collect a new source-bound report before holdout.
+        result["development_approved"] = bool(clean and safe)
+    else:
+        require(isinstance(development, dict) and approved_development(development), "seal development before reading holdout labels")
+        require(all(development.get(k) == result.get(k) for k in ("corpus_sha256", "replay_binary_sha256", "source_commit", "policy_revision")), "holdout candidate differs from sealed development")
+        require(type(replay.get("collected_at_unix")) is int and development["sealed_at_unix"] <= replay["collected_at_unix"] <= int(time.time()), "holdout collection time is outside the sealed evaluation window")
+        result["retrieval_qualified"] = bool(clean and safe and metrics["independent_labels"]
+                                              and metrics["known_item_top1"] >= 0.95 and metrics["precision_at_5"] >= 0.8)
+    return result
+
+
+def build_selector():
+    root = Path(__file__).resolve().parents[2]
+    require(not subprocess.check_output(["git", "status", "--porcelain"], cwd=root).strip(), "clean source required to build selector")
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+    subprocess.run(["cargo", "build", "-p", "mcp-tools", "--example", "grounding_replay", "--offline"], cwd=root, check=True)
+    metadata = json.loads(subprocess.check_output(["cargo", "metadata", "--no-deps", "--format-version", "1", "--offline"], cwd=root))
+    binary = Path(metadata["target_directory"]) / "debug" / "examples" / ("grounding_replay.exe" if os.name == "nt" else "grounding_replay")
+    require(commit == subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            and not subprocess.check_output(["git", "status", "--porcelain"], cwd=root).strip(), "source changed during build")
+    return {"schema_version":1,"policy_revision":POLICY,"source_commit":commit,"source_dirty":False,
+            "binary":str(binary),"replay_binary_sha256":digest(binary),"profile":"debug","built_at_unix":int(time.time())}
+
+
+def collect(corpus_path, split, recalls_path, binary, build_receipt, development=None):
+    corpus = read(corpus_path)
+    queries = corpus_queries(corpus, split)
+    rows = [json.loads(line) for line in Path(recalls_path).read_text().splitlines() if line.strip()]
+    by_id = indexed(rows, "query_id")
+    require(set(by_id) == set(queries), "exact split coverage required for recall input")
+    for query_id, row in by_id.items():
+        require(row.get("query_sha256") == hashlib.sha256(queries[query_id]["text"].encode()).hexdigest(), "recall input belongs to a different query")
+    root = Path(__file__).resolve().parents[2]
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+    dirty = bool(subprocess.check_output(["git", "status", "--porcelain"], cwd=root).strip())
+    candidate = digest(binary)
+    require(isinstance(build_receipt, dict) and build_receipt.get("source_dirty") is False
+            and build_receipt.get("source_commit") == commit and build_receipt.get("replay_binary_sha256") == candidate
+            and build_receipt.get("policy_revision") == POLICY, "selector build receipt mismatch")
+    corpus_hash = digest(corpus_path)
+    if split == "holdout":
+        require(isinstance(development, dict) and approved_development(development), "development must be sealed first")
+        require(not dirty and development["source_commit"] == commit and development["replay_binary_sha256"] == candidate and development["corpus_sha256"] == corpus_hash, "candidate changed after development")
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CONTEXTSTREAM_GROUNDING_")}
+    process = subprocess.run([str(Path(binary).resolve())], input="\n".join(json.dumps(row) for row in rows) + "\n",
+                             text=True, capture_output=True, timeout=120, check=True, env=env)
+    results = [json.loads(line) for line in process.stdout.splitlines()]
+    require(set(indexed(results, "query_id")) == set(queries), "selector did not return complete coverage")
+    require(candidate == digest(binary), "selector changed during collection")
+    require(commit == subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip(), "source changed during collection")
+    dirty = dirty or bool(subprocess.check_output(["git", "status", "--porcelain"], cwd=root).strip())
+    return {"schema_version": 1, "split": split, "policy_revision": POLICY, "corpus_sha256": corpus_hash,
+            "replay_binary_sha256": candidate, "source_commit": commit, "source_dirty": dirty,
+            "recalls_sha256": digest(recalls_path), "collected_at_unix": int(time.time()), "results": results,
+            "timing_scope": "selector_only_not_end_to_end", "release_qualified": False}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("build", "collect", "evaluate"))
+    parser.add_argument("--split", choices=SPLITS)
+    parser.add_argument("--corpus", type=Path)
+    parser.add_argument("--build-receipt", type=Path)
+    parser.add_argument("--development", type=Path)
+    parser.add_argument("--recalls", type=Path)
+    parser.add_argument("--binary", type=Path)
+    parser.add_argument("--labels", type=Path)
+    parser.add_argument("--replay", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.action == "build":
+        args.output.write_text(json.dumps(build_selector(), indent=2) + "\n")
+        return 0
+    require(args.split and args.corpus, "split and corpus required")
+    development = read(args.development) if args.development else None
+    # Before opening holdout labels, check the development seal.
+    if args.split == "holdout":
+        require(isinstance(development, dict) and approved_development(development), "development seal required")
+    if args.action == "collect":
+        require(args.recalls and args.binary and args.build_receipt, "collect requires --recalls, --binary and --build-receipt")
+        result = collect(args.corpus, args.split, args.recalls, args.binary, read(args.build_receipt), development)
+        passed = not result["source_dirty"]
+    else:
+        require(args.labels and args.replay, "evaluate requires --labels and --replay")
+        result = evaluate(args.corpus, args.split, read(args.labels), read(args.replay), development)
+        passed = result["development_approved"] if args.split == "development" else result["retrieval_qualified"]
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps({k: result[k] for k in ("split", "policy_revision", "release_qualified")}))
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (ValueError, OSError, TypeError, KeyError, subprocess.SubprocessError):
+        raise SystemExit("Grounding qualification failed: missing, malformed, unsealed or mismatched evidence.")

--- a/testing/grounding/test_qualify.py
+++ b/testing/grounding/test_qualify.py
@@ -1,0 +1,105 @@
+"""Synthetic unit-test data only; never persisted as holdout evidence."""
+import copy
+import json
+from pathlib import Path
+import tempfile
+import time
+import unittest
+
+from qualify import CATEGORIES, POLICY, corpus_queries, digest, evaluate, measure
+
+
+class QualificationTests(unittest.TestCase):
+    def setUp(self):
+        self.corpus = {"schema_version":1,"authors":["unit-test-author"],"queries":[
+            {"id":f"{split}-{category}-{i}","text":f"unit test {split} {category} {i}","split":split,
+             "category":category,"allowed_project_ids":["test-project"]}
+            for split in ("development", "holdout") for category in sorted(CATEGORIES) for i in range(10)]}
+
+    def evidence(self, split):
+        labels, runs = [], []
+        for q in corpus_queries(self.corpus, split).values():
+            hits = [] if q["category"] == "no_answer" else [{"id":f"{q['id']}-{i}","project_id":"test-project"} for i in range(5)]
+            labels.append({"query_id":q["id"],"reviewer_id":"unit-test-reviewer","relevant":hits,"known_item":hits[0] if hits else None})
+            runs.append({"query_id":q["id"],"policy_revision":POLICY,"candidate":copy.deepcopy(hits),"retrieval_status":"available" if hits else "no_evidence"})
+        return ({"schema_version":1,"split":split,"provenance":"independent_review","labels":labels},
+                {"schema_version":1,"split":split,"policy_revision":POLICY,"results":runs,
+                 "source_commit":"unit-test-commit","source_dirty":False,"replay_binary_sha256":"a"*64,"collected_at_unix":int(time.time())})
+
+    def test_full_scoped_evidence_scores_exactly(self):
+        labels, replay = self.evidence("holdout")
+        result = measure(self.corpus, "holdout", labels, replay)
+        self.assertEqual(result["known_item_top1"], 1)
+        self.assertEqual(result["precision_at_5"], 1)
+        self.assertEqual(result["false_grounding_rate"], 0)
+        self.assertTrue(result["independent_labels"])
+
+    def test_author_is_not_an_independent_labeler(self):
+        labels, replay = self.evidence("holdout")
+        labels["labels"][0]["reviewer_id"] = "unit-test-author"
+        self.assertFalse(measure(self.corpus, "holdout", labels, replay)["independent_labels"])
+
+    def test_missing_duplicate_and_unbalanced_corpus_rejected(self):
+        for mutation in (lambda c: c["queries"].pop(),
+                         lambda c: c["queries"].__setitem__(0, c["queries"][1]),
+                         lambda c: c["queries"][0].update(category="scope")):
+            corpus = copy.deepcopy(self.corpus)
+            mutation(corpus)
+            with self.assertRaises(ValueError):
+                corpus_queries(corpus, "development")
+
+    def test_missing_duplicate_foreign_and_unknown_replay_rejected(self):
+        for mutation in (lambda r: r["results"].pop(),
+                         lambda r: r["results"].append(r["results"][0]),
+                         lambda r: r["results"][0].update(query_id="foreign"),
+                         lambda r: r["results"][0].update(retrieval_status="partial")):
+            labels, replay = self.evidence("holdout")
+            mutation(replay)
+            with self.assertRaises(ValueError):
+                measure(self.corpus, "holdout", labels, replay)
+
+    def test_no_answer_and_unavailable_are_not_silently_successful(self):
+        labels, replay = self.evidence("holdout")
+        row = next(r for r in replay["results"] if "no_answer" in r["query_id"])
+        row["candidate"] = [{"id":"unrelated","project_id":"foreign"}]
+        replay["results"][0]["retrieval_status"] = "unavailable"
+        result = measure(self.corpus, "holdout", labels, replay)
+        self.assertEqual(result["false_grounding_rate"], 0.1)
+        self.assertEqual(result["scope_violations"], 1)
+        self.assertEqual(result["unavailable_queries"], 1)
+
+    def test_fewer_hits_cannot_inflate_precision(self):
+        labels, replay = self.evidence("holdout")
+        for row in replay["results"]:
+            row["candidate"] = row["candidate"][:1]
+        result = measure(self.corpus, "holdout", labels, replay)
+        self.assertEqual(result["known_item_top1"], 1)
+        self.assertEqual(result["precision_at_5"], 0.2)
+
+    def test_sealed_candidate_identity_and_dirty_source_gates(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "unit-test-corpus.json"
+            path.write_text(json.dumps(self.corpus))
+            labels, replay = self.evidence("development")
+            labels["corpus_sha256"] = replay["corpus_sha256"] = digest(path)
+            development = evaluate(path, "development", labels, replay)
+            self.assertTrue(development["development_approved"])
+            labels, replay = self.evidence("holdout")
+            labels["corpus_sha256"] = replay["corpus_sha256"] = digest(path)
+            result = evaluate(path, "holdout", labels, replay, development)
+            self.assertTrue(result["retrieval_qualified"])
+            self.assertFalse(result["release_qualified"])
+            for key, value in [("corpus_sha256","foreign"), ("replay_binary_sha256","b"*64),
+                               ("source_commit","foreign"), ("collected_at_unix",1)]:
+                invalid = copy.deepcopy(replay)
+                invalid[key] = value
+                with self.assertRaises(ValueError):
+                    evaluate(path, "holdout", labels, invalid, development)
+            replay["source_dirty"] = True
+            self.assertFalse(evaluate(path, "holdout", labels, replay, development)["retrieval_qualified"])
+            with self.assertRaises(ValueError):
+                evaluate(path, "holdout", labels, replay)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Completes the verified MCP portion of the premium reliability plan. Adds typed relevance/provenance, evidence-before-deduplication, caller-isolated cache identity and notices, shadow-only rollout defaults, and a source-bound Rust replay evaluator. No serving rollout is enabled. Missing independent holdout and end-to-end/canary evidence remain explicit gates.

Validation: 1,429 mcp-tools tests passed, 7 evaluation harness tests passed, formatting and public source boundary passed. Further CI is running.

Direct push was correctly rejected by the repository protection. This PR requires the configured independent code-owner approval; no bypass is requested.