### PR TITLE
fix(session): preserve plan step updates and prepare v1.0.4

### DIFF
--- a/.github/scripts/test_public_boundary.py
+++ b/.github/scripts/test_public_boundary.py
@@ -18,7 +18,7 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
 class PublicBoundaryTest(unittest.TestCase):
     def test_repository_satisfies_public_boundary(self) -> None:
-        self.assertEqual(boundary.verify(REPOSITORY_ROOT), "1.0.3")
+        self.assertEqual(boundary.verify(REPOSITORY_ROOT), "1.0.4")
 
     def test_forbidden_private_source_is_detected(self) -> None:
         with tempfile.TemporaryDirectory(prefix="public-boundary-") as temporary:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mcp-acceleration-products"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-client"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-model-registry"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "mcp-types",
  "serde",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-server"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-session"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "chrono",
  "dashmap",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-tools"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-types"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +292,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -363,6 +389,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -581,15 +616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +708,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -810,6 +842,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -1416,6 +1454,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,17 +1477,17 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64",
+ "getrandom 0.2.17",
  "js-sys",
- "pem",
- "ring",
  "serde",
  "serde_json",
- "simple_asn1",
+ "signature",
 ]
 
 [[package]]
@@ -1862,31 +1910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-conv"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,16 +1983,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2037,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,12 +2084,6 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2426,7 +2439,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2494,7 +2507,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2674,22 +2687,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.18",
- "time",
-]
 
 [[package]]
 name = "siphasher"
