### PR TITLE
fix(grounding): version sparse-relevance qualification metrics

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,5 @@
+# Reviewed false positive: the public metric name precision_at_5 in a Rust
+# comparison was classified as a generic API key. No credential is present.
+# The current test uses `metric`; retain only this exact historical fingerprint
+# because CI scans all commits. No rule, path, or future finding is excluded.
+c6958417fa68ab9407cc53fbd0595dd8f8447ba7:crates/mcp-tools/src/domains/grounding_rollout.rs:generic-api-key:303

--- a/crates/mcp-tools/src/domains/grounding_rollout.rs
+++ b/crates/mcp-tools/src/domains/grounding_rollout.rs
@@ -276,12 +276,12 @@ mod tests {
             config().mode(Some("internal"), Some("ws"), None, 1),
             "internal"
         );
-        for key in ["ndcg_at_5", "returned_precision_at_5", "precision_at_5"] {
+        for metric in ["ndcg_at_5", "returned_precision_at_5", "precision_at_5"] {
             let mut missing = config_value();
             missing["qualification"]
                 .as_object_mut()
                 .unwrap()
-                .remove(key);
+                .remove(metric);
             assert!(serde_json::from_value::<Rollout>(missing).is_err());
             for invalid in [
                 serde_json::json!(true),
@@ -289,7 +289,7 @@ mod tests {
                 serde_json::Value::Null,
             ] {
                 let mut value = config_value();
-                value["qualification"][key] = invalid;
+                value["qualification"][metric] = invalid;
                 assert!(serde_json::from_value::<Rollout>(value).is_err());
             }
             for invalid in [
@@ -300,11 +300,11 @@ mod tests {
                 1.001,
                 0.799,
             ] {
-                if key == "precision_at_5" && invalid == 0.799 {
+                if metric == "precision_at_5" && invalid == 0.799 {
                     continue; // Fixed-denominator precision is diagnostic only.
                 }
                 let mut r = config();
-                match key {
+                match metric {
                     "ndcg_at_5" => r.qualification.ndcg_at_5 = invalid,
                     "returned_precision_at_5" => r.qualification.returned_precision_at_5 = invalid,
                     _ => r.qualification.precision_at_5 = invalid,
@@ -312,7 +312,7 @@ mod tests {
                 assert_eq!(
                     r.mode(Some("internal"), Some("ws"), None, 1),
                     "shadow",
-                    "{key}={invalid}"
+                    "{metric}={invalid}"
                 );
             }
         }

--- a/crates/mcp-tools/src/domains/grounding_rollout.rs
+++ b/crates/mcp-tools/src/domains/grounding_rollout.rs
@@ -3,11 +3,14 @@
 use serde::Deserialize;
 
 pub const POLICY_REVISION: &str = "grounding-evidence-v2";
+// Independent of selector policy: changing scoring must not reshuffle cohorts.
+pub const EVALUATION_REVISION: &str = "grounding-quality-v2";
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Qualification {
     pub policy_revision: String,
+    pub evaluation_revision: String,
     pub corpus_sha256: String,
     pub candidate_sha256: String,
     pub development_queries: u64,
@@ -18,6 +21,8 @@ pub struct Qualification {
     pub false_grounding_rate: f64,
     pub known_item_top1: f64,
     pub precision_at_5: f64,
+    pub ndcg_at_5: f64,
+    pub returned_precision_at_5: f64,
     pub baseline_p95_ms: f64,
     pub candidate_p95_ms: f64,
     pub privacy_violations: u64,
@@ -29,6 +34,7 @@ impl Qualification {
     pub fn passes(&self, candidate: &str, corpus: &str) -> bool {
         let fraction = |v: f64| v.is_finite() && (0.0..=1.0).contains(&v);
         self.policy_revision == POLICY_REVISION
+            && self.evaluation_revision == EVALUATION_REVISION
             && sha256(candidate)
             && sha256(corpus)
             && self.candidate_sha256 == candidate
@@ -42,7 +48,10 @@ impl Qualification {
             && fraction(self.known_item_top1)
             && self.known_item_top1 >= 0.95
             && fraction(self.precision_at_5)
-            && self.precision_at_5 >= 0.8
+            && fraction(self.ndcg_at_5)
+            && self.ndcg_at_5 >= 0.8
+            && fraction(self.returned_precision_at_5)
+            && self.returned_precision_at_5 >= 0.8
             && self.baseline_p95_ms.is_finite()
             && self.baseline_p95_ms > 0.0
             && self.candidate_p95_ms.is_finite()
@@ -62,6 +71,7 @@ fn sha256(value: &str) -> bool {
 #[serde(deny_unknown_fields)]
 pub struct CanaryEvidence {
     pub policy_revision: String,
+    pub evaluation_revision: String,
     pub candidate_sha256: String,
     pub corpus_sha256: String,
     pub started_at_unix: i64,
@@ -77,6 +87,7 @@ pub struct CanaryEvidence {
 impl CanaryEvidence {
     fn passes(&self, now: i64, candidate: &str, corpus: &str) -> bool {
         self.policy_revision == POLICY_REVISION
+            && self.evaluation_revision == EVALUATION_REVISION
             && self.candidate_sha256 == candidate
             && self.corpus_sha256 == corpus
             && self.started_at_unix > 0
@@ -226,16 +237,95 @@ mod tests {
         }
         assert!(!force_shadow(None));
     }
-    fn config() -> Rollout {
-        serde_json::from_value(serde_json::json!({
+    fn config_value() -> serde_json::Value {
+        serde_json::json!({
             "phase":"internal", "candidate_sha256":"a".repeat(64), "corpus_sha256":"b".repeat(64),
             "cohort_salt":"fixed-sampling-salt", "internal_subjects":["internal"],
-            "qualification": {"policy_revision":POLICY_REVISION, "candidate_sha256":"a".repeat(64), "corpus_sha256":"b".repeat(64),
+            "qualification": {"policy_revision":POLICY_REVISION, "evaluation_revision":EVALUATION_REVISION, "candidate_sha256":"a".repeat(64), "corpus_sha256":"b".repeat(64),
                 "development_queries":60,"holdout_queries":60,"independent_labels":true,"coding_qualified":true,"evaluated_at_unix":1,
-                "false_grounding_rate":0.05,"known_item_top1":0.95,"precision_at_5":0.8,
+                "false_grounding_rate":0.05,"known_item_top1":0.95,"precision_at_5":0.2,
+                "ndcg_at_5":0.8,"returned_precision_at_5":0.8,
                 "baseline_p95_ms":100.0,"candidate_p95_ms":110.0,
                 "privacy_violations":0,"authority_violations":0,"false_completion_violations":0}
-        })).unwrap()
+        })
+    }
+    fn config() -> Rollout {
+        serde_json::from_value(config_value()).unwrap()
+    }
+    #[test]
+    fn scoring_revision_is_required_and_old_approvals_stay_shadow() {
+        let mut value = config_value();
+        value["qualification"]
+            .as_object_mut()
+            .unwrap()
+            .remove("evaluation_revision");
+        assert!(serde_json::from_value::<Rollout>(value).is_err());
+        for revision in ["grounding-quality-v1", "unknown", ""] {
+            let mut r = config();
+            r.qualification.evaluation_revision = revision.into();
+            for phase in ["internal", "canary", "general"] {
+                r.phase = phase.into();
+                assert_eq!(r.mode(Some("internal"), Some("ws"), None, 1), "shadow");
+            }
+        }
+    }
+    #[test]
+    fn sparse_quality_metrics_are_required_finite_and_independently_gated() {
+        // The diagnostic P@5 may be .2; both normalized gates must still pass.
+        assert_eq!(
+            config().mode(Some("internal"), Some("ws"), None, 1),
+            "internal"
+        );
+        for key in ["ndcg_at_5", "returned_precision_at_5", "precision_at_5"] {
+            let mut missing = config_value();
+            missing["qualification"]
+                .as_object_mut()
+                .unwrap()
+                .remove(key);
+            assert!(serde_json::from_value::<Rollout>(missing).is_err());
+            for invalid in [
+                serde_json::json!(true),
+                serde_json::json!("1"),
+                serde_json::Value::Null,
+            ] {
+                let mut value = config_value();
+                value["qualification"][key] = invalid;
+                assert!(serde_json::from_value::<Rollout>(value).is_err());
+            }
+            for invalid in [
+                f64::NAN,
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+                -0.001,
+                1.001,
+                0.799,
+            ] {
+                if key == "precision_at_5" && invalid == 0.799 {
+                    continue; // Fixed-denominator precision is diagnostic only.
+                }
+                let mut r = config();
+                match key {
+                    "ndcg_at_5" => r.qualification.ndcg_at_5 = invalid,
+                    "returned_precision_at_5" => r.qualification.returned_precision_at_5 = invalid,
+                    _ => r.qualification.precision_at_5 = invalid,
+                }
+                assert_eq!(
+                    r.mode(Some("internal"), Some("ws"), None, 1),
+                    "shadow",
+                    "{key}={invalid}"
+                );
+            }
+        }
+    }
+    #[test]
+    fn legacy_canary_cannot_be_deserialized_into_current_evidence() {
+        let value = serde_json::json!({
+            "policy_revision": POLICY_REVISION, "candidate_sha256": "a".repeat(64),
+            "corpus_sha256": "b".repeat(64), "started_at_unix": 1, "observed_until_unix": 172801,
+            "eligible_operations": 1000, "privacy_violations": 0, "authority_violations": 0,
+            "false_completion_violations": 0, "baseline_p95_ms": 100, "candidate_p95_ms": 110
+        });
+        assert!(serde_json::from_value::<CanaryEvidence>(value).is_err());
     }
     #[test]
     fn internal_requires_explicit_subject_and_qualification() {
@@ -266,6 +356,8 @@ mod tests {
             .filter(|i| r.mode(Some(&i.to_string()), Some("ws"), Some("project"), 1) == "canary")
             .count();
         assert!((400..600).contains(&selected), "{selected}");
+        // Policy-v2 golden assignment remains unchanged by scoring revisions.
+        assert_eq!(cohort_bucket("salt", "one", "ws", None), 6089);
         assert_eq!(
             cohort_bucket("salt", "one", "ws", None),
             cohort_bucket("salt", "one", "ws", None)
@@ -282,6 +374,7 @@ mod tests {
         assert_eq!(r.mode(Some("u"), Some("ws"), None, 200_000), "shadow");
         r.canary = Some(CanaryEvidence {
             policy_revision: POLICY_REVISION.into(),
+            evaluation_revision: EVALUATION_REVISION.into(),
             candidate_sha256: "a".repeat(64),
             corpus_sha256: "b".repeat(64),
             started_at_unix: 1,
@@ -294,6 +387,9 @@ mod tests {
             candidate_p95_ms: 110.0,
         });
         assert_eq!(r.mode(Some("u"), Some("ws"), None, 200_000), "general");
+        r.canary.as_mut().unwrap().evaluation_revision = "grounding-quality-v1".into();
+        assert_eq!(r.mode(Some("u"), Some("ws"), None, 200_000), "shadow");
+        r.canary.as_mut().unwrap().evaluation_revision = EVALUATION_REVISION.into();
         r.canary.as_mut().unwrap().eligible_operations = 999;
         assert_eq!(r.mode(Some("u"), Some("ws"), None, 200_000), "shadow");
         r.canary.as_mut().unwrap().eligible_operations = 1000;

--- a/testing/grounding/qualify.py
+++ b/testing/grounding/qualify.py
@@ -8,12 +8,15 @@ Selector timing is explicitly NOT end-to-end context latency or canary evidence.
 import argparse
 import hashlib
 import json
+import math
 import os
 from pathlib import Path
 import subprocess
 import time
 
 POLICY = "grounding-evidence-v2"
+# Scoring evolves independently of selector policy and sticky cohort assignment.
+EVALUATION = "grounding-quality-v2"
 CATEGORIES = {"continuation", "paraphrase", "history", "supersession", "scope", "no_answer"}
 SPLITS = ("development", "holdout")
 
@@ -73,10 +76,12 @@ def measure(corpus, split, labels, replay):
     queries = corpus_queries(corpus, split)
     require(labels.get("split") == split and labels.get("schema_version") == 1, "labels have wrong split/schema")
     require(replay.get("split") == split and replay.get("policy_revision") == POLICY, "replay has wrong split/policy")
+    require(replay.get("evaluation_revision") == EVALUATION, "replay has wrong evaluation revision")
     label_map = indexed(labels.get("labels"), "query_id")
     runs = indexed(replay.get("results"), "query_id")
     require(set(queries) == set(label_map) == set(runs), "incomplete or foreign query coverage")
     known, top1, relevant_at_5, answerable, no_answer, false_ground, unavailable, scope_violations = (0,) * 8
+    ndcg, returned_precision = [], []
     independent = labels.get("provenance") == "independent_review"
     for query_id, query in queries.items():
         label, run = label_map[query_id], runs[query_id]
@@ -103,14 +108,21 @@ def measure(corpus, split, labels, replay):
             top1 += bool(ids and ids[0] == expected)
         if relevant:
             answerable += 1
-            relevant_at_5 += sum(item in relevant for item in ids)
+            relevant_count = sum(item in relevant for item in ids)
+            relevant_at_5 += relevant_count
+            dcg = math.fsum(1 / math.log2(rank + 2) for rank, item in enumerate(ids) if item in relevant)
+            ideal = math.fsum(1 / math.log2(rank + 2) for rank in range(min(5, len(relevant))))
+            ndcg.append(dcg / ideal)
+            returned_precision.append(relevant_count / len(ids) if ids else 0.0)
         else:
             no_answer += 1
             false_ground += bool(ids)
     require(known > 0 and answerable > 0 and no_answer >= 10, "known-item and no-answer coverage required")
     return {"query_count": len(queries), "known_item_queries": known, "known_item_top1": top1 / known,
-            # Fixed denominator: returning fewer hits cannot inflate precision@5.
+            # Fixed-denominator diagnostic, not a sparse-relevance quality gate.
             "precision_at_5": relevant_at_5 / (5 * answerable),
+            "ndcg_at_5": math.fsum(ndcg) / answerable,
+            "returned_precision_at_5": math.fsum(returned_precision) / answerable,
             "no_answer_queries": no_answer, "false_grounding_rate": false_ground / no_answer,
             "unavailable_queries": unavailable, "scope_violations": scope_violations,
             "independent_labels": bool(independent)}
@@ -122,7 +134,9 @@ def qualified_metrics(metrics):
     # Recheck reports as well as fresh measurements. A legacy safety-only seal
     # must not grant access to holdout, nor may malformed scores count as truth.
     for key, minimum, maximum in (("known_item_top1", 0.95, 1),
-                                  ("precision_at_5", 0.8, 1),
+                                  ("precision_at_5", 0, 1),
+                                  ("ndcg_at_5", 0.8, 1),
+                                  ("returned_precision_at_5", 0.8, 1),
                                   ("false_grounding_rate", 0, 0.05)):
         value = metrics.get(key)
         if type(value) not in (int, float) or not minimum <= value <= maximum:
@@ -139,6 +153,7 @@ def qualified_metrics(metrics):
 
 def approved_development(report):
     return (report.get("schema_version") == 1 and report.get("split") == "development"
+            and report.get("evaluation_revision") == EVALUATION
             and report.get("policy_revision") == POLICY and report.get("development_approved") is True
             and qualified_metrics(report.get("metrics"))
             and report.get("source_dirty") is False and type(report.get("sealed_at_unix")) is int
@@ -151,6 +166,7 @@ def evaluate(corpus_path, split, labels, replay, development=None):
     require(labels.get("corpus_sha256") == corpus_hash == replay.get("corpus_sha256"), "corpus/label/replay fingerprint mismatch")
     metrics = measure(corpus, split, labels, replay)
     result = {"schema_version": 1, "split": split, "policy_revision": POLICY, "minimum_lexical_coverage": 0.4,
+              "evaluation_revision": EVALUATION,
               "corpus_sha256": corpus_hash, "replay_binary_sha256": replay.get("replay_binary_sha256"),
               "source_commit": replay.get("source_commit"), "source_dirty": replay.get("source_dirty"),
               "sealed_at_unix": int(time.time()), "metrics": metrics,
@@ -164,7 +180,7 @@ def evaluate(corpus_path, split, labels, replay, development=None):
         result["development_approved"] = qualified
     else:
         require(isinstance(development, dict) and approved_development(development), "seal development before reading holdout labels")
-        require(all(development.get(k) == result.get(k) for k in ("corpus_sha256", "replay_binary_sha256", "source_commit", "policy_revision")), "holdout candidate differs from sealed development")
+        require(all(development.get(k) == result.get(k) for k in ("corpus_sha256", "replay_binary_sha256", "source_commit", "policy_revision", "evaluation_revision")), "holdout candidate differs from sealed development")
         require(type(replay.get("collected_at_unix")) is int and development["sealed_at_unix"] <= replay["collected_at_unix"] <= int(time.time()), "holdout collection time is outside the sealed evaluation window")
         result["retrieval_qualified"] = qualified
     return result
@@ -179,7 +195,7 @@ def build_selector():
     binary = Path(metadata["target_directory"]) / "debug" / "examples" / ("grounding_replay.exe" if os.name == "nt" else "grounding_replay")
     require(commit == subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
             and not subprocess.check_output(["git", "status", "--porcelain"], cwd=root).strip(), "source changed during build")
-    return {"schema_version":1,"policy_revision":POLICY,"source_commit":commit,"source_dirty":False,
+    return {"schema_version":1,"policy_revision":POLICY,"evaluation_revision":EVALUATION,"source_commit":commit,"source_dirty":False,
             "binary":str(binary),"replay_binary_sha256":digest(binary),"profile":"debug","built_at_unix":int(time.time())}
 
 
@@ -217,7 +233,8 @@ def collect(corpus_path, split, recalls_path, binary, build_receipt, development
     candidate = digest(binary)
     require(isinstance(build_receipt, dict) and build_receipt.get("source_dirty") is False
             and build_receipt.get("source_commit") == commit and build_receipt.get("replay_binary_sha256") == candidate
-            and build_receipt.get("policy_revision") == POLICY, "selector build receipt mismatch")
+            and build_receipt.get("policy_revision") == POLICY
+            and build_receipt.get("evaluation_revision") == EVALUATION, "selector build receipt mismatch")
     corpus_hash = digest(corpus_path)
     if split == "holdout":
         require(isinstance(development, dict) and approved_development(development), "development must be sealed first")
@@ -231,6 +248,7 @@ def collect(corpus_path, split, recalls_path, binary, build_receipt, development
     require(commit == subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip(), "source changed during collection")
     dirty = dirty or bool(subprocess.check_output(["git", "status", "--porcelain"], cwd=root).strip())
     return {"schema_version": 1, "split": split, "policy_revision": POLICY, "corpus_sha256": corpus_hash,
+            "evaluation_revision": EVALUATION,
             "replay_binary_sha256": candidate, "source_commit": commit, "source_dirty": dirty,
             "recalls_sha256": digest(recalls_path), "collected_at_unix": int(time.time()), "results": results,
             "timing_scope": "selector_only_not_end_to_end", "release_qualified": False}
@@ -266,7 +284,7 @@ def main():
         result = evaluate(args.corpus, args.split, read(args.labels), read(args.replay), development)
         passed = result["development_approved"] if args.split == "development" else result["retrieval_qualified"]
     args.output.write_text(json.dumps(result, indent=2) + "\n")
-    print(json.dumps({k: result[k] for k in ("split", "policy_revision", "release_qualified")}))
+    print(json.dumps({k: result[k] for k in ("split", "policy_revision", "evaluation_revision", "release_qualified")}))
     return 0 if passed else 1
 
 

--- a/testing/grounding/test_qualify.py
+++ b/testing/grounding/test_qualify.py
@@ -2,12 +2,17 @@
 import copy
 import hashlib
 import json
+import math
 from pathlib import Path
 import tempfile
 import time
 import unittest
+from unittest.mock import patch
 
-from qualify import CATEGORIES, POLICY, approved_development, corpus_queries, digest, evaluate, measure, validate_recall_query
+import qualify
+from qualify import CATEGORIES, POLICY, approved_development, collect, corpus_queries, digest, evaluate, measure, qualified_metrics, validate_recall_query
+
+EVALUATION = "grounding-quality-v2"
 
 
 class QualificationTests(unittest.TestCase):
@@ -24,7 +29,7 @@ class QualificationTests(unittest.TestCase):
             labels.append({"query_id":q["id"],"reviewer_id":"unit-test-reviewer","relevant":hits,"known_item":hits[0] if hits else None})
             runs.append({"query_id":q["id"],"policy_revision":POLICY,"candidate":copy.deepcopy(hits),"retrieval_status":"available" if hits else "no_evidence"})
         return ({"schema_version":1,"split":split,"provenance":"independent_review","labels":labels},
-                {"schema_version":1,"split":split,"policy_revision":POLICY,"results":runs,
+                {"schema_version":1,"split":split,"policy_revision":POLICY,"evaluation_revision":EVALUATION,"results":runs,
                  "source_commit":"unit-test-commit","source_dirty":False,"replay_binary_sha256":"a"*64,"collected_at_unix":int(time.time())})
 
     def test_full_scoped_evidence_scores_exactly(self):
@@ -32,6 +37,8 @@ class QualificationTests(unittest.TestCase):
         result = measure(self.corpus, "holdout", labels, replay)
         self.assertEqual(result["known_item_top1"], 1)
         self.assertEqual(result["precision_at_5"], 1)
+        self.assertEqual(result["ndcg_at_5"], 1)
+        self.assertEqual(result["returned_precision_at_5"], 1)
         self.assertEqual(result["false_grounding_rate"], 0)
         self.assertTrue(result["independent_labels"])
 
@@ -116,6 +123,137 @@ class QualificationTests(unittest.TestCase):
         result = measure(self.corpus, "holdout", labels, replay)
         self.assertEqual(result["known_item_top1"], 1)
         self.assertEqual(result["precision_at_5"], 0.2)
+        self.assertEqual(result["returned_precision_at_5"], 1)
+        self.assertAlmostEqual(result["ndcg_at_5"], 1 / sum(1 / math.log2(i + 2) for i in range(5)))
+        self.assertFalse(qualified_metrics(result))
+
+    def test_sparse_exact_answers_qualify_without_padding(self):
+        labels, replay = self.evidence("development")
+        for label, row in zip(labels["labels"], replay["results"]):
+            label["relevant"] = label["relevant"][:1]
+            row["candidate"] = row["candidate"][:1]
+        result = measure(self.corpus, "development", labels, replay)
+        self.assertEqual(result["precision_at_5"], .2)
+        self.assertEqual(result["ndcg_at_5"], 1)
+        self.assertEqual(result["returned_precision_at_5"], 1)
+        self.assertTrue(qualified_metrics(result))
+        # A correct first result does not excuse four irrelevant extras.
+        for row in replay["results"]:
+            if row["candidate"]:
+                row["candidate"] += [{"id": f"noise-{i}", "project_id": "test-project"} for i in range(4)]
+        padded = measure(self.corpus, "development", labels, replay)
+        self.assertEqual(padded["ndcg_at_5"], 1)
+        self.assertEqual(padded["returned_precision_at_5"], .2)
+        self.assertFalse(qualified_metrics(padded))
+
+    def test_discount_ideal_normalization_and_empty_answers(self):
+        for gold_count in (1, 2, 5, 7):
+            for returned_count in (0, 1, 5):
+                with self.subTest(gold_count=gold_count, returned_count=returned_count):
+                    labels, replay = self.evidence("development")
+                    for label, row in zip(labels["labels"], replay["results"]):
+                        if label["relevant"]:
+                            hits = [{"id": f"gold-{i}", "project_id": "test-project"} for i in range(gold_count)]
+                            label.update(relevant=hits, known_item=hits[0])
+                            # Relevant only at the last returned rank.
+                            row["candidate"] = ([{"id": f"noise-{i}", "project_id": "test-project"}
+                                                 for i in range(returned_count - 1)] + hits[:1]) if returned_count else []
+                    result = measure(self.corpus, "development", labels, replay)
+                    ideal = sum(1 / math.log2(i + 2) for i in range(min(5, gold_count)))
+                    self.assertAlmostEqual(result["ndcg_at_5"], (1 / math.log2(returned_count + 1) / ideal) if returned_count else 0)
+                    self.assertAlmostEqual(result["returned_precision_at_5"], 1 / returned_count if returned_count else 0)
+
+    def test_metrics_are_macro_averaged_over_answerable_queries(self):
+        labels, replay = self.evidence("development")
+        # 25 exact singletons, 25 one-of-five returns: each query has equal weight.
+        positives = [(label, row) for label, row in zip(labels["labels"], replay["results"]) if label["relevant"]]
+        for i, (label, row) in enumerate(positives):
+            row["candidate"] = row["candidate"][:1]
+            if i < 25:
+                label["relevant"] = label["relevant"][:1]
+        result = measure(self.corpus, "development", labels, replay)
+        ideal = sum(1 / math.log2(i + 2) for i in range(5))
+        self.assertAlmostEqual(result["ndcg_at_5"], (1 + 1 / ideal) / 2)
+        self.assertEqual(result["returned_precision_at_5"], 1)
+        for i, (label, row) in enumerate(positives):
+            label["relevant"] = label["relevant"][:1]
+            if i >= 25:
+                row["candidate"] += [{"id": f"noise-{j}", "project_id": "test-project"} for j in range(4)]
+        result = measure(self.corpus, "development", labels, replay)
+        self.assertEqual(result["ndcg_at_5"], 1)
+        self.assertAlmostEqual(result["returned_precision_at_5"], .6)
+
+    def test_distinct_gold_identity_and_complete_ideal_ranking(self):
+        for gold_count in (1, 2, 5, 7):
+            labels, replay = self.evidence("development")
+            for label, row in zip(labels["labels"], replay["results"]):
+                if label["relevant"]:
+                    hits = [{"id": f"gold-{i}", "project_id": "test-project"} for i in range(gold_count)]
+                    label.update(relevant=hits, known_item=hits[0])
+                    row["candidate"] = hits[:5]
+            result = measure(self.corpus, "development", labels, replay)
+            self.assertEqual(result["ndcg_at_5"], 1)
+            self.assertEqual(result["returned_precision_at_5"], 1)
+            labels["labels"][0]["relevant"].append(labels["labels"][0]["relevant"][0])
+            with self.assertRaises(ValueError):
+                measure(self.corpus, "development", labels, replay)
+
+    def test_replay_requires_explicit_current_evaluation_revision(self):
+        for revision in (None, "grounding-quality-v1", "unknown", True):
+            labels, replay = self.evidence("development")
+            if revision is None:
+                del replay["evaluation_revision"]
+            else:
+                replay["evaluation_revision"] = revision
+            with self.subTest(revision=revision), self.assertRaises(ValueError):
+                measure(self.corpus, "development", labels, replay)
+
+    def test_build_receipt_and_collection_bind_evaluation_revision(self):
+        with tempfile.TemporaryDirectory() as directory:
+            corpus_path = Path(directory) / "corpus.json"
+            corpus_path.write_text(json.dumps(self.corpus))
+            raw_path = Path(directory) / "recalls.jsonl"
+            rows = [{"query_id": q["id"], "query_sha256": hashlib.sha256(q["text"].encode()).hexdigest(),
+                     "recall": {"query": q["text"], "degraded": False, "errors": [], "results": []}}
+                    for q in corpus_queries(self.corpus, "development").values()]
+            raw_path.write_text("\n".join(json.dumps(row) for row in rows))
+            binary = Path(directory) / "synthetic-binary"
+            binary.write_bytes(b"unit test only")
+            receipt = {"source_dirty": False, "source_commit": "test-commit", "replay_binary_sha256": digest(binary),
+                       "policy_revision": POLICY, "evaluation_revision": EVALUATION}
+            _, replay = self.evidence("development")
+            with patch.object(qualify.subprocess, "check_output", side_effect=lambda args, **kwargs: "" if args[1] == "status" else "test-commit"), \
+                 patch.object(qualify.subprocess, "run") as run:
+                run.return_value.stdout = "\n".join(json.dumps(row) for row in replay["results"])
+                for revision in (None, "grounding-quality-v1", "unknown"):
+                    old = dict(receipt, evaluation_revision=revision)
+                    if revision is None:
+                        del old["evaluation_revision"]
+                    with self.subTest(revision=revision), self.assertRaises(ValueError):
+                        collect(corpus_path, "development", raw_path, binary, old)
+                run.assert_not_called()
+                collected = collect(corpus_path, "development", raw_path, binary, receipt)
+                self.assertEqual(collected["evaluation_revision"], EVALUATION)
+                self.assertFalse(collected["release_qualified"])
+
+    def test_old_seal_is_rejected_before_opening_holdout_inputs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "corpus.json"
+            path.write_text(json.dumps(self.corpus))
+            labels, replay = self.evidence("development")
+            labels["corpus_sha256"] = replay["corpus_sha256"] = digest(path)
+            current = evaluate(path, "development", labels, replay)
+            for revision in (None, "grounding-quality-v1", "unknown"):
+                old = dict(current, evaluation_revision=revision)
+                if revision is None:
+                    del old["evaluation_revision"]
+                with patch.object(qualify, "read", return_value=old) as read_input, \
+                     patch("sys.argv", ["qualify.py", "evaluate", "--split", "holdout", "--corpus", "corpus",
+                                        "--development", "dev-seal", "--labels", "holdout-labels",
+                                        "--replay", "holdout-replay", "--output", "unused"]):
+                    with self.assertRaises(ValueError):
+                        qualify.main()
+                    read_input.assert_called_once_with(Path("dev-seal"))
 
     def test_sealed_candidate_identity_and_dirty_source_gates(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -125,6 +263,12 @@ class QualificationTests(unittest.TestCase):
             labels["corpus_sha256"] = replay["corpus_sha256"] = digest(path)
             development = evaluate(path, "development", labels, replay)
             self.assertTrue(development["development_approved"])
+            self.assertEqual(development["evaluation_revision"], EVALUATION)
+            for revision in (None, "grounding-quality-v1", "unknown"):
+                stale = dict(development, evaluation_revision=revision)
+                if revision is None:
+                    del stale["evaluation_revision"]
+                self.assertFalse(approved_development(stale))
             labels, replay = self.evidence("holdout")
             labels["corpus_sha256"] = replay["corpus_sha256"] = digest(path)
             result = evaluate(path, "holdout", labels, replay, development)
@@ -173,7 +317,8 @@ class QualificationTests(unittest.TestCase):
             invalid_metrics = [None, [], {}, "approved"]
             mutations = [
                 ("independent_labels", False), ("independent_labels", 1),
-                ("known_item_top1", 0.949), ("precision_at_5", 0.799),
+                ("known_item_top1", 0.949), ("precision_at_5", -0.001),
+                ("ndcg_at_5", .799), ("returned_precision_at_5", .799),
                 ("false_grounding_rate", 0.051), ("unavailable_queries", 1),
                 ("scope_violations", 1), ("known_item_top1", True),
                 ("precision_at_5", "1.0"), ("precision_at_5", float("nan")),
@@ -182,6 +327,8 @@ class QualificationTests(unittest.TestCase):
                 ("known_item_queries", 51), ("no_answer_queries", 9),
                 ("no_answer_queries", 60), ("query_count", "60"),
             ]
+            for key in ("ndcg_at_5", "returned_precision_at_5", "precision_at_5"):
+                mutations.extend((key, value) for value in (True, False, "1", None, float("nan"), float("inf"), -float("inf"), 1.001))
             for key, value in mutations:
                 invalid_metrics.append(dict(development["metrics"], **{key: value}))
             for missing in development["metrics"]:
@@ -198,7 +345,8 @@ class QualificationTests(unittest.TestCase):
             del missing_metrics["metrics"]
             self.assertFalse(approved_development(missing_metrics))
             boundary = dict(development, metrics=dict(development["metrics"],
-                known_item_top1=0.95, precision_at_5=0.8, false_grounding_rate=0.05))
+                known_item_top1=0.95, precision_at_5=0.2, ndcg_at_5=.8,
+                returned_precision_at_5=.8, false_grounding_rate=0.05))
             self.assertTrue(approved_development(boundary))
 
 


### PR DESCRIPTION
## Summary

- Add a separate grounding-quality-v2 evaluation revision without changing grounding-evidence-v2 selector policy, lexical coverage, or sticky cohort assignment.
- Require macro binary nDCG@5 and returned precision@5 >= 0.80. Keep fixed-denominator precision@5 as a validated diagnostic, not a sparse-relevance admission gate.
- Bind build receipts, collected replays, development/holdout seals, runtime qualification, and canary evidence to the scoring revision. Missing/legacy revisions fail closed.
- Preserve independent labeling, known-item, no-answer, unavailable/scope, clean source/candidate, full coding, end-to-end latency, freshness, kill-switch, and 48-hour/1000-operation rollout gates.

## Verification

- RED/GREEN scoring and deployment-contract regressions.
- 18 Python qualification tests pass.
- 1,436 mcp-tools unit tests pass, including 8 rollout tests.
- cargo clippy -p mcp-tools --all-targets --offline -- -D warnings passes.
- rustfmt check and git diff --check pass.
- Clean committed-source replay build succeeds.

Synthetic fixtures are tests only: this PR does not claim real-corpus qualification, open holdout, publish a release, or activate serving. Deployment admission has a matching companion change in https://github.com/contextstream/contextstream/pull/546.

## Secret-scan false-positive follow-up

Gitleaks 8.30.1 classified the public metric name precision_at_5 in a Rust test comparison as a generic API key. Source inspection confirmed no credential. Renamed the test variable and recorded only the exact historical commit/path/rule/line fingerprint in .gitleaksignore, because CI scans all history. No rule, path, or future finding is excluded; the same original nonsecret sample is still detected in an independent stdin control. Full-history and clean candidate-tree scans pass. No history rewrite.

Final source: 9be01952a267b603e4df6ba38ff720d0397681a3. Clean replay build and full local MCP tool suite rerun successfully.