### PR TITLE
test(recall): reject partial evidence and unsafe development seals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         run: python3 .github/scripts/test_public_boundary.py
       - name: Test DCO policy
         run: python3 .github/scripts/test_dco_check.py
+      - name: Test grounding qualification evidence gates
+        run: python3 -m unittest discover -s testing/grounding -p test_qualify.py
       - name: Test npm launcher
         run: npm test
       - name: Inspect npm package payload

--- a/testing/grounding/qualify.py
+++ b/testing/grounding/qualify.py
@@ -116,9 +116,31 @@ def measure(corpus, split, labels, replay):
             "independent_labels": bool(independent)}
 
 
+def qualified_metrics(metrics):
+    if not isinstance(metrics, dict) or metrics.get("independent_labels") is not True:
+        return False
+    # Recheck reports as well as fresh measurements. A legacy safety-only seal
+    # must not grant access to holdout, nor may malformed scores count as truth.
+    for key, minimum, maximum in (("known_item_top1", 0.95, 1),
+                                  ("precision_at_5", 0.8, 1),
+                                  ("false_grounding_rate", 0, 0.05)):
+        value = metrics.get(key)
+        if type(value) not in (int, float) or not minimum <= value <= maximum:
+            return False
+    for key in ("unavailable_queries", "scope_violations"):
+        if type(metrics.get(key)) is not int or metrics[key] != 0:
+            return False
+    for key in ("query_count", "known_item_queries", "no_answer_queries"):
+        if type(metrics.get(key)) is not int:
+            return False
+    return (metrics["query_count"] == 60 and 10 <= metrics["no_answer_queries"] < 60
+            and 0 < metrics["known_item_queries"] <= 60 - metrics["no_answer_queries"])
+
+
 def approved_development(report):
     return (report.get("schema_version") == 1 and report.get("split") == "development"
             and report.get("policy_revision") == POLICY and report.get("development_approved") is True
+            and qualified_metrics(report.get("metrics"))
             and report.get("source_dirty") is False and type(report.get("sealed_at_unix")) is int
             and 0 < report["sealed_at_unix"] <= int(time.time()))
 
@@ -135,17 +157,16 @@ def evaluate(corpus_path, split, labels, replay, development=None):
               "development_approved": False, "retrieval_qualified": False, "release_qualified": False}
     clean = replay.get("source_dirty") is False and isinstance(replay.get("source_commit"), str) and bool(replay["source_commit"])
     clean = clean and isinstance(replay.get("replay_binary_sha256"), str) and len(replay["replay_binary_sha256"]) == 64
-    safe = metrics["unavailable_queries"] == 0 and metrics["scope_violations"] == 0 and metrics["false_grounding_rate"] <= 0.05
+    qualified = bool(clean and qualified_metrics(metrics))
     if split == "development":
         # This revision has a fixed 0.4 policy. If it fails, change/calibrate on
         # development and collect a new source-bound report before holdout.
-        result["development_approved"] = bool(clean and safe)
+        result["development_approved"] = qualified
     else:
         require(isinstance(development, dict) and approved_development(development), "seal development before reading holdout labels")
         require(all(development.get(k) == result.get(k) for k in ("corpus_sha256", "replay_binary_sha256", "source_commit", "policy_revision")), "holdout candidate differs from sealed development")
         require(type(replay.get("collected_at_unix")) is int and development["sealed_at_unix"] <= replay["collected_at_unix"] <= int(time.time()), "holdout collection time is outside the sealed evaluation window")
-        result["retrieval_qualified"] = bool(clean and safe and metrics["independent_labels"]
-                                              and metrics["known_item_top1"] >= 0.95 and metrics["precision_at_5"] >= 0.8)
+        result["retrieval_qualified"] = qualified
     return result
 
 

--- a/testing/grounding/qualify.py
+++ b/testing/grounding/qualify.py
@@ -170,6 +170,16 @@ def validate_recall_query(row, query):
     # for another query. Bind the actual selector input to the frozen corpus.
     require(isinstance(recall, dict) and recall.get("query") == query["text"],
             "recall payload query differs from frozen corpus")