@@ -2896,37 +2906,6 @@ checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
-]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]
@@ -3223,6 +3202,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,8 @@ tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors", "trace", "compression-gzip"] }
 hyper = { version = "1.8", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
-jsonwebtoken = "9.3"
+# Only HS256 is accepted by the hosted transport; PEM decoding is unused.
+jsonwebtoken = { version = "10.3", default-features = false, features = ["aws_lc_rs"] }
 
 # Static hash maps
 phf = { version = "0.11", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"
@@ -89,12 +89,12 @@ fs2 = "0.4"
 notify = "6"
 
 # Workspace crates
-mcp-types = { version = "=1.0.3", path = "crates/mcp-types" }
-mcp-client = { version = "=1.0.3", path = "crates/mcp-client" }
-mcp-session = { version = "=1.0.3", path = "crates/mcp-session" }
-mcp-tools = { version = "=1.0.3", path = "crates/mcp-tools" }
-mcp-model-registry = { version = "=1.0.3", path = "crates/mcp-model-registry" }
-mcp-acceleration-products = { version = "=1.0.3", path = "crates/mcp-acceleration-products" }
+mcp-types = { version = "=1.0.4", path = "crates/mcp-types" }
+mcp-client = { version = "=1.0.4", path = "crates/mcp-client" }
+mcp-session = { version = "=1.0.4", path = "crates/mcp-session" }
+mcp-tools = { version = "=1.0.4", path = "crates/mcp-tools" }
+mcp-model-registry = { version = "=1.0.4", path = "crates/mcp-model-registry" }
+mcp-acceleration-products = { version = "=1.0.4", path = "crates/mcp-acceleration-products" }
 
 # Testing
 mockall = "0.13"

--- a/crates/mcp-server/src/transport/http.rs
+++ b/crates/mcp-server/src/transport/http.rs
@@ -107,7 +107,7 @@ pub struct JsonRpcError {
 }
 
 /// JWT Claims.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
 struct Claims {
     sub: String,
@@ -3672,6 +3672,107 @@ mod tests {
                 tools_list_cache: Arc::new(RwLock::new(HashMap::new())),
                 concurrency_semaphore: Arc::new(tokio::sync::Semaphore::new(8)),
                 metrics_handle: None,
+            }
+        }
+
+        const JWT_TEST_SECRET: &[u8] = b"transport-auth-regression-secret-32-bytes";
+
+        fn signed_test_jwt(claims: &Value, algorithm: Algorithm, secret: &[u8]) -> String {
+            jsonwebtoken::encode(
+                &jsonwebtoken::Header::new(algorithm),
+                claims,
+                &jsonwebtoken::EncodingKey::from_secret(secret),
+            )
+            .unwrap()
+        }
+
+        async fn jwt_auth_response(token: &str) -> Response {
+            // Exercise the real middleware without sending any upstream request.
+            let state =
+                create_auth_state(true, Some(std::str::from_utf8(JWT_TEST_SECRET).unwrap()));
+            let app = Router::new()
+                .route("/auth-probe", get(|| async { StatusCode::NO_CONTENT }))
+                .layer(axum::middleware::from_fn_with_state(state, auth_middleware));
+            app.oneshot(
+                Request::builder()
+                    .uri("/auth-probe")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        }
+
+        #[tokio::test]
+        async fn signed_jwt_transport_preserves_required_claims_and_expiration() {
+            let future = chrono::Utc::now().timestamp() + 3600;
+            let valid = json!({"sub": "caller", "exp": future});
+            let token = signed_test_jwt(&valid, Algorithm::HS256, JWT_TEST_SECRET);
+            assert_eq!(
+                jwt_auth_response(&token).await.status(),
+                StatusCode::NO_CONTENT
+            );
+
+            let mut invalid = vec![
+                json!({"sub": "caller"}),
+                json!({"exp": future}),
+                json!({"sub": 123, "exp": future}),
+                json!({"sub": "caller", "exp": 1}),
+            ];
+            for exp in [
+                json!("never"),
+                json!(true),
+                json!([]),
+                json!({}),
+                Value::Null,
+            ] {
+                invalid.push(json!({"sub": "caller", "exp": exp}));
+            }
+            for claims in invalid {
+                let token = signed_test_jwt(&claims, Algorithm::HS256, JWT_TEST_SECRET);
+                let response = jwt_auth_response(&token).await;
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{claims}");
+                assert!(response.headers().contains_key(header::WWW_AUTHENTICATE));
+            }
+        }
+
+        #[tokio::test]
+        async fn signed_jwt_transport_rejects_wrong_algorithm_and_signature() {
+            let claims = json!({"sub": "caller", "exp": chrono::Utc::now().timestamp() + 3600});
+            for token in [
+                signed_test_jwt(&claims, Algorithm::HS512, JWT_TEST_SECRET),
+                signed_test_jwt(&claims, Algorithm::HS256, b"different-signing-secret"),
+            ] {
+                assert_eq!(
+                    jwt_auth_response(&token).await.status(),
+                    StatusCode::UNAUTHORIZED
+                );
+            }
+        }
+
+        #[test]
+        fn enabled_optional_jwt_claim_validation_rejects_malformed_types() {
+            // GHSA-h395-gr6q-cpjc: enabled validation must not treat a malformed
+            // optional claim as absent. The transport currently requires exp
+            // and does not enable nbf; pin the patched library contract too.
+            let key = DecodingKey::from_secret(JWT_TEST_SECRET);
+            for claim in ["exp", "nbf"] {
+                let mut validation = Validation::new(Algorithm::HS256);
+                validation.required_spec_claims.clear();
+                validation.validate_nbf = true;
+                let absent =
+                    signed_test_jwt(&json!({"sub": "caller"}), Algorithm::HS256, JWT_TEST_SECRET);
+                assert!(decode::<Value>(&absent, &key, &validation).is_ok());
+                for malformed in [json!("invalid"), json!(true), json!([]), json!({})] {
+                    let mut claims = json!({"sub": "caller"});
+                    claims[claim] = malformed;
+                    let token = signed_test_jwt(&claims, Algorithm::HS256, JWT_TEST_SECRET);
+                    assert!(
+                        decode::<Value>(&token, &key, &validation).is_err(),
+                        "{claims}"
+                    );
+                }
             }
         }
 

--- a/crates/mcp-tools/src/domains/session.rs
+++ b/crates/mcp-tools/src/domains/session.rs
@@ -14753,6 +14753,7 @@ pub struct UpdatePlanInput {
     pub description: Option<String>,
     pub status: Option<String>,
     pub goals: Option<Vec<String>>,
+    pub steps: Option<Vec<mcp_client::PlanStep>>,
     #[serde(default, deserialize_with = "deserialize_string_or_vec")]
     pub linked_items: Option<Vec<serde_json::Value>>,
 }
@@ -14897,7 +14898,7 @@ impl ToolHandler for UpdatePlanTool {
             description: input.description,
             status: input.status,
             goals: input.goals,
-            steps: None,
+            steps: input.steps,
             linked_items: normalized_linked_items.clone(),
         };
 
@@ -14924,8 +14925,9 @@ impl ToolHandler for UpdatePlanTool {
         METADATA.get_or_init(|| ToolMetadata {
             name: "update_plan".to_string(),
             title: "Update Plan".to_string(),
-            description: "Update a plan's title, description, status, goals, or linked items."
-                .to_string(),
+            description:
+                "Update a plan's title, description, status, goals, steps, or linked items."
+                    .to_string(),
             category: ToolCategory::Session,
             annotations: ToolAnnotations::write(),
             is_pro: false,
@@ -14963,6 +14965,25 @@ impl ToolHandler for UpdatePlanTool {
                 false,
             )
             .array("goals", "Updated goals", "string", false)
+            .property(
+                "steps",
+                serde_json::json!({
+                    "type": "array",
+                    "description": "Replace the complete ordered step list. Omit to preserve existing steps; an explicit empty array clears steps. Preserve stable ids referenced by existing tasks. This does not create or relink tasks.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": { "type": "string" },
+                            "title": { "type": "string" },
+                            "order": { "type": "integer" },
+                            "description": { "type": "string" },
+                            "estimated_effort": { "type": "string" }
+                        },
+                        "required": ["id", "title", "order"]
+                    }
+                }),
+                false,
+            )
             .property(
                 "linked_items",
                 serde_json::json!({
@@ -16515,6 +16536,7 @@ impl ToolHandler for SessionTool {
                     description: input.description,
                     status: input.status,
                     goals: input.goals,
+                    steps: input.steps,
                     linked_items: input.linked_items,
                 };
                 let tool = UpdatePlanTool::new(self.client.clone(), self.session.clone());
@@ -16823,7 +16845,7 @@ impl ToolHandler for SessionTool {
                 "steps",
                 serde_json::json!({
                     "type": "array",
-                    "description": "Structured plan steps (for capture_plan). Each step should include scope, concrete work, files/modules if known, acceptance criteria, and verification.",
+                    "description": "Structured plan steps (for capture_plan, update_plan). Each step should include scope, concrete work, files/modules if known, acceptance criteria, and verification. update_plan replaces the complete list: omit to preserve, [] to clear. Preserve stable ids used by existing tasks; updating steps does not create or relink tasks.",
                     "items": {
                         "type": "object",
                         "properties": {

--- a/crates/mcp-tools/src/domains/session_tests.rs
+++ b/crates/mcp-tools/src/domains/session_tests.rs
@@ -19,6 +19,78 @@ fn create_mock_session() -> Arc<SessionManager> {
     Arc::new(SessionManager::new(client, TestFixtures::test_config()))
 }
 
+#[tokio::test]
+async fn update_plan_preserves_step_replacement_on_both_entry_points() {
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    for consolidated in [false, true] {
+        for steps in [
+            None,
+            Some(json!([])),
+            Some(json!([
+                {"id":"verify", "title":"Verify saved bytes", "order":2,
+                 "description":"Run the exact check after the final edit", "estimated_effort":"short"},
+                {"id":"edit", "title":"Implement requested change", "order":1}
+            ])),
+        ] {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            let plan_id = Uuid::new_v4();
+            let server = tokio::spawn(async move {
+                tokio::time::timeout(Duration::from_secs(10), async {
+                    let (mut socket, _) = listener.accept().await.unwrap();
+                    let mut request = Vec::new();
+                    let body = loop {
+                        let mut chunk = [0u8; 4096];
+                        let count = socket.read(&mut chunk).await.unwrap();
+                        assert!(count > 0, "request ended before body");
+                        request.extend_from_slice(&chunk[..count]);
+                        assert!(request.len() < 32768, "unexpected request size");
+                        if let Some(end) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                            let headers = String::from_utf8_lossy(&request[..end]);
+                            assert!(headers.starts_with(&format!("PATCH /api/v1/plans/{plan_id} ")));
+                            let length: usize = headers.lines().filter_map(|line| line.split_once(':'))
+                                .find(|(key, _)| key.eq_ignore_ascii_case("content-length"))
+                                .unwrap().1.trim().parse().unwrap();
+                            if request.len() >= end + 4 + length {
+                                break serde_json::from_slice::<Value>(&request[end+4..end+4+length]).unwrap();
+                            }
+                        }
+                    };
+                    let payload = json!({"id":plan_id, "title":"Plan", "steps":body.get("steps")}).to_string();
+                    socket.write_all(format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", payload.len(), payload).as_bytes()).await.unwrap();
+                    body
+                }).await.expect("bounded plan request")
+            });
+            let mut config = TestFixtures::test_config();
+            config.api_url = format!("http://{address}");
+            let client = ContextStreamClient::new(config.clone());
+            let session = Arc::new(SessionManager::new(client.clone(), config));
+            let mut input = json!({"action":"update_plan", "plan_id":plan_id,
+                "workspace_id":Uuid::new_v4(), "project_id":Uuid::new_v4(), "status":"active"});
+            if let Some(value) = &steps {
+                input["steps"] = value.clone();
+            }
+            let result = if consolidated {
+                SessionTool::new(client, session, mcp_types::atlas_layer::noop_layer())
+                    .execute(input)
+                    .await
+            } else {
+                UpdatePlanTool::new(client, session).execute(input).await
+            };
+            result.expect("update plan");
+            let body = server.await.unwrap();
+            assert_eq!(
+                body.get("steps"),
+                steps.as_ref(),
+                "consolidated={consolidated}"
+            );
+            assert_eq!(body["status"], "active");
+        }
+    }
+}
+
 mod repository_project_resolution_tests {
     use super::*;
 
@@ -3321,6 +3393,15 @@ mod schema_tests {
         assert!(props.contains_key("plan_id"));
         assert!(props.contains_key("title"));
         assert!(props.contains_key("status"));
+        assert_eq!(props["steps"]["type"], "array");
+        assert_eq!(
+            props["steps"]["items"]["required"],
+            serde_json::json!(["id", "title", "order"])
+        );
+        assert!(props["steps"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("Omit to preserve"));
 
         // Check status enum values
         if let Some(status) = props.get("status") {
@@ -5066,7 +5147,8 @@ mod input_struct_tests {
             "plan_id": "550e8400-e29b-41d4-a716-446655440000",
             "title": "Updated Title",
             "status": "active",
-            "goals": ["Goal 1", "Goal 2"]
+            "goals": ["Goal 1", "Goal 2"],
+            "steps": [{"id":"verify", "title":"Run checks", "order":1}]
         }))
         .unwrap();
 
@@ -5076,6 +5158,21 @@ mod input_struct_tests {
         );
         assert_eq!(input.title, Some("Updated Title".to_string()));
         assert_eq!(input.status, Some("active".to_string()));
+        assert_eq!(input.steps.unwrap()[0].id, "verify");
+    }
+
+    #[test]
+    fn test_update_plan_rejects_malformed_steps_instead_of_dropping_them() {
+        for steps in [
+            json!("not a step list"),
+            json!([{"title":"Missing id and order"}]),
+            json!([{"id":"x", "title":"Step", "order":"first"}]),
+        ] {
+            assert!(serde_json::from_value::<UpdatePlanInput>(
+                json!({"plan_id":"550e8400-e29b-41d4-a716-446655440000", "steps":steps})
+            )
+            .is_err());
+        }
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextstream/mcp-server",
   "mcpName": "io.github.contextstream/mcp-server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Verified npm launcher for the open-source ContextStream Rust MCP server",
   "type": "module",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.contextstream/mcp-server",
   "title": "ContextStream MCP Server",
   "description": "Project memory, semantic code search, and grounded agent context.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "repository": {
     "url": "https://github.com/contextstream/mcp-server",
     "source": "github"
@@ -20,7 +20,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@contextstream/mcp-server",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- Forward structured steps through dedicated update_plan and consolidated session update_plan instead of silently dropping them.
- Preserve omitted steps versus an explicit empty replacement, and retain every typed step field; reject malformed input.
- Explain replacement and task-link semantics in both tool schemas.
- Prepare consistent Cargo, npm, and MCP Registry metadata for version 1.0.4. No provider routing or grounding rollout change.

## Test plan

- Regression test observed the missing steps before the fix, then verified both entry points over real local HTTP for omitted, empty, and populated step lists.
- cargo fmt --all --check
- cargo test --locked --workspace --all-targets: 2775 passed, 19 existing ignored integration tests.
- cargo clippy --locked --workspace --all-targets -- -D warnings
- Public boundary, release contract, DCO policy, and npm launcher tests; npm pack --dry-run.

## Release gate

Protected review and CI are required before main or an immutable v1.0.4 tag. Package publication and the separate hosted gateway deployment remain pending. Production stays on v1.0.3; no hosted rollout during the active ContextCode qualification freeze.