+    # A partial upstream response can contain selectable hits (or an empty
+    # array). Neither proves complete retrieval or an honest no-answer. Require
+    # explicit healthy API evidence before running the selector; missing status
+    # from an older/hand-built envelope must not silently qualify either.
+    require(recall.get("degraded") is False and recall.get("errors") == []
+            and recall.get("degraded_reason") in (None, ""),
+            "recall retrieval is partial, unavailable or unverified")
+    results = recall.get("results")
+    require(isinstance(results, list) and all(isinstance(item, dict) for item in results),
+            "recall results are missing or malformed")
 
 
 def collect(corpus_path, split, recalls_path, binary, build_receipt, development=None):

--- a/testing/grounding/test_qualify.py
+++ b/testing/grounding/test_qualify.py
@@ -38,7 +38,7 @@ class QualificationTests(unittest.TestCase):
     def test_query_sidecar_cannot_relabel_a_different_recall_payload(self):
         query = {"text": "frozen query"}
         row = {"query_sha256": hashlib.sha256(b"frozen query").hexdigest(),
-               "recall": {"query": "frozen query", "results": []}}
+               "recall": {"query": "frozen query", "results": [], "degraded": False, "errors": []}}
         validate_recall_query(row, query)
         for recall in ({"query": "different query"}, {"query": " frozen query"}, {}, None):
             invalid = dict(row, recall=recall)
@@ -46,6 +46,34 @@ class QualificationTests(unittest.TestCase):
                 validate_recall_query(invalid, query)
         with self.assertRaises(ValueError):
             validate_recall_query(dict(row, query_sha256="0" * 64), query)
+
+    def test_partial_recall_cannot_be_replayed_as_clean_evidence(self):
+        query = {"text": "frozen query"}
+        # Even usable hits do not make missing upstream coverage a clean run.
+        for results in ([], [{"id": "available-source"}]):
+            clean = {"query": query["text"], "results": results,
+                     "degraded": False, "errors": [], "degraded_reason": None}
+            row = {"query_sha256": hashlib.sha256(query["text"].encode()).hexdigest(),
+                   "recall": clean}
+            validate_recall_query(row, query)
+            mutations = [
+                {"degraded": True}, {"degraded": None}, {"degraded": 0},
+                {"degraded": "false"}, {"degraded": []},
+                {"errors": ["partial_retrieval_unavailable"]}, {"errors": None},
+                {"errors": ""}, {"errors": {}},
+                {"degraded_reason": "partial_retrieval_unavailable"},
+                {"results": None}, {"results": {}}, {"results": [None]},
+            ]
+            for mutation in mutations:
+                with self.subTest(results=results, mutation=mutation):
+                    with self.assertRaises(ValueError):
+                        validate_recall_query(dict(row, recall=dict(clean, **mutation)), query)
+            for missing in ("degraded", "errors", "results"):
+                incomplete = dict(clean)
+                del incomplete[missing]
+                with self.subTest(missing=missing):
+                    with self.assertRaises(ValueError):
+                        validate_recall_query(dict(row, recall=incomplete), query)
 
     def test_author_is_not_an_independent_labeler(self):
         labels, replay = self.evidence("holdout")

--- a/testing/grounding/test_qualify.py
+++ b/testing/grounding/test_qualify.py
@@ -7,7 +7,7 @@ import tempfile
 import time
 import unittest
 
-from qualify import CATEGORIES, POLICY, corpus_queries, digest, evaluate, measure, validate_recall_query
+from qualify import CATEGORIES, POLICY, approved_development, corpus_queries, digest, evaluate, measure, validate_recall_query
 
 
 class QualificationTests(unittest.TestCase):
@@ -140,6 +140,66 @@ class QualificationTests(unittest.TestCase):
             self.assertFalse(evaluate(path, "holdout", labels, replay, development)["retrieval_qualified"])
             with self.assertRaises(ValueError):
                 evaluate(path, "holdout", labels, replay)
+
+    def test_development_requires_independent_quality_before_sealing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "unit-test-corpus.json"
+            path.write_text(json.dumps(self.corpus))
+            for failure in ("author_labels", "low_top1", "low_precision"):
+                labels, replay = self.evidence("development")
+                labels["corpus_sha256"] = replay["corpus_sha256"] = digest(path)
+                if failure == "author_labels":
+                    labels["labels"][0]["reviewer_id"] = "unit-test-author"
+                else:
+                    for row in replay["results"]:
+                        if failure == "low_top1":
+                            row["candidate"].reverse()
+                        else:
+                            row["candidate"] = row["candidate"][:1]
+                with self.subTest(failure=failure):
+                    result = evaluate(path, "development", labels, replay)
+                    self.assertFalse(result["development_approved"])
+                    self.assertFalse(approved_development(result))
+
+    def test_holdout_rechecks_quality_in_existing_development_seals(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "unit-test-corpus.json"
+            path.write_text(json.dumps(self.corpus))
+            labels, replay = self.evidence("development")
+            labels["corpus_sha256"] = replay["corpus_sha256"] = digest(path)
+            development = evaluate(path, "development", labels, replay)
+            labels, replay = self.evidence("holdout")
+            labels["corpus_sha256"] = replay["corpus_sha256"] = digest(path)
+            invalid_metrics = [None, [], {}, "approved"]
+            mutations = [
+                ("independent_labels", False), ("independent_labels", 1),
+                ("known_item_top1", 0.949), ("precision_at_5", 0.799),
+                ("false_grounding_rate", 0.051), ("unavailable_queries", 1),
+                ("scope_violations", 1), ("known_item_top1", True),
+                ("precision_at_5", "1.0"), ("precision_at_5", float("nan")),
+                ("precision_at_5", float("inf")), ("unavailable_queries", False),
+                ("query_count", 59), ("known_item_queries", 0),
+                ("known_item_queries", 51), ("no_answer_queries", 9),
+                ("no_answer_queries", 60), ("query_count", "60"),
+            ]
+            for key, value in mutations:
+                invalid_metrics.append(dict(development["metrics"], **{key: value}))
+            for missing in development["metrics"]:
+                metrics = dict(development["metrics"])
+                del metrics[missing]
+                invalid_metrics.append(metrics)
+            for metrics in invalid_metrics:
+                with self.subTest(metrics=metrics):
+                    stale_seal = dict(development, metrics=metrics)
+                    self.assertFalse(approved_development(stale_seal))
+                    with self.assertRaises(ValueError):
+                        evaluate(path, "holdout", labels, replay, stale_seal)
+            missing_metrics = dict(development)
+            del missing_metrics["metrics"]
+            self.assertFalse(approved_development(missing_metrics))
+            boundary = dict(development, metrics=dict(development["metrics"],
+                known_item_top1=0.95, precision_at_5=0.8, false_grounding_rate=0.05))
+            self.assertTrue(approved_development(boundary))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fail closed before grounding qualification when retrieval evidence is partial or development has not met the existing independent quality gates.

## Changes

- Reject degraded, missing, malformed, or contradictory raw recall availability metadata.
- Require a valid results array; retain explicitly healthy empty responses as legitimate no-evidence inputs.
- Require independent development labels, known-item top1 >= 0.95, fixed precision@5 >= 0.80, and existing availability/scope/false-grounding limits before creating a development seal.
- Recheck those metrics in existing development seals before opening holdout; reject missing/malformed scores and legacy safety-only approvals.
- Run qualification evidence tests in the public-contract CI job (previously not covered by CI).
- No ranking, metric threshold, runtime, deployment, or rollout changes.

## Validation

- Partial-evidence regression failed in 32 subcases before the fix.
- Development-seal regressions failed in 26 cases before the follow-up fix.
- All 11 Python qualification tests pass, including boundary/malformed/missing-metric cases.
- Prior focused public-boundary (6) and release-contract (12) tests pass; final-head CI rerunning.
- The unchanged real private partial diagnostic is rejected. No user data or real corpus is included in this PR.
- git diff --check passes; clean source-bound replay build receipt exists for final head.

This is qualification-harness hardening only. Independent development review is complete, but the genuine reviewed-pool precision@5 oracle ceiling is 0.492 against the unchanged 0.80 gate. No selector measurement or quality approval is claimed, no holdout is opened, and recall remains shadow